### PR TITLE
Added support for front panel port prefix regex

### DIFF
--- a/sonic_platform_base/sonic_sfp/sfputilbase.py
+++ b/sonic_platform_base/sonic_sfp/sfputilbase.py
@@ -16,6 +16,7 @@ try:
     from portconfig import get_port_config
     from sonic_py_common import device_info
     from sonic_py_common.interface import backplane_prefix, inband_prefix, recirc_prefix
+    from swsscommon.swsscommon import FRONT_PANEL_PORT_REGEX
 
     from sonic_eeprom import eeprom_dts
     from .sff8472 import sff8472InterfaceId  # Dot module supports both Python 2 and Python 3 using explicit relative import methods
@@ -510,12 +511,19 @@ class SfpUtilBase(object):
                 elif "asic_port_name" not in title and len(line.split()) >= 4:
                     fp_port_index = int(line.split()[3])
                 else:
-                    fp_port_index = portname.split("Ethernet").pop()
+                    front_panel_prefix_match = re.match(FRONT_PANEL_PORT_REGEX, portname)
+                    if not front_panel_prefix_match:
+                        continue
+                    front_panel_prefix = front_panel_prefix_match.group(1)
+                    fp_port_index = portname.split(front_panel_prefix).pop()
                     fp_port_index = int(fp_port_index.split("s").pop(0))/4
             else:  # Parsing logic for older 'portmap.ini' file
                 (portname, bcm_port) = line.split("=")[1].split(",")[:2]
-
-                fp_port_index = portname.split("Ethernet").pop()
+                front_panel_prefix_match = re.match(FRONT_PANEL_PORT_REGEX, portname)
+                if not front_panel_prefix_match:
+                    continue
+                front_panel_prefix = front_panel_prefix_match.group(1)
+                fp_port_index = portname.split(front_panel_prefix).pop()
                 fp_port_index = int(fp_port_index.split("s").pop(0))/4
 
             if ((len(self.sfp_ports) > 0) and (fp_port_index not in self.sfp_ports)):


### PR DESCRIPTION
What I did
Removed the dependency on the "Ethernet" string in the SONiC code base and added support
for extending the front panel port name pattern.

How I did it

Introduced FRONT_PANEL_PORT_PREFIX_REGEX that extends the old FRONT_PANEL_PORT_PREFIX ("Ethernet")
Updated all the relevant usage of the "Ethernet" throughout the code base to use the new regex pattern
How to verify it
Pass all UT and CI testing.

Why I did it
In order to support distinguishing between different types of front panel ports in a maintainable fashion.
Specifically, we are planning to bring up a system with 'service' ports (in addition to the regular ethernet data ports) - these
are lower speed ports that used for connection to accelerators, internal loopbacks and more.

**- Related Commits and Merge Strategy**
_This is part of a group of related commits and should be merged **after https://github.com/Azure/sonic-swss-common/pull/598 and https://github.com/Azure/sonic-buildimage/pull/10471 and https://github.com/Azure/sonic-py-swsssdk/pull/121**._

The full merge order is:

1. swss-common - https://github.com/Azure/sonic-swss-common/pull/598
2. sonic-buildimage - https://github.com/Azure/sonic-buildimage/pull/10471
3. swsssdk - https://github.com/Azure/sonic-py-swsssdk/pull/121
4. all the rest
     [ https://github.com/Azure/sonic-utilities/pull/2127](https://github.com/Azure/sonic-utilities/pull/2127)
     [ https://github.com/Azure/sonic-snmpagent/pull/251](https://github.com/Azure/sonic-snmpagent/pull/251)
     [ https://github.com/Azure/sonic-swss/pull/2223](https://github.com/Azure/sonic-swss/pull/2223)
     [ https://github.com/Azure/sonic-platform-daemons/pull/252](https://github.com/Azure/sonic-platform-daemons/pull/252)
     [ https://github.com/Azure/sonic-platform-common/pull/274](https://github.com/Azure/sonic-platform-common/pull/274)
