### PR TITLE
Remove shell=True

### DIFF
--- a/sonic_platform_base/sonic_pcie/pcie_common.py
+++ b/sonic_platform_base/sonic_pcie/pcie_common.py
@@ -39,14 +39,14 @@ class PcieUtil(PcieBase):
         pciList = []
         p1 = "^(\w+):(\w+)\.(\w)\s(.*)\s*\(*.*\)*"
         p2 = "^.*:.*:.*:(\w+)\s*\(*.*\)*"
-        command1 = "sudo lspci"
-        command2 = "sudo lspci -n"
+        command1 = ["sudo", "lspci"]
+        command2 = ["sudo", "lspci", "-n"]
         # run command 1
-        proc1 = subprocess.Popen(command1, shell=True, universal_newlines=True, stdout=subprocess.PIPE)
+        proc1 = subprocess.Popen(command1, universal_newlines=True, stdout=subprocess.PIPE)
         output1 = proc1.stdout.readlines()
         (out, err) = proc1.communicate()
         # run command 2
-        proc2 = subprocess.Popen(command2, shell=True, universal_newlines=True, stdout=subprocess.PIPE)
+        proc2 = subprocess.Popen(command2, universal_newlines=True, stdout=subprocess.PIPE)
         output2 = proc2.stdout.readlines()
         (out, err) = proc2.communicate()
 

--- a/tests/pcie_common_test.py
+++ b/tests/pcie_common_test.py
@@ -131,9 +131,9 @@ class TestPcieCommon:
     def test_get_pcie_devices(self, subprocess_popen_mock):
 
         def subprocess_popen_side_effect(*args, **kwargs):
-            if args[0] == 'sudo lspci':
+            if args[0] == ['sudo', 'lspci']:
                 output = lspci_output.splitlines()
-            elif args[0] == 'sudo lspci -n':
+            elif args[0] == ['sudo', 'lspci', '-n']:
                 output = lspci_ID_output.splitlines()
 
             popen_mock = mock.Mock()


### PR DESCRIPTION
Signed-off-by: maipbui <maibui@microsoft.com>

<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
`subprocess()` - use `shell=False`, use list of strings Ref: [https://semgrep.dev/docs/cheat-sheets/python-command-injection/#mitigation](https://semgrep.dev/docs/cheat-sheets/python-command-injection/#mitigation)
#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
`subprocess()` - when using with `shell=True` is dangerous. Using subprocess function without a static string can lead to command injection.
#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Pass UT `tests/pcie_common_test.py`
#### Additional Information (Optional)

