### PR TITLE
Fix Cmis memmap field offset

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/c_cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/c_cmis.py
@@ -122,12 +122,7 @@ class CCmisApi(CmisApi):
         assert channel_number % 3 == 0
         if channel_number > hi_ch_num or channel_number < low_ch_num:
             raise ValueError('Provisioned frequency out of range. Max Freq: 196100; Min Freq: 191300 GHz.')
-        self.set_lpmode(True)
-        time.sleep(5)
         status = self.xcvr_eeprom.write(consts.LASER_CONFIG_CHANNEL, channel_number)
-        time.sleep(1)
-        self.set_lpmode(False)
-        time.sleep(1)
         return status
 
     def set_tx_power(self, tx_power):

--- a/sonic_platform_base/sonic_xcvr/mem_maps/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/mem_maps/public/cmis.py
@@ -123,6 +123,9 @@ class CmisMemMap(XcvrMemMap):
             ),
 
             RegGroupField(consts.APPLS_ADVT_FIELD_PAGE01,
+                *(NumberRegField("%s_%d" % (consts.MEDIA_LANE_ASSIGNMENT_OPTION, app), self.getaddr(0x1, 176 + (app - 1)),
+                    format="B", size=1) for app in range(1, 16)),
+                
                 *(CodeRegField("%s_%d" % (consts.HOST_ELECTRICAL_INTERFACE, app), self.getaddr(0x1, 223 + 4 * (app - 9)),
                     self.codes.HOST_ELECTRICAL_INTERFACE) for app in range(9, 16)),
 
@@ -149,11 +152,8 @@ class CmisMemMap(XcvrMemMap):
                     *(RegBitField("Bit%d" % (bit), bit) for bit in range (4, 8))
                     ) for lane in range(9, 16)),
 
-                *(NumberRegField("%s_%d" % (consts.HOST_LANE_ASSIGNMENT_OPTION, app), self.getaddr(0x1, 226 + 4 * (app - 1)),
-                    format="B", size=1) for app in range(9, 16)),
-
-                *(NumberRegField("%s_%d" % (consts.MEDIA_LANE_ASSIGNMENT_OPTION, app), self.getaddr(0x1, 176 + (app - 1)),
-                    format="B", size=1) for app in range(1, 16))
+                *(NumberRegField("%s_%d" % (consts.HOST_LANE_ASSIGNMENT_OPTION, app), self.getaddr(0x1, 226 + 4 * (app - 9)),
+                    format="B", size=1) for app in range(9, 16))
             )
         )
 


### PR DESCRIPTION
#### Description
Fix wrong field offset for HostLaneAssignementOption for applications 9 to 15 in CMIS memmap

#### Motivation and Context
1. Wrong field offset for host lane map assignment
2. Updated the frequency setting API for ZR module. No need to include sleep and force low power mode, as the these are managed by Xcvrd, so just update or configure the required frequency.

#### How Has This Been Tested?
Setting laser frequency
```
root@sonic:~# config interface transceiver frequency Ethernet0 193175
Setting laser frequency to 193175 GHz on port Ethernet0
root@sonic:~# config interface transceiver frequency Ethernet16 193175
Setting laser frequency to 193175 GHz on port Ethernet16
root@sonic:~#
```

Verifying the same

```
>>> from sonic_platform.platform import Platform
>>> p = Platform()
>>> c = p.get_chassis()
>>> sfp = c.get_sfp(1)
>>> api = sfp.get_xcvr_api()
>>> api.get_current_laser_freq()
193175.0
>>>
```

Also, verified the link is DOWN if same freq is not configured on the peer port and link comes UP if same freq is configured on the peer.

#### Additional Information (Optional)

