### PR TITLE
JIRA-SONIC-5341: [eBay_ec202111_214] EEPROM/DOM Info: The Compliance …

### DIFF
--- a/sonic_platform_base/sonic_xcvr/codes/public/sff8472.py
+++ b/sonic_platform_base/sonic_xcvr/codes/public/sff8472.py
@@ -42,10 +42,10 @@ class Sff8472Codes(Sff8024):
     }
 
     ETHERNET_10G_COMPLIANCE = {
-        16: "10GBASE-SR",
-        32: "10GBASE-LR",
-        64: "10GBASE-LRM",
-        128: "10GBASE-ER",
+        1: "10GBASE-SR",
+        2: "10GBASE-LR",
+        4: "10GBASE-LRM",
+        8: "10GBASE-ER",
     }
 
     INFINIBAND_COMPLIANCE = {
@@ -56,8 +56,8 @@ class Sff8472Codes(Sff8024):
     }
 
     ESCON_COMPLIANCE = {
-        128: "ESCON MMF, 1310nm LED",
-        64: "ESCON SMF, 1310nm Laser"
+        2: "ESCON MMF, 1310nm LED",
+        1: "ESCON SMF, 1310nm Laser"
     }
 
     SONET_COMPLIANCE = {
@@ -87,21 +87,21 @@ class Sff8472Codes(Sff8024):
     }
 
     FIBRE_CHANNEL_LINK_LENGTH = {
-        8: "Medium (M)",
-        16: "Long distance (L)",
-        32: "Intermediate distance (I)",
-        64: "Short distance (S)",
-        128: "Very long distance (V)"
+        1: "Medium (M)",
+        2: "Long distance (L)",
+        4: "Intermediate distance (I)",
+        8: "Short distance (S)",
+        16: "Very long distance (V)"
     }
 
     FIBRE_CHANNEL_TRANSMITTER_TECH = {
-        16: "Longwave Laser (LL)",
-        32: "Shortwave laser w OFC (SL)",
-        64: "Shortwave laser w/o OFC (SN)",
-        128: "Electrical intra-enclosure (EL)",
-        256: "Electrical inter-enclosure (EL)",
-        512: "Longwave laser (LC)",
-        1024: "Shortwave laser, linear RX (SA)"
+        1: "Longwave Laser (LL)",
+        2: "Shortwave laser w OFC (SL)",
+        4: "Shortwave laser w/o OFC (SN)",
+        8: "Electrical intra-enclosure (EL)",
+        16: "Electrical inter-enclosure (EL)",
+        32: "Longwave laser (LC)",
+        64: "Shortwave laser, linear RX (SA)"
     }
 
     SFP_CABLE_TECH = {


### PR DESCRIPTION
…Code will show "unknown" by using FINISAR 10G LR XCVR

correct the code mapping

<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
The Specification compliance is wrong
```
root@sonic:/home/admin# show interfaces transceiver eeprom Ethernet51
Ethernet51: SFP EEPROM detected
        Application Advertisement: N/A
        Connector: LC
        DOM Capability:
                Rx_power_support: True
                Temp_support: True
                Tx_power_support: True
                Voltage_support: True
        Encoding: 64B/66B
        Extended Identifier: GBIC/SFP defined by two-wire interface ID
        Extended RateSelect Compliance: Unknown
        Identifier: SFP/SFP+/SFP28
        Length SMF (100m): 100.0
        Nominal Bit Rate(100Mbs): 103
        Specification compliance:
                10G Ethernet Compliance: Unknown
                ESCON Compliance: Unknown
                Ethernet Compliance: Unknown
                Fibre Channel Link Length: Unknown
                Fibre Channel Speed: Unknown
                Fibre Channel Transmission Media: Unknown
                Fibre Channel Transmitter Technology: Unknown
                Infiniband Compliance: Unknown
                SFP+CableTechnology: Unknown
                SONET Compliance Codes: Unknown
        Vendor Date Code(YYYY-MM-DD Lot): 2019-01-15
        Vendor Name: FINISAR CORP.
        Vendor OUI: 00-90-65
        Vendor PN: FTLX1471D3BCL
        Vendor Rev: A
        Vendor SN: A13A8YL
```
#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)

