### PR TITLE
Fix get_aux_mon_type xcvr API

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -790,7 +790,7 @@ class CmisApi(XcvrApi):
         '''
         This function returns the aux monitor types
         '''
-        result = self.xcvr_eeprom.read(consts.AUX_MON_TYPE)
+        result = self.xcvr_eeprom.read(consts.AUX_MON_TYPE) if not self.is_flat_memory() else None
         if result is None:
             return None
         aux1_mon_type = result & 0x1


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
Add error handling to get_aux_mon_type API

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
get_aux_mon_type reads field consts.AUX_MON_TYPE in eeprom on page 1 address 145
If memory model is flat, there is no page 1 in eeprom, only 0_lower and 0_upper
Here get_aux_mon_type doesn't check whether memory model is not flat, this causes errors in running xcvrd

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Tested on testbed, assured that logs of failed eeprom reading disappeared
#### Additional Information (Optional)

