### PR TITLE
Update host electrical interface for 2x100G AOC

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -142,7 +142,6 @@ class CmisApi(XcvrApi):
             "cable_type": "Length Cable Assembly(m)",
             "cable_length": float(admin_info[consts.LENGTH_ASSEMBLY_FIELD]),
             "nominal_bit_rate": 0, # Not supported
-            "specification_compliance": admin_info[consts.MEDIA_TYPE_FIELD],
             "vendor_date": admin_info[consts.VENDOR_DATE_FIELD],
             "vendor_oui": admin_info[consts.VENDOR_OUI_FIELD]
         }

--- a/sonic_platform_base/sonic_xcvr/codes/public/sff8024.py
+++ b/sonic_platform_base/sonic_xcvr/codes/public/sff8024.py
@@ -247,7 +247,9 @@ class Sff8024(XcvrCodes):
         61: 'FOIC2.8 (ITU-T G.709.1/Y.1331 G.Sup58)',
         62: 'FOIC2.4 (ITU-T G.709.1/Y.1331 G.Sup58)',
         63: 'FOIC4.16 (ITU-T G.709.1 G.Sup58)',
-        64: 'FOIC4.8 (ITU-T G.709.1 G.Sup58)'
+        64: 'FOIC4.8 (ITU-T G.709.1 G.Sup58)',
+        65: 'CAUI-4 C2M (Annex 83E) without FEC',
+        66: 'CAUI-4 C2M (Annex 83E) with RS(528,514) FEC'
     }
 
     NM_850_MEDIA_INTERFACE = {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
Update host electrical interface for 2x100G AOC

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
It seems that the host electrical interface for 2x100G AOC was not part of HOST_ELECTRICAL_INTERFACE. The corresponding change has now been made.
Also, updating value for "specification_compliance" had a code duplication. I have now removed the corresponding duplicate entry for this.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Verified that 2x100G AOC is detected and CMIS init code is triggered

#### Additional Information (Optional)

