### PR TITLE
Skip CDB and VDM for flat memory modules

### DIFF
--- a/tests/sonic_xcvr/test_cmisCDB.py
+++ b/tests/sonic_xcvr/test_cmisCDB.py
@@ -13,6 +13,15 @@ class TestCDB(object):
     eeprom = XcvrEeprom(reader, writer, mem_map)
     api = CmisCdbApi(eeprom)
 
+    def test_cdb_is_none(self):
+        self.cdb = None
+        assert False == self.api.get_module_fw_mgmt_feature()
+        assert False == self.get_module_fw_info()
+        assert False == self.module_fw_run()
+        assert False == self.module_fw_commit()
+        assert False == self.module_fw_download()
+
+
     @pytest.mark.parametrize("mock_response, expected", [
         (64, False),
         (0, True)
@@ -101,7 +110,7 @@ class TestCDB(object):
         self.api.cdb1_chkstatus = MagicMock()
         self.api.cdb1_chkstatus.return_value = mock_response[0]
         self.api.read_cdb = MagicMock()
-        self.api.read_cdb.return_value = mock_response[1]        
+        self.api.read_cdb.return_value = mock_response[1]
         result = self.api.get_fw_management_features()
         assert result == expected
 
@@ -185,7 +194,7 @@ class TestCDB(object):
         self.api.cdb1_chkstatus.return_value = mock_response
         result = self.api.run_fw_image()
         assert result == expected
-        
+
     @pytest.mark.parametrize("mock_response, expected", [
         (1, 1),
         (64, 64),

--- a/tests/sonic_xcvr/test_cmisCDB.py
+++ b/tests/sonic_xcvr/test_cmisCDB.py
@@ -16,12 +16,14 @@ class TestCDB(object):
 
     def test_cdb_is_none(self):
         api = CmisApi(self.eeprom)
-        self.cdb = None
+        api.cdb = None
+        print(api)
+        print(api.get_module_fw_mgmt_feature())
         assert False == api.get_module_fw_mgmt_feature()['status']
         assert False == api.get_module_fw_info()['status']
         assert False == api.module_fw_run()[0]
         assert False == api.module_fw_commit()[0]
-        assert False == api.module_fw_download()[0]
+        assert False == api.module_fw_download(None, None, None, None, None, None)[0]
 
 
     @pytest.mark.parametrize("mock_response, expected", [

--- a/tests/sonic_xcvr/test_cmisCDB.py
+++ b/tests/sonic_xcvr/test_cmisCDB.py
@@ -1,5 +1,6 @@
 from mock import MagicMock
 import pytest
+from sonic_platform_base.sonic_xcvr.api.public.cmis import CmisApi
 from sonic_platform_base.sonic_xcvr.api.public.cmisCDB import CmisCdbApi
 from sonic_platform_base.sonic_xcvr.mem_maps.public.cmis import CmisMemMap
 from sonic_platform_base.sonic_xcvr.xcvr_eeprom import XcvrEeprom
@@ -14,12 +15,13 @@ class TestCDB(object):
     api = CmisCdbApi(eeprom)
 
     def test_cdb_is_none(self):
+        api = CmisApi(self.eeprom)
         self.cdb = None
-        assert False == self.api.get_module_fw_mgmt_feature()
-        assert False == self.get_module_fw_info()
-        assert False == self.module_fw_run()
-        assert False == self.module_fw_commit()
-        assert False == self.module_fw_download()
+        assert False == api.get_module_fw_mgmt_feature()
+        assert False == api.get_module_fw_info()
+        assert False == api.module_fw_run()
+        assert False == api.module_fw_commit()
+        assert False == api.module_fw_download()
 
 
     @pytest.mark.parametrize("mock_response, expected", [

--- a/tests/sonic_xcvr/test_cmisCDB.py
+++ b/tests/sonic_xcvr/test_cmisCDB.py
@@ -17,11 +17,11 @@ class TestCDB(object):
     def test_cdb_is_none(self):
         api = CmisApi(self.eeprom)
         self.cdb = None
-        assert False == api.get_module_fw_mgmt_feature()
-        assert False == api.get_module_fw_info()
-        assert False == api.module_fw_run()
-        assert False == api.module_fw_commit()
-        assert False == api.module_fw_download()
+        assert False == api.get_module_fw_mgmt_feature()['status']
+        assert False == api.get_module_fw_info()['status']
+        assert False == api.module_fw_run()[0]
+        assert False == api.module_fw_commit()[0]
+        assert False == api.module_fw_download()[0]
 
 
     @pytest.mark.parametrize("mock_response, expected", [


### PR DESCRIPTION
#### Description
Skip VDM and CDB support for flat memory modules like DAC

#### Motivation and Context
CDB or VDM support fields in Page01H does
not exist on flat memory module, so we should avoid reading this page for such modules to prevent read error/crash

#### How Has This Been Tested?
Verify Xcvrd does not crash due to presence of DAC cable

#### Additional Information (Optional)

