### PR TITLE
[credo][ycable] remove mux-toggle inprogress flags for some API's

### DIFF
--- a/sonic_y_cable/credo/y_cable_credo.py
+++ b/sonic_y_cable/credo/y_cable_credo.py
@@ -859,8 +859,6 @@ class YCable(YCableBase):
                 TARGET_UNKNOWN, if checking which side is linked and sending traffic API fails.
         """
 
-        if self.mux_toggle_status == self.MUX_TOGGLE_STATUS_INPROGRESS:
-            return YCableBase.TARGET_UNKNOWN
 
         curr_offset = YCable.OFFSET_ACTIVE_TOR_INDICATOR
 
@@ -924,8 +922,6 @@ class YCable(YCableBase):
                      , False if the link is not active
         """
 
-        if self.mux_toggle_status == self.MUX_TOGGLE_STATUS_INPROGRESS:
-            return YCableBase.TARGET_UNKNOWN
 
         curr_offset = YCable.OFFSET_CHECK_LINK_ACTIVE
 
@@ -996,8 +992,6 @@ class YCable(YCableBase):
             a list, with EYE values of lane 0 lane 1 lane 2 lane 3 with corresponding index
         """
 
-        if self.mux_toggle_status == self.MUX_TOGGLE_STATUS_INPROGRESS:
-            return None
 
         eye_result = []
 
@@ -1144,8 +1138,6 @@ class YCable(YCableBase):
                 an integer, the number of times the Y-cable has been switched
         """
 
-        if self.mux_toggle_status == self.MUX_TOGGLE_STATUS_INPROGRESS:
-            return 0
 
         count = 0
 
@@ -2185,8 +2177,6 @@ class YCable(YCableBase):
             an Integer, the temperature of the local MCU
         """
 
-        if self.mux_toggle_status == self.MUX_TOGGLE_STATUS_INPROGRESS:
-            return 0
 
         curr_offset = YCable.OFFSET_INTERNAL_TEMPERATURE
         if self.platform_chassis is not None:
@@ -2214,8 +2204,6 @@ class YCable(YCableBase):
             a float, the voltage of the NIC MCU
         """
 
-        if self.mux_toggle_status == self.MUX_TOGGLE_STATUS_INPROGRESS:
-            return 0
 
         if self.platform_chassis is not None:
             with self.rlock.acquire_timeout(RLocker.ACQUIRE_LOCK_TIMEOUT) as lock_status:
@@ -2244,8 +2232,6 @@ class YCable(YCableBase):
             a float, the voltage of the local MCU
         """
 
-        if self.mux_toggle_status == self.MUX_TOGGLE_STATUS_INPROGRESS:
-            return 0
 
         if self.platform_chassis is not None:
             with self.rlock.acquire_timeout(RLocker.ACQUIRE_LOCK_TIMEOUT) as lock_status:


### PR DESCRIPTION
this PR removes some of the toggle synchronization logic for SONiC telemetry, since SONiC telemetry table MUX_CABLE_INFO is anyways disabled/enabled using CLI
```config muxcable telemetry enable/disable```, it is redundant to have this logic embedded in ycabled and port_instance helper objects, which could be unneccessary

Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>

<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
Deploying changes on Arista testbed
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)

