### PR TITLE
 CmisApi::get_application_advertisement catch AttributeError as well 

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -1867,7 +1867,7 @@ class CmisApi(XcvrApi):
             # Read the application advertisement in page01
             try:
                 dic.update(self.xcvr_eeprom.read(consts.APPLS_ADVT_FIELD_PAGE01))
-            except TypeError as e:
+            except (TypeError, AttributeError) as e:
                 logger.error('Failed to read APPLS_ADVT_FIELD_PAGE01: ' + str(e))
                 return ret
 

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -1970,6 +1970,12 @@ class TestCmis(object):
         assert result[1]['media_lane_count'] == 4
         assert result[1]['host_lane_assignment_options'] == 0x01
 
+    def test_get_application_advertisement_non_support(self):
+        self.api.xcvr_eeprom.read = MagicMock(return_value = None)
+        self.api.is_flat_memory = MagicMock(return_value = False)
+        result = self.api.get_application_advertisement()
+        assert result == {}
+
     def test_get_application(self):
         self.api.xcvr_eeprom.read = MagicMock()
         self.api.xcvr_eeprom.read.return_value = 0x20


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

Catch both `TypeError` and `AttributeError` in `CmisApi::get_application_advertisement` because an AttributeError will be thrown when updating a dict with `None`.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

Manually test
Added unit test

#### Additional Information (Optional)

