### PR TITLE
Modify get_host_lane_assignment_option to return value based on application id

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -715,11 +715,15 @@ class CmisApi(XcvrApi):
         '''
         return self.xcvr_eeprom.read(consts.MEDIA_INTERFACE_TECH)
 
-    def get_host_lane_assignment_option(self):
+    def get_host_lane_assignment_option(self, app=1):
         '''
         This function returns the host lane that the application begins on
+        Args:
+            app:
+                Integer, desired application for which host_lane_assignment_options are requested
         '''
-        return self.xcvr_eeprom.read(consts.HOST_LANE_ASSIGNMENT_OPTION)
+        appl_advt = self.get_application_advertisement()
+        return appl_advt[app]['host_lane_assignment_options'] if len(appl_advt) > 0 else 0
 
     def get_media_lane_assignment_option(self):
         '''

--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -715,15 +715,18 @@ class CmisApi(XcvrApi):
         '''
         return self.xcvr_eeprom.read(consts.MEDIA_INTERFACE_TECH)
 
-    def get_host_lane_assignment_option(self, app=1):
+    def get_host_lane_assignment_option(self, appl=1):
         '''
         This function returns the host lane that the application begins on
         Args:
             app:
                 Integer, desired application for which host_lane_assignment_options are requested
         '''
+        if (appl <= 0):
+            return 0
+
         appl_advt = self.get_application_advertisement()
-        return appl_advt[app]['host_lane_assignment_options'] if len(appl_advt) > 0 else 0
+        return appl_advt[appl]['host_lane_assignment_options'] if len(appl_advt) >= appl else 0
 
     def get_media_lane_assignment_option(self):
         '''

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -675,13 +675,30 @@ class TestCmis(object):
         result = self.api.get_media_interface_technology()
         assert result == expected
 
-    @pytest.mark.parametrize("mock_response, expected", [
-        (1, 1)
+    @pytest.mark.parametrize("appl, expected", [
+        (1, 1),
+        (2, 17)
     ])
-    def test_get_host_lane_assignment_option(self, mock_response, expected):
-        self.api.xcvr_eeprom.read = MagicMock()
-        self.api.xcvr_eeprom.read.return_value = mock_response
-        result = self.api.get_host_lane_assignment_option()
+    def test_get_host_lane_assignment_option(self, appl, expected):
+        appl_advert_dict = {
+            1: {
+                'host_electrical_interface_id': '400GAUI-8 C2M (Annex 120E)',
+                'module_media_interface_id': '400GBASE-DR4 (Cl 124)',
+                'media_lane_count': 4,
+                'host_lane_count': 8,
+                'host_lane_assignment_options': 1
+            },
+            2: {
+                'host_electrical_interface_id': 'CAUI-4 C2M (Annex 83E)',
+                'module_media_interface_id': 'Active Cable assembly with BER < 5x10^-5',
+                'media_lane_count': 4,
+                'host_lane_count': 4,
+                'host_lane_assignment_options': 17
+            }
+        }
+        self.api.get_application_advertisement = MagicMock(return_value=appl_advert_dict)
+
+        result = self.api.get_host_lane_assignment_option(appl)
         assert result == expected
 
     @pytest.mark.parametrize("mock_response, expected", [

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -677,8 +677,10 @@ class TestCmis(object):
         assert result == expected
 
     @pytest.mark.parametrize("appl, expected", [
+        (0, 0),
         (1, 1),
-        (2, 17)
+        (2, 17),
+        (3, 0)
     ])
     @patch('sonic_platform_base.sonic_xcvr.api.public.cmis.CmisApi.get_application_advertisement', MagicMock(return_value =
         {

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -1,3 +1,4 @@
+from unittest.mock import patch
 from mock import MagicMock
 import pytest
 from sonic_platform_base.sonic_xcvr.api.public.cmis import CmisApi
@@ -679,8 +680,8 @@ class TestCmis(object):
         (1, 1),
         (2, 17)
     ])
-    def test_get_host_lane_assignment_option(self, appl, expected):
-        appl_advert_dict = {
+    @patch('sonic_platform_base.sonic_xcvr.api.public.cmis.CmisApi.get_application_advertisement', MagicMock(return_value =
+        {
             1: {
                 'host_electrical_interface_id': '400GAUI-8 C2M (Annex 120E)',
                 'module_media_interface_id': '400GBASE-DR4 (Cl 124)',
@@ -696,8 +697,8 @@ class TestCmis(object):
                 'host_lane_assignment_options': 17
             }
         }
-        self.api.get_application_advertisement = MagicMock(return_value=appl_advert_dict)
-
+    ))
+    def test_get_host_lane_assignment_option(self, appl, expected):
         result = self.api.get_host_lane_assignment_option(appl)
         assert result == expected
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
The changes with this PR needs to be merged along with sonic-net/sonic-platform-daemons#342

#### Description
<!--
     Describe your changes in detail
-->
The API get_host_lane_assignment_option doesn't return the host_lane_assignment_options using the application id and always returns value from Application Descriptor 1 (AppSel = 1)

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
The API get_host_lane_assignment_option will now take the AppSel id as the input and would return the host_lane_assignment_option from the relevant Application Descriptor

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Testcase summary
Please refer to the test details attached to sonic-net/sonic-platform-daemons#342

#### Additional Information (Optional)
