### PR TITLE
[202205] [Backport] Add media assignment options to Application Advertisement

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -1914,6 +1914,11 @@ class CmisApi(XcvrApi):
                 break
             buf['host_lane_assignment_options'] = val
 
+            key = "{}_{}".format(consts.MEDIA_LANE_ASSIGNMENT_OPTION, app)
+            val = dic.get(key)
+            if val is not None:
+                buf['media_lane_assignment_options'] = val
+
             ret[app] = buf
         return ret
 

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -1991,7 +1991,8 @@ class TestCmis(object):
                 consts.MODULE_MEDIA_INTERFACE_SM + "_1": "400GBASE-DR4 (Cl 124)",
                 consts.MEDIA_LANE_COUNT + "_1": 4,
                 consts.HOST_LANE_COUNT + "_1": 8,
-                consts.HOST_LANE_ASSIGNMENT_OPTION + "_1": 0x01
+                consts.HOST_LANE_ASSIGNMENT_OPTION + "_1": 0x01,
+                consts.MEDIA_LANE_ASSIGNMENT_OPTION + "_1": 0x02
             },
             Sff8024.MODULE_MEDIA_TYPE[2]
         ]
@@ -2003,6 +2004,7 @@ class TestCmis(object):
         assert result[1]['host_lane_count'] == 8
         assert result[1]['media_lane_count'] == 4
         assert result[1]['host_lane_assignment_options'] == 0x01
+        assert result[1]['media_lane_assignment_options'] == 0x02
 
     def test_get_application_advertisement_non_support(self):
         self.api.xcvr_eeprom.read = MagicMock(return_value = None)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
Add media assignment options to Application Advertisement

#### Motivation and Context
Add media assignment options to Application Advertisement

#### How Has This Been Tested?
Manual test

#### Additional Information (Optional)

