### PR TITLE
Can't get SFP's DOM information via get_transceiver_dom_info_dict()

### DIFF
--- a/sonic_platform_base/sonic_sfp/sfputilbase.py
+++ b/sonic_platform_base/sonic_sfp/sfputilbase.py
@@ -1049,7 +1049,16 @@ class SfpUtilBase(object):
                 print("Error: reading sysfs file %s" % file_path)
                 return None
 
-            sfpd_obj = sff8472Dom()
+            eeprom_ifraw = self.get_eeprom_raw(port_num)
+            if eeprom_ifraw is None:
+                return None
+            sfpi_obj = sff8472InterfaceId(eeprom_ifraw)
+            if sfpi_obj is not None:
+                cal_type = sfpi_obj.get_calibration_type()
+            else:
+                return None
+
+            sfpd_obj = sff8472Dom(None, cal_type)
             if sfpd_obj is None:
                 return None
             dom_temperature_raw = self._read_eeprom_specific_bytes(sysfsfile_eeprom, (offset + SFP_TEMPE_OFFSET), SFP_TEMPE_WIDTH)


### PR DESCRIPTION
The default value of calibration_type is 0:
    def __init__(self, eeprom_raw_data=None, calibration_type=0):
        self._calibration_type = calibration_type
If the calibration_type of the SFP is 1, it wouldn't get the correct DOM information.

What I do:
It should get calibration type defore parse DOM information.

Signed-off-by: chiourung_huang <chiourung_huang@edge-core.com>