### PR TITLE
[sonic_xcvr]Enhance to support QSFP port_id=0xC for access eeprom

### DIFF
--- a/sonic_platform_base/sonic_xcvr/xcvr_api_factory.py
+++ b/sonic_platform_base/sonic_xcvr/xcvr_api_factory.py
@@ -56,8 +56,8 @@ class XcvrApiFactory(object):
             mem_map = Sff8636MemMap(codes)
             xcvr_eeprom = XcvrEeprom(self.reader, self.writer, mem_map)
             api = Sff8636Api(xcvr_eeprom)
-        # QSFP+
-        elif id == 0x0D:
+        # QSFP+ or QSFP
+        elif id == 0x0D or id == 0x0C:
             codes = Sff8436Codes
             mem_map = Sff8436MemMap(codes)
             xcvr_eeprom = XcvrEeprom(self.reader, self.writer, mem_map)


### PR DESCRIPTION
Signed-off-by: jostar-yang <jostar_yang@edge-core.com>

<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
This PR is for fix issue:https://github.com/sonic-net/sonic-platform-common/issues/330
Cmd, sfputil show eeprom, will get fail when insert QSFP(port_id=0xC).
root@sonic:/home/admin# sfputil show eeprom
Traceback (most recent call last):
  File "/usr/local/bin/sfputil", line 8, in <module>
    sys.exit(cli())
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.9/dist-packages/sfputil/main.py", line 673, in eeprom
    output += convert_sfp_info_to_output_string(xcvr_info)
  File "/usr/local/lib/python3.9/dist-packages/sfputil/main.py", line 336, in convert_sfp_info_to_output_string
    sfp_type = sfp_info_dict['type']
#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
Check code and found below code in ,

        elif id == 0x0D
            codes = Sff8436Codes
            mem_map = Sff8436MemMap(codes)
            xcvr_eeprom = XcvrEeprom(self.reader, self.writer, mem_map)
            api = Sff8436Api(xcvr_eeprom)
QSFP port id=0x0C should follow SPEC8436.
So modify to below ,

        elif id == 0x0D or id == 0x0C:
            codes = Sff8436Codes
#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
After patch the code, sfputul show eeprom will fine as below,
Ethernet0: SFP EEPROM detected
        Application Advertisement: N/A
        Connector: No separable connector
        Encoding: Unspecified
        Extended Identifier: Power Class 1 Module (1.5W max. Power consumption), No CLEI code present in Page 02h, No CDR in TX, No CDR in RX
        Extended RateSelect Compliance: QSFP+ Rate Select Version 1
        Identifier: QSFP
        Length Cable Assembly(m): 1.0
        Nominal Bit Rate(100Mbs): 103
        Specification compliance:
#### Additional Information (Optional)

