### PR TITLE
[202012][sffbase] change TX/RX POWER value from '-inf' to '-40dB' when the raw data is 0

### DIFF
--- a/sonic_platform_base/sonic_sfp/sffbase.py
+++ b/sonic_platform_base/sonic_sfp/sffbase.py
@@ -76,7 +76,7 @@ class sffbase(object):
 
     def mw_to_dbm(self, mW):
         if mW == 0:
-            return float("-inf")
+            return float("-40")
         elif mW < 0:
             return float("NaN")
         return 10. * log10(mW)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
according to the Transceiver EEPROM DOM description, the measurement range of TX/RX POWER is 0 to 6.5535
mW (~-40 to +8.2 dBm) , detail please refer to SFF8636, CMIS, etc. 

With the current implementation,  when the raw data is 0, it will be converted to a special string '-inf dB', however, since this string does not contain a valid number, eventually, it will be treated as an invalid value and will be interpreted as 'N/A'.   When the cable doesn't support this measurement, the platform API will also return 'N/A' as a result, so the current implementation can not differentiate these two cases.

furthermore, in the CLI(show interface transceiver eeprom -d), when the value of some field is 'N/A', it will be omitted from the CLI output. In a particular case,  if some cable channel RX/TX POWER is '0', it will not be in the output, hence confusing the user about whether the channel exists or not.  Below is an example with QSFP-DD cable, it has 8 channels, but the tx/rx power raw data of 4 of them is 0, so it will not be displayed and will on see 4 channels tx/rx power in the CLI output:

```
admin@sonic# show interfaces transceiver eeprom -d Ethernet224
...
...
      ChannelMonitorValues:
                RX1Power: 1.4777dBm
                RX2Power: 2.7017dBm
                RX3Power: -4.7496dBm
                RX4Power: 2.3144dBm
                TX1Bias: 75.0000mA
                TX1Power: 2.173dBm
                TX2Bias: 67.0000mA
                TX2Power: 2.6916dBm
                TX3Bias: 67.5000mA
                TX3Power: 2.1165dBm
                TX4Bias: 80.0000mA
                TX4Power: 2.7602dBm
                TX5Bias: 0.0000mA
                TX6Bias: 0.0000mA
                TX7Bias: 0.0000mA
                TX8Bias: 0.0000mA
```

So a better implementation is to interpret '0' as '-40 dB' according to the measurement range, and the CLI output will have all the channels displayed in the output:

```
        ChannelMonitorValues:
                RX1Power: 1.533dBm
                RX2Power: 1.345dBm
                RX3Power: 1.8963dBm
                RX4Power: 2.1291dBm
                RX5Power: -40.0dBm
                RX6Power: -40.0dBm
                RX7Power: -40.0dBm
                RX8Power: -40.0dBm
                TX1Bias: 110.0000mA
                TX1Power: 1.7108dBm
                TX2Bias: 88.1000mA
                TX2Power: 1.801dBm
                TX3Bias: 78.1080mA
                TX3Power: 1.9808dBm
                TX4Bias: 86.2000mA
                TX4Power: 1.9789dBm
                TX5Bias: 0.0000mA
                TX5Power: -40.0dBm
                TX6Bias: 0.0000mA
                TX6Power: -40.0dBm
                TX7Bias: 0.0000mA
                TX7Power: -40.0dBm
                TX8Bias: 0.0000mA
                TX8Power: -40.0dBm
```

#### Motivation and Context
To fix the display issue when RX/RX POWER raw data is '0'.

#### How Has This Been Tested?
check the 'show interface transceiver eeprom -d' output,
call the relevant platform API to check the result
run platform related regression test case

#### Additional Information (Optional)

