### PR TITLE
[sonic_ssd] Nokia-7215: Fix "show platform ssdhealth"

### DIFF
--- a/sonic_platform_base/sonic_ssd/ssd_generic.py
+++ b/sonic_platform_base/sonic_ssd/ssd_generic.py
@@ -124,12 +124,18 @@ class SsdUtil(SsdBase):
         if self.vendor_ssd_info:
             self.health = self._parse_re('Health:\s*(.+?)%', self.vendor_ssd_info)
             self.temperature = self._parse_re('Temperature\s*\[\s*(.+?)\]', self.vendor_ssd_info)
-        else:
-            if self.health == NOT_AVAILABLE:
-                health_raw = self.parse_id_number(INNODISK_HEALTH_ID)
+        
+        if self.health == NOT_AVAILABLE:
+            health_raw = self.parse_id_number(INNODISK_HEALTH_ID)
+            if health_raw == NOT_AVAILABLE:
+                self.health = NOT_AVAILABLE
+            else:
                 self.health = health_raw.split()[-1]
-            if self.temperature == NOT_AVAILABLE:
-                temp_raw = self.parse_id_number(INNODISK_TEMPERATURE_ID)
+        if self.temperature == NOT_AVAILABLE:
+            temp_raw = self.parse_id_number(INNODISK_TEMPERATURE_ID)
+            if temp_raw == NOT_AVAILABLE:
+                self.temperature = NOT_AVAILABLE
+            else:
                 self.temperature = temp_raw.split()[-6]
 
     def parse_virtium_info(self):

--- a/tests/ssd_generic_test.py
+++ b/tests/ssd_generic_test.py
@@ -389,7 +389,7 @@ class TestSsdGeneric:
     def test_Innodisk_ssd(self):
         # Test parsing Innodisk ssd info
         Innodisk_ssd = SsdUtil('/dev/sda')
-        assert(Innodisk_ssd.get_health() == 'N/A')
+        assert(Innodisk_ssd.get_health() == '0x000000000000')
         assert(Innodisk_ssd.get_model() == 'InnoDisk Corp. - mSATA 3ME')
         assert(Innodisk_ssd.get_firmware() == "S140714")
         assert(Innodisk_ssd.get_temperature() == 'N/A')
@@ -411,4 +411,14 @@ class TestSsdGeneric:
         Innodisk_ssd.parse_vendor_ssd_info('InnoDisk')
         assert(Innodisk_ssd.get_health() == '94')
         assert(Innodisk_ssd.get_temperature() == '39')
+        
+    @mock.patch('sonic_platform_base.sonic_ssd.ssd_generic.SsdUtil._execute_shell', mock.MagicMock(return_value=output_Innodisk_missing_names_ssd))
+    def test_Innodisk_missing_names_ssd_2(self):
+        # Test parsing Innodisk ssd info
+        Innodisk_ssd = SsdUtil('/dev/sda')
+        Innodisk_ssd.vendor_ssd_info = 'ERROR message from cmd'
+        Innodisk_ssd.parse_vendor_ssd_info('InnoDisk')
+        assert(Innodisk_ssd.get_health() == '94')
+        assert(Innodisk_ssd.get_temperature() == '39')
+        
 


### PR DESCRIPTION
Description:
The command is not showing the correct value for ssd health and temperature.

admin@sonic:~$ show platform ssdhealth
Device Model : M.2 (S42) 3IE4
Health       : N/A
Temperature  : N/A

Motivation and Context:
SSD health percentage and temperature not displayed on Nokia-7215 platform.

How Has This Been Tested?
"show platform ssdhealth" cli command on Nokia-7215 and Unittests

Output after fix:
admin@sonic:~$ show platform ssdhealth
Device Model : M.2 (S42) 3IE4
Health       : 100%
Temperature  : 25C
