### PR TITLE
Change get_tx_bias return type to list

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -207,7 +207,7 @@ class CmisApi(XcvrApi):
 
         for i in range(1, self.NUM_CHANNELS + 1):
             bulk_status["tx%ddisable" % i] = tx_disable[i-1] if self.get_tx_disable_support() else 'N/A'
-            bulk_status["tx%dbias" % i] = tx_bias['LaserBiasTx%dField' % i] if self.get_tx_bias_support() else 'N/A'
+            bulk_status["tx%dbias" % i] = tx_bias[i - 1]
             bulk_status["rx%dpower" % i] = float("{:.3f}".format(self.mw_to_dbm(rx_power[i - 1]))) if self.get_rx_power_support() else 'N/A'
             bulk_status["tx%dpower" % i] = float("{:.3f}".format(self.mw_to_dbm(tx_power[i - 1]))) if self.get_tx_power_support() else 'N/A'
 
@@ -495,7 +495,7 @@ class CmisApi(XcvrApi):
         tx_bias = self.xcvr_eeprom.read(consts.TX_BIAS_FIELD)
         for key, value in tx_bias.items():
             tx_bias[key] *= scale
-        return tx_bias
+        return [tx_bias['LaserBiasTx%dField' % i] for i in range(1, self.NUM_CHANNELS + 1)]
 
     def get_tx_power(self):
         '''

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -358,9 +358,11 @@ class TestCmis(object):
         assert result == expected
 
     @pytest.mark.parametrize("mock_response, expected", [
-        ([True, 2, {'TxBias1': 2}], {'TxBias1': 8}),
-        ([True, 3, {'TxBias1': 2}], {'TxBias1': 2}),
-        ([False, 0, {'TxBias1': 0}], ['N/A','N/A','N/A','N/A','N/A','N/A','N/A','N/A']),
+        ([True, 2, {'LaserBiasTx1Field': 2, 'LaserBiasTx2Field': 2, 'LaserBiasTx3Field': 2, 'LaserBiasTx4Field': 2, 'LaserBiasTx5Field': 2, 'LaserBiasTx6Field': 2, 'LaserBiasTx7Field': 2, 'LaserBiasTx8Field': 2}],
+        [8, 8, 8, 8, 8, 8, 8, 8]),
+        ([True, 3, {'LaserBiasTx1Field': 2, 'LaserBiasTx2Field': 2, 'LaserBiasTx3Field': 2, 'LaserBiasTx4Field': 2, 'LaserBiasTx5Field': 2, 'LaserBiasTx6Field': 2, 'LaserBiasTx7Field': 2, 'LaserBiasTx8Field': 2}],
+        [2, 2, 2, 2, 2, 2, 2, 2]),
+        ([False, 0, {'LaserBiasTx1Field': 0}], ['N/A','N/A','N/A','N/A','N/A','N/A','N/A','N/A']),
         ([None, 0, None], None)
     ])
     def test_get_tx_bias(self, mock_response, expected):
@@ -1221,10 +1223,7 @@ class TestCmis(object):
                 0,
                 50,
                 3.3,
-                {'LaserBiasTx1Field': 70, 'LaserBiasTx2Field': 70,
-                 'LaserBiasTx3Field': 70, 'LaserBiasTx4Field': 70,
-                 'LaserBiasTx5Field': 70, 'LaserBiasTx6Field': 70,
-                 'LaserBiasTx7Field': 70, 'LaserBiasTx8Field': 70},
+                [70, 70, 70, 70, 70, 70, 70, 70],
                 [0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1],
                 [0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1],
                 True, True, True, True, True, True,


### PR DESCRIPTION
Signed-off-by: Mihir Patel <patelmi@microsoft.com>

<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
It seems that the get_tx_bias API returns dictionary instead of list for 400GAUI-8C2M which is causing platform_tests/api/test_sfp.py::test_get_tx_bias test to fail.
Fixes sonic-net/sonic-buildimage#13380
#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
The return for this function has now been changed to list.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Summary
1. Ensure get_tx_bias returns list - Cisco [Passed]
2. Ensure get_tx_bias returns list - Arista [Passed]
3. Ensure test_get_tx_bias passes [Passed]

For detailed unit-test, please refer to [Unit-test_get_tx_bias .txt](https://github.com/sonic-net/sonic-platform-common/files/10494570/Unit-test_get_tx_bias.txt)

#### Additional Information (Optional)

