### PR TITLE
Update SFP index definition

### DIFF
--- a/sonic_platform_base/chassis_base.py
+++ b/sonic_platform_base/chassis_base.py
@@ -468,17 +468,18 @@ class ChassisBase(device_base.DeviceBase):
             A list of objects derived from SfpBase representing all sfps
             available on this chassis
         """
-        return self._sfp_list
+        return [ sfp for sfp in self._sfp_list if sfp is not None ]
 
     def get_sfp(self, index):
         """
-        Retrieves sfp represented by (0-based) index <index>
+        Retrieves sfp corresponding to physical port <index>
 
         Args:
-            index: An integer, the index (0-based) of the sfp to retrieve.
-                   The index should be the sequence of a physical port in a chassis,
-                   starting from 0.
-                   For example, 0 for Ethernet0, 1 for Ethernet4 and so on.
+            index: An integer (>=0), the index of the sfp to retrieve.
+                   The index should correspond to the physical port in a chassis.
+                   For example:-
+                   1 for Ethernet0, 2 for Ethernet4 and so on for one platform.
+                   0 for Ethernet0, 1 for Ethernet4 and so on for another platform.
 
         Returns:
             An object dervied from SfpBase representing the specified sfp


### PR DESCRIPTION
Signed-off-by: Prince George <prgeor@microsoft.com>

<!-- Provide a general summary of your changes in the Title above -->

#### Description
SFP index on some platforms can start from non-zero index. Updated the comment to reflect the same.
Handle non existing SFP indices in chassis's _sfp_list[]

#### Motivation and Context
Updated the comment to avoid any confusion in future.
Platform can have 'None' for invalid SFP index in chassis's _sfp_list[], so handle the same in get_all_sfps() to return only valid SFP objects. With this change, platform need not override ChassisBase's get_all_sfp() and get_sfp() to handle case where SFP index starts from 1. This change can handle a case where the platform has "holes" in indices, for eg:-
valid port indices :1, 3, 5, 7
_sfp_list = [None, Sfp1, None, Sfp3, None, Sfp5, None, Sfp7]
get_all_sfps() = [Sfp1, Sfp3, Sfp5, Sfp7]
get_sfp() - There is now 1:1 mapping between the sfp_list[] index and port index

#### How Has This Been Tested?
Run SFP test in test_chassis.py

#### Additional Information (Optional)

