### PR TITLE
[SSD] Parse SSD info correctly if smartctl does NOT have vendor name

### DIFF
--- a/sonic_platform_base/sonic_ssd/ssd_generic.py
+++ b/sonic_platform_base/sonic_ssd/ssd_generic.py
@@ -57,8 +57,11 @@ class SsdUtil(SsdBase):
                 self.fetch_vendor_ssd_info(diskdev, vendor)
                 self.parse_vendor_ssd_info(vendor)
             else:
-                # No handler registered for this disk model
-                pass
+                for model in ["InnoDisk", "Virtium"]:
+                    if self.health != NOT_AVAILABLE and self.temperature != NOT_AVAILABLE:
+                        break
+                    self.fetch_vendor_ssd_info(diskdev, model)
+                    self.parse_vendor_ssd_info(model)
         else:
             # Failed to get disk model
             self.model = "Unknown"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
I extended parse_generic_ssd_info if the unknown vendor name and health is N/A
#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
Problem: smartctl can't get the vendor name and the health attribute is missing.
In this case output for health and temperature are incorrect by show platform ssdhealth command:
`show platform ssdhealth 

Device Model : FS128GM280I-AC
Health       : N/A
Temperature  : 100C`

I expanded parse_generic_ssd_info, in which is read health and temperature information by SmartCmd utility and if did not work out by iSmart utility.
Example:
`show platform ssdhealth 

Device Model : FS128GM280I-AC
Health       : 91.96666666666667%
Temperature  : 36C`

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
comand:
show platform ssdhealth
#### Additional Information (Optional)

