### PR TITLE
Add missing sys imports to psu_base and fan_drawer_base

### DIFF
--- a/sonic_platform_base/fan_drawer_base.py
+++ b/sonic_platform_base/fan_drawer_base.py
@@ -5,6 +5,7 @@
     to interact with a fan drawer module in SONiC
 """
 
+import sys
 from . import device_base
 
 

--- a/sonic_platform_base/psu_base.py
+++ b/sonic_platform_base/psu_base.py
@@ -5,6 +5,7 @@
     to interact with a power supply unit (PSU) in SONiC
 """
 
+import sys
 from . import device_base
 
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
Import `sys` in modules where it was missing and attempted to be referenced. Found it missing in psu_base.py and fan_drawer_base.py.

#### Motivation and Context
`sys.stderr.write` is used in default API definitions within psu_base.py and fan_drawer_base.py. When an exception is caught within these APIs, they will throw `NameError: name 'sys' is not defined` when trying to use the `sys` module without first importing it. Issue was originally found for PSUs, but also exists within fan_drawer_base.

#### How Has This Been Tested?
Test code demonstrating the issue and the fix after importing `sys`
```
>>> def test(index):
...     l = []
...     try:
...         return l[index]
...     except IndexError:
...         sys.stderr.write('Index out of range\n')
...     return None
...
>>> test(1)
Traceback (most recent call last):
  File "<stdin>", line 4, in test
IndexError: list index out of range

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<stdin>", line 6, in test
NameError: name 'sys' is not defined
>>> import sys
>>> test(1)
Index out of range
```

#### Additional Information (Optional)

This fix should go into all active branches, especially master, 202205, and 202012.

