### PR TITLE
[sfp-refactor] Fix cmis cable length issue

### DIFF
--- a/sonic_platform_base/sonic_xcvr/fields/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/fields/public/cmis.py
@@ -3,6 +3,7 @@ from .. import consts
 
 class CableLenField(NumberRegField):
     def __init__(self, name, offset, *fields, **kwargs):
+        kwargs["deps"] = [consts.LEN_MULT_FIELD]
         super(CableLenField, self).__init__(name, offset, *fields, **kwargs)
 
     def decode(self, raw_data, **decoded_deps):

--- a/sonic_platform_base/sonic_xcvr/mem_maps/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/mem_maps/public/cmis.py
@@ -48,10 +48,10 @@ class CmisMemMap(XcvrMemMap):
                 *(RegBitField("%s_%d" % (consts.LEN_MULT_FIELD, bit), bit) for bit in range (6, 8))
             ),
             CableLenField(consts.LENGTH_ASSEMBLY_FIELD, self.get_addr(0x0, 202),
-                *(RegBitField("%s_%d" % (consts.LENGTH_ASSEMBLY_FIELD, bit), bit) for bit in range(0, 6)),
-                deps=[consts.LEN_MULT_FIELD]
+                *(RegBitField("%s_%d" % (consts.LENGTH_ASSEMBLY_FIELD, bit), bit) for bit in range(0, 6))
             ),
             CodeRegField(consts.CONNECTOR_FIELD, self.get_addr(0x0, 203), self.codes.CONNECTORS),
+            deps=[consts.LEN_MULT_FIELD]
         )
 
         self.MODULE_LEVEL_MONITORS = RegGroupField(consts.MODULE_MONITORS_FIELD,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
Fix an issue where the length multipler field for CMIS was not specified in the memory map correctly and would not be read before computing the cable length, causing an error.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
Fixes #224

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Tested on Arista platform with CMIS xcvrs.

#### Additional Information (Optional)

