### PR TITLE
Removing null characters while decoding from syseeprom

### DIFF
--- a/sonic_platform_base/sonic_eeprom/eeprom_tlvinfo.py
+++ b/sonic_platform_base/sonic_eeprom/eeprom_tlvinfo.py
@@ -522,6 +522,7 @@ class TlvInfoDecoder(eeprom_base.EepromDecoder):
             value = ""
             for c in t[2:2 + t[1]]:
                 value += "0x%02X " % c
+        value = value.replace('\x00', '')
         return name, value
 
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
This PR will track the resolution for failure seen on Mellanox devices with SONiC management test failure for test_pmon_syseepromd_kill_and_start_status test case. The testcase is failing with the below error:
```
========================================================================= ERRORS =========================================================================
______________________________________________ ERROR at setup of test_pmon_syseepromd_term_and_start_status ______________________________________________

duthosts = [<MultiAsicSonicHost str2-sn3800-02>], rand_one_dut_hostname = 'str2-sn3800-02'

    @pytest.fixture(scope='module')
    def data_before_restart(duthosts, rand_one_dut_hostname):
        duthost = duthosts[rand_one_dut_hostname]
    
>       data = collect_data(duthost)

duthost    = <MultiAsicSonicHost str2-sn3800-02>
duthosts   = [<MultiAsicSonicHost str2-sn3800-02>]
rand_one_dut_hostname = 'str2-sn3800-02'

platform_tests/daemon/test_syseepromd.py:99: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
platform_tests/daemon/test_syseepromd.py:80: in collect_data
    data = compose_dict_from_cli(data)
common/utilities.py:515: in compose_dict_from_cli
    return literal_eval(str_output)
/usr/lib/python2.7/ast.py:49: in literal_eval
    node_or_string = parse(node_or_string, mode='eval')
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

source = u"{'Name': 'Part Number', 'Len': '20', 'Value': 'MSN3800-CS2FO\x00\x00\x00\x00\x00\x00\x00'}", filename = '<unknown>', mode = 'eval'

    def parse(source, filename='<unknown>', mode='exec'):
        """
        Parse the source into an AST node.
        Equivalent to compile(source, filename, mode, PyCF_ONLY_AST).
        """
>       return compile(source, filename, mode, PyCF_ONLY_AST)
E       TypeError: compile() expected string without null bytes

filename   = '<unknown>'
mode       = 'eval'
source     = u"{'Name': 'Part Number', 'Len': '20', 'Value': 'MSN3800-CS2FO\x00\x00\x00\x00\x00\x00\x00'}"

/usr/lib/python2.7/ast.py:37: TypeError
-------------------------------------------- generated xml file: /var/src/test_lpm/tests/logs/tmp.log/tr.xml ---------------------------------------------
================================================================ short test summary info =================================================================
ERROR platform_tests/daemon/test_syseepromd.py::test_pmon_syseepromd_term_and_start_status - TypeError: compile() expected string without null bytes
=============================================================== 1 error in 113.67 seconds ================================================================
INFO:root:Can not get Allure report URL. Please check logs
```
#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
Overall, the testcase failed on Mellanox since the syseeprom has some fields wherein the string is appended by null characters. When the above testcase is executed, the null characters in the string are causing the error seen.
We observed that other platforms have string not terminated with null characters for various fields and the length mentioned in the EEPROM is same that of the string on EEPROM.
The below o/p was taken from Mellanox 3800 and it can be seen that the length of string is 20 which includes multiple null characters (^@ is 1 null character). The actual length of the string is 13 and there are 7 additional null characters.
root@str2-sn3800-02:/home/admin# sonic-db-cli STATE_DB HGETALL "EEPROM_INFO|0x22" | cat --show-nonprinting
{'Name': 'Part Number', 'Len': '20', 'Value': 'MSN3800-CS2FO^@^@^@^@^@^@^@'}
root@str2-sn3800-02:/home/admin#


#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Please refer to the below for the details related to the tests performed
[test_pmon_syseepromd_kill_and_start_status_test.txt](https://github.com/sonic-net/sonic-platform-common/files/10256723/test_pmon_syseepromd_kill_and_start_status_test.txt)

#### Additional Information (Optional)

Signed-off-by: Mihir Patel <patelmi@microsoft.com>
