### PR TITLE
[syseeprom] Remove the trailing space in the value of VENDOR_EXT field in the eepromTlvInfo decoder

### DIFF
--- a/sonic_platform_base/sonic_eeprom/eeprom_tlvinfo.py
+++ b/sonic_platform_base/sonic_eeprom/eeprom_tlvinfo.py
@@ -490,6 +490,7 @@ class TlvInfoDecoder(eeprom_base.EepromDecoder):
             if self._TLV_DISPLAY_VENDOR_EXT:
                 for c in t[2:2 + t[1]]:
                     value += "0x%02X " % c
+                value = value.rstrip()
         elif t[0] == self._TLV_CODE_CRC_32 and len(t) == 6:
             name = "CRC-32"
             value = "0x%08X" % ((t[2] << 24) | (t[3] << 16) | (t[4] << 8) | t[5])


### PR DESCRIPTION
#### Description
The VEMDOR_EXT field parse the data and format each in byte in hex with space as separator.  But the logic leaves a space at the end of the value.  This PR removes the trailing space in output of the VENDOR_EXT field in the eepromTlvInfo decode 

This change is needed by 202205 branch

#### Motivation and Context
The trailing space at end of the VENDOR_EXT field cause the test of function get_system_eeprom_info() failed.  The trailing space of the data filed is invisible char in the show platform syseeprom output while the get_system_eeprom_info() return a dictionary with trailing space in the end.  This results in a mis-matched in the test case.    

#### How Has This Been Tested?
```
admin@sonic:~$ show platform syseeprom 
TlvInfo Header:
   Id String:    TlvInfo
   Version:      1
   Total Length: 177
TLV Name          Code      Len  Value
----------------  ------  -----  ---------------------------------------------
Product Name      0x21       11  7215 IXS-T1
Part Number       0x22       14  3HE16794AARD01
Serial Number     0x23       11  NK223913228
Base MAC Address  0x24        6  AC:8F:F8:5B:80:FD
Manufacture Date  0x25       19  09/26/2022 13:50:19
Platform Name     0x28       26  armhf-nokia_ixs7215_52x-r0
ONIE Version      0x29       45  2019.11-onie_version-nokia_ixs7215_52x-v1.5.1
MAC Addresses     0x2A        2  64
Service Tag       0x2F       10  CSM9W00FRA
Vendor Extension  0xFD        7  0x00 0x00 0x19 0x7F 0x01 0x01 0xB5
CRC-32            0xFE        4  0x4F96FED5

(checksum valid)
admin@sonic:~$ python3
Python 3.9.2 (default, Feb 28 2021, 17:03:44) 
[GCC 10.2.1 20210110] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import sonic_platform
>>> c=sonic_platform.platform.Platform().get_chassis()
>>> i=c.get_system_eeprom_info()
>>> print(i)
{'0x21': '7215 IXS-T1', '0x22': '3HE16794AARD01', '0x23': 'NK223913228', '0x24': 'AC:8F:F8:5B:80:FD', '0x25': '09/26/2022 13:50:19', '0x28': 'armhf-nokia_ixs7215_52x-r0', '0x29': '2019.11-onie_version-nokia_ixs7215_52x-v1.5.1', '0x2A': '64', '0x2F': 'CSM9W00FRA', '0xFD': '0x00 0x00 0x19 0x7F 0x01 0x01 0xB5', '0xFE': '0x4F96FED5'}
```

#### Additional Information (Optional)

