### PR TITLE
[sonic_xcvr/cmis] Tune to set_lpmode status for 400G-ZR

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -965,7 +965,11 @@ class CmisApi(XcvrApi):
                 # Force module transition to LowPwr under SW control
                 lpmode_val = lpmode_val | (1 << CmisApi.LowPwrRequestSW)
                 self.xcvr_eeprom.write(consts.MODULE_LEVEL_CONTROL, lpmode_val)
-                time.sleep(0.1)
+                for retries in range(50):
+                    if self.get_lpmode():
+                        break
+                    time.sleep(0.1)
+            
                 return self.get_lpmode()
             else:
                 # Force transition from LowPwr to HighPower state under SW control.
@@ -975,7 +979,8 @@ class CmisApi(XcvrApi):
                 self.xcvr_eeprom.write(consts.MODULE_LEVEL_CONTROL, lpmode_val)
                 time.sleep(1)
                 mstate = self.get_module_state()
-                return True if mstate == 'ModuleReady' else False
+                return True if mstate == 'ModuleReady' or mstate=='ModulePwrUp' else False
+
         return False
 
     def get_loopback_capability(self):


### PR DESCRIPTION
Signed-off-by: jostar-yang <jostar_yang@edge-core.com>

<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
We add retry for set_lpmode=on for 400G-ZR. Let check more time to get status. When get status=true, break checking.
Add "mstate=='ModulePwrUp" for set_lpmode=off. Because we find it need more time. So we can use check mstate is PWrUP to return True. Otherwise, ZR maybe need 3 or 4 sec to get mstate=='ModulePwrUp.
Motivation and Context
#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
We test 400-ZR to machine(as9716-32d) and cmd below to set lpmode on or off. But get status is failed. From show cmd, "on/off" value can be set to port eeprom.
root@sonic:~# sfputil lpmode on Ethernet248
Enabling low-power mode for port Ethernet248 ... Failed

root@sonic:~# sfputil show lpmode
Port Low-power Mode

....................
Ethernet248 On

root@sonic:~# sfputil lpmode off Ethernet248
Disabling low-power mode for port Ethernet248 ... Failed

root@sonic:~# sfputil show lpmode
Port Low-power Mode

Ethernet248 Off
#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
After change code, test result is ok.
root@sonic:# sfputil lpmode on Ethernet248
Enabling low-power mode for port Ethernet248 ... OK
root@sonic:#
root@sonic:~# sfputil show lpmode
Port Low-power Mode

....................
Ethernet248 On
..................
Ethernet240 Off

root@sonic:~# sfputil lpmode off Ethernet248
Disabling low-power mode for port Ethernet248 ... OK

root@sonic:~# sfputil show lpmode
Port Low-power Mode

Ethernet248 Off
#### Additional Information (Optional)

