### PR TITLE
[SSD] deduce vendor name from part number for Virtium

### DIFF
--- a/sonic_platform_base/sonic_ssd/ssd_generic.py
+++ b/sonic_platform_base/sonic_ssd/ssd_generic.py
@@ -52,10 +52,10 @@ class SsdUtil(SsdBase):
 
         # Known vendor part
         if self.model:
-            model_short = self.model.split()[0]
-            if model_short in self.vendor_ssd_utility:
-                self.fetch_vendor_ssd_info(diskdev, model_short)
-                self.parse_vendor_ssd_info(model_short)
+            vendor = self._parse_vendor()
+            if vendor:
+                self.fetch_vendor_ssd_info(diskdev, vendor)
+                self.parse_vendor_ssd_info(vendor)
             else:
                 # No handler registered for this disk model
                 pass
@@ -71,6 +71,15 @@ class SsdUtil(SsdBase):
     def _parse_re(self, pattern, buffer):
         res_list = re.findall(pattern, buffer)
         return res_list[0] if res_list else NOT_AVAILABLE
+
+    def _parse_vendor(self):
+        model_short = self.model.split()[0]
+        if model_short in self.vendor_ssd_utility:
+            return model_short
+        elif self.model.startswith('VSF'):
+            return 'Virtium'
+        else:
+            return None
 
     def fetch_generic_ssd_info(self, diskdev):
         self.ssd_info = self._execute_shell(self.vendor_ssd_utility["Generic"]["utility"].format(diskdev))


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
Deduce SSD vendor name from part number for Virtum

#### Motivation and Context
Currently, ssd_generic.py deduce vendor name by `smartctl` command. For example,

```
Device Model:     StorFly VSFDM8XC240G-V11-T
```

"StorFly" is the vendor name. However, for some SSD vendor, `smartctl` cannot get vendor name. For example:

```
Device Model:     VSFDM8XC240G-V11-T
```

In such case, vendor name shall be deduced from part number.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)

