### PR TITLE
Add warning/critical thresholds for PSU power

### DIFF
--- a/sonic_platform_base/psu_base.py
+++ b/sonic_platform_base/psu_base.py
@@ -223,7 +223,7 @@ class PsuBase(device_base.DeviceBase):
         """
         raise NotImplementedError
 
-    def get_psu_power_threshold(self):
+    def get_psu_power_warning_threshold(self):
         """
         Retrieve the warning threshold of the power on this PSU
         The value can be volatile, so the caller should call the API each time it is used.

--- a/sonic_platform_base/psu_base.py
+++ b/sonic_platform_base/psu_base.py
@@ -223,13 +223,13 @@ class PsuBase(device_base.DeviceBase):
         """
         raise NotImplementedError
 
-    def get_psu_power_warning_threshold(self):
+    def get_psu_power_warning_suppress_threshold(self):
         """
-        Retrieve the warning threshold of the power on this PSU
+        Retrieve the warning suppress threshold of the power on this PSU
         The value can be volatile, so the caller should call the API each time it is used.
 
         Returns:
-            A float number, the warning threshold of the PSU in watts.
+            A float number, the warning suppress threshold of the PSU in watts.
         """
         raise NotImplementedError
 

--- a/sonic_platform_base/psu_base.py
+++ b/sonic_platform_base/psu_base.py
@@ -223,6 +223,26 @@ class PsuBase(device_base.DeviceBase):
         """
         raise NotImplementedError
 
+    def get_psu_power_threshold(self):
+        """
+        Retrieve the warning threshold of the power on this PSU
+        The value can be volatile, so the caller should call the API each time it is used.
+
+        Returns:
+            A float number, the warning threshold of the PSU in watts.
+        """
+        raise NotImplementedError
+
+    def get_psu_power_critical_threshold(self):
+        """
+        Retrieve the critical threshold of the power on this PSU
+        The value can be volatile, so the caller should call the API each time it is used.
+
+        Returns:
+            A float number, the critical threshold of the PSU in watts.
+        """
+        raise NotImplementedError
+
     @classmethod
     def get_status_master_led(cls):
         """

--- a/tests/psu_base_test.py
+++ b/tests/psu_base_test.py
@@ -1,0 +1,29 @@
+from sonic_platform_base.psu_base import PsuBase
+
+class TestPsuBase:
+
+    def test_psu_base(self):
+        psu = PsuBase()
+        not_implemented_methods = [
+            psu.get_voltage,
+            psu.get_current,
+            psu.get_power,
+            psu.get_powergood_status,
+            psu.get_temperature,
+            psu.get_temperature_high_threshold,
+            psu.get_voltage_high_threshold,
+            psu.get_voltage_low_threshold,
+            psu.get_maximum_supplied_power,
+            psu.get_psu_power_warning_suppress_threshold,
+            psu.get_psu_power_critical_threshold,
+            psu.get_input_voltage,
+            psu.get_input_current]
+
+        for method in not_implemented_methods:
+            exception_raised = False
+            try:
+                method()
+            except NotImplementedError:
+                exception_raised = True
+
+            assert exception_raised


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
Two new platform APIs for PSU
- get_psu_power_warning_suppress_threshold
- get_psu_power_critical_threshold

Signed-off-by: Stephen Sun <stephens@nvidia.com>

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)

