### PR TITLE
[CMIS] 'get_transceiver_info' should return 'None' when CMIS cable EEPROM is not ready 

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -164,7 +164,10 @@ class CmisApi(XcvrApi):
         xcvr_info['active_firmware'] = self.get_module_active_firmware()
         xcvr_info['inactive_firmware'] = self.get_module_inactive_firmware()
         xcvr_info['specification_compliance'] = self.get_module_media_type()
-        return xcvr_info
+        if None in xcvr_info.values():
+            return None
+        else:
+            return xcvr_info
 
     def get_transceiver_bulk_status(self):
         rx_los = self.get_rx_los()

--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -164,6 +164,12 @@ class CmisApi(XcvrApi):
         xcvr_info['active_firmware'] = self.get_module_active_firmware()
         xcvr_info['inactive_firmware'] = self.get_module_inactive_firmware()
         xcvr_info['specification_compliance'] = self.get_module_media_type()
+
+        # In normal case will get a valid value for each of the fields. If get a 'None' value
+        # means there was a failure while reading the EEPROM, either because the EEPROM was
+        # not ready yet or experincing some other issues. It shouldn't return a dict with a
+        # wrong field value, instead should return a 'None' to indicate to XCVRD that retry is
+        # needed.
         if None in xcvr_info.values():
             return None
         else:

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -1157,6 +1157,10 @@ class TestCmis(object):
         self.api.is_flat_memory.return_value = False
         result = self.api.get_transceiver_info()
         assert result == expected
+        # Test negative path
+        self.api.get_cmis_rev.return_value = None
+        result = self.api.get_transceiver_info()
+        assert result == None
 
 
     @pytest.mark.parametrize("mock_response, expected",[


### PR DESCRIPTION
Signed-off-by: Kebo Liu <kebol@nvidia.com>

<!-- Provide a general summary of your changes in the Title above -->

#### Description
When the CMIS cable EEPROM is not ready,  `get_transceiver_info` should return None to notify XCVRD that cable EEPROM is not ready instead of returning a dictionary including 'None' values.

If any field is 'None', we consider the CMIS cable EEPROM is not fully ready yet.  

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
`get_transceiver_info`  should return a dictionary including the correct field and values to XCVRD, if EEPROM is not ready should not return a dictionary with incorrect values. The 'None' return value can trigger XCVRD to start the retry EEPROM reading flow.

This is also to fix issue https://github.com/sonic-net/sonic-buildimage/issues/11525

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
keep run sfputil reset test case and see no further crash.
#### Additional Information (Optional)

