### PR TITLE
Add set/get_lpmode APIs for sff8436 and sff8636 optics

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/sff8436.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/sff8436.py
@@ -308,3 +308,38 @@ class Sff8436Api(XcvrApi):
 
     def get_power_override_support(self):
         return not self.is_copper()
+
+    def set_lpmode(self, lpmode):
+        '''
+        This function sets the module to low power state.
+
+        Args:
+            lpmode (bool): False means "set to high power", True means "set to low power"
+
+        Returns:
+            bool: True if the provision succeeds, False if it fails
+        '''
+        if not self.get_lpmode_support() or not self.get_power_override_support():
+            return False
+
+        if lpmode:
+            return self.set_power_override(True, True)
+        else:
+            return self.set_power_override(True, False)
+
+    def get_lpmode(self):
+        '''
+        Retrieves low power module status
+
+        Returns:
+            bool: True if module in low power else returns False.
+        '''
+        if not self.get_lpmode_support() or not self.get_power_override_support():
+            return False
+
+        power_set = self.get_power_set()
+        power_override = self.get_power_override()
+
+        # Since optics come up by default set to high power, in this case,
+        # power_override not being set, function will return high power mode.
+        return power_set and power_override

--- a/sonic_platform_base/sonic_xcvr/api/public/sff8436.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/sff8436.py
@@ -340,6 +340,6 @@ class Sff8436Api(XcvrApi):
         power_set = self.get_power_set()
         power_override = self.get_power_override()
 
-        # Since optics come up by default set to high power, in this case,
+        # Since typically optics come up by default set to high power, in this case,
         # power_override not being set, function will return high power mode.
         return power_set and power_override

--- a/sonic_platform_base/sonic_xcvr/api/public/sff8436.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/sff8436.py
@@ -322,10 +322,7 @@ class Sff8436Api(XcvrApi):
         if not self.get_lpmode_support() or not self.get_power_override_support():
             return False
 
-        if lpmode:
-            return self.set_power_override(True, True)
-        else:
-            return self.set_power_override(True, False)
+        return self.set_power_override(True, lpmode)
 
     def get_lpmode(self):
         '''

--- a/sonic_platform_base/sonic_xcvr/api/public/sff8436.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/sff8436.py
@@ -314,7 +314,7 @@ class Sff8436Api(XcvrApi):
         This function sets LPMode for the module.
 
         Args:
-            lpmode (bool): False means "set to high power", True means "set to low power"
+            lpmode (bool): False means LPMode Off, True means LPMode On
 
         Returns:
             bool: True if the provision succeeds, False if it fails

--- a/sonic_platform_base/sonic_xcvr/api/public/sff8436.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/sff8436.py
@@ -311,7 +311,7 @@ class Sff8436Api(XcvrApi):
 
     def set_lpmode(self, lpmode):
         '''
-        This function sets the module to low power state.
+        This function sets LPMode for the module.
 
         Args:
             lpmode (bool): False means "set to high power", True means "set to low power"
@@ -326,7 +326,7 @@ class Sff8436Api(XcvrApi):
 
     def get_lpmode(self):
         '''
-        Retrieves low power module status
+        Retrieves low power mode status
 
         Returns:
             bool: True if module in low power else returns False.

--- a/sonic_platform_base/sonic_xcvr/api/public/sff8636.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/sff8636.py
@@ -360,3 +360,38 @@ class Sff8636Api(XcvrApi):
 
     def get_power_override_support(self):
         return not self.is_copper()
+
+    def set_lpmode(self, lpmode):
+        '''
+        This function sets the module to low power state.
+
+        Args:
+            lpmode (bool): False means "set to high power", True means "set to low power"
+
+        Returns:
+            bool: True if the provision succeeds, False if it fails
+        '''
+        if not self.get_lpmode_support() or not self.get_power_override_support():
+            return False
+
+        if lpmode:
+            return self.set_power_override(True, True)
+        else:
+            return self.set_power_override(True, False)
+
+    def get_lpmode(self):
+        '''
+        Retrieves low power module status
+
+        Returns:
+            bool: True if module in low power else returns False.
+        '''
+        if not self.get_lpmode_support() or not self.get_power_override_support():
+            return False
+
+        power_set = self.get_power_set()
+        power_override = self.get_power_override()
+
+        # Since optics come up by default set to high power, in this case,
+        # power_override not being set, function will return high power mode.
+        return power_set and power_override

--- a/sonic_platform_base/sonic_xcvr/api/public/sff8636.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/sff8636.py
@@ -374,10 +374,7 @@ class Sff8636Api(XcvrApi):
         if not self.get_lpmode_support() or not self.get_power_override_support():
             return False
 
-        if lpmode:
-            return self.set_power_override(True, True)
-        else:
-            return self.set_power_override(True, False)
+        return self.set_power_override(True, lpmode)
 
     def get_lpmode(self):
         '''

--- a/sonic_platform_base/sonic_xcvr/api/public/sff8636.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/sff8636.py
@@ -366,7 +366,7 @@ class Sff8636Api(XcvrApi):
         This function sets LPMode for the module.
 
         Args:
-            lpmode (bool): False means "set to high power", True means "set to low power"
+            lpmode (bool): False means LPMode Off, True means LPMode On
 
         Returns:
             bool: True if the provision succeeds, False if it fails

--- a/sonic_platform_base/sonic_xcvr/api/public/sff8636.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/sff8636.py
@@ -363,7 +363,7 @@ class Sff8636Api(XcvrApi):
 
     def set_lpmode(self, lpmode):
         '''
-        This function sets the module to low power state.
+        This function sets LPMode for the module.
 
         Args:
             lpmode (bool): False means "set to high power", True means "set to low power"
@@ -378,7 +378,7 @@ class Sff8636Api(XcvrApi):
 
     def get_lpmode(self):
         '''
-        Retrieves low power module status
+        Retrieves low power mode status
 
         Returns:
             bool: True if module in low power else returns False.

--- a/sonic_platform_base/sonic_xcvr/api/public/sff8636.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/sff8636.py
@@ -392,6 +392,6 @@ class Sff8636Api(XcvrApi):
         power_set = self.get_power_set()
         power_override = self.get_power_override()
 
-        # Since optics come up by default set to high power, in this case,
+        # Since typically optics come up by default set to high power, in this case,
         # power_override not being set, function will return high power mode.
         return power_set and power_override

--- a/tests/sonic_xcvr/test_sff8436.py
+++ b/tests/sonic_xcvr/test_sff8436.py
@@ -54,6 +54,8 @@ class TestSff8436(object):
         self.api.get_transceiver_thresholds_support()
         self.api.get_lpmode_support()
         self.api.get_power_override_support()
+        self.api.set_lpmode(True)
+        self.api.get_lpmode()
 
     @pytest.mark.parametrize("mock_response, expected", [
         (bytearray([0x0]), "Power Class 1 Module (1.5W max. Power consumption)"),
@@ -104,3 +106,32 @@ class TestSff8436(object):
             assert not self.api.get_temperature_support()
             assert not self.api.get_voltage_support()
 
+    def test_get_lpmode(self):
+        self.api.get_lpmode_support = MagicMock()
+        self.api.get_lpmode_support.return_value = True
+        self.api.get_power_override_support = MagicMock()
+        self.api.get_power_override_support.return_value = True
+        self.api.get_power_set = MagicMock()
+        self.api.get_power_set.return_value = True
+        self.api.get_power_override = MagicMock()
+        self.api.get_power_override.return_value = True
+        assert self.api.get_lpmode()
+        self.api.get_power_set.return_value = False
+        self.api.get_power_override.return_value = True
+        assert not self.api.get_lpmode()
+        self.api.get_lpmode_support.return_value = False
+        self.api.get_power_override_support.return_value = False
+        assert not self.api.get_lpmode()
+
+    def test_set_lpmode(self):
+        self.api.get_lpmode_support = MagicMock()
+        self.api.get_lpmode_support.return_value = True
+        self.api.get_power_override_support = MagicMock()
+        self.api.get_power_override_support.return_value = True
+        self.api.set_power_override = MagicMock()
+        self.api.set_power_override.return_value = True
+        assert self.api.set_lpmode(True)
+        assert self.api.set_lpmode(False)
+        self.api.get_lpmode_support.return_value = False
+        self.api.get_power_override_support.return_value = False
+        assert not self.api.set_lpmode(True)

--- a/tests/sonic_xcvr/test_sff8636.py
+++ b/tests/sonic_xcvr/test_sff8636.py
@@ -54,6 +54,8 @@ class TestSff8636(object):
         self.api.get_transceiver_thresholds_support()
         self.api.get_lpmode_support()
         self.api.get_power_override_support()
+        self.api.set_lpmode(True)
+        self.api.get_lpmode()
 
     @pytest.mark.parametrize("mock_response, expected", [
         (bytearray([0x0]), "Power Class 1 Module (1.5W max.)"),
@@ -104,4 +106,34 @@ class TestSff8636(object):
             assert not self.api.get_rx_power_support()
             assert not self.api.get_temperature_support()
             assert not self.api.get_voltage_support()
+
+    def test_get_lpmode(self):
+        self.api.get_lpmode_support = MagicMock()
+        self.api.get_lpmode_support.return_value = True
+        self.api.get_power_override_support = MagicMock()
+        self.api.get_power_override_support.return_value = True
+        self.api.get_power_set = MagicMock()
+        self.api.get_power_set.return_value = True
+        self.api.get_power_override = MagicMock()
+        self.api.get_power_override.return_value = True
+        assert self.api.get_lpmode()
+        self.api.get_power_set.return_value = False
+        self.api.get_power_override.return_value = True
+        assert not self.api.get_lpmode()
+        self.api.get_lpmode_support.return_value = False
+        self.api.get_power_override_support.return_value = False
+        assert not self.api.get_lpmode()
+
+    def test_set_lpmode(self):
+        self.api.get_lpmode_support = MagicMock()
+        self.api.get_lpmode_support.return_value = True
+        self.api.get_power_override_support = MagicMock()
+        self.api.get_power_override_support.return_value = True
+        self.api.set_power_override = MagicMock()
+        self.api.set_power_override.return_value = True
+        assert self.api.set_lpmode(True)
+        assert self.api.set_lpmode(False)
+        self.api.get_lpmode_support.return_value = False
+        self.api.get_power_override_support.return_value = False
+        assert not self.api.set_lpmode(True)
 


### PR DESCRIPTION
Add set/get_lpmode APIs for sff8436 and sff8636 optics

#### Description
Add set/get_lpmode APIs implementation in sff8436.py and sff8636.py

#### Motivation and Context
According to 8436 and 8636 spec, lpmode can be manipulated via the combination of the Power_over-ride and Power_set software control bits (Address A0h, byte 93 bits 0,1),  as sfp refactor came in, such logic needs to be in sonic-platform-common, thus add set/get_lpmode implementation following the spec.  
This is common routine based on standard spec. Vendor/platform can decide to whether use it or combine it with platform specific actions. 
CMIS/C-CMIS already has the support, thus no need to add.

#### How Has This Been Tested?
1. Verified set/get APIs on 100G optics. checked eeprom dump/tx_power/rx_power after setting lpmode. (when optics is in lpmode, oper_status is down, and there's no tx/rx_power, but eeprom is still accessible.) 
3. Verified set/get APIs on 40G optics which is power class 1 (max power 1.5W), checked eeprom dump/tx_power/rx_power after setting lpmode.  In this case, set API will return False. Even if, we toggle the control bits to set it to lpmode, optics will still be in oper_status UP, because as mentioned by sff8436 spec, ```If the Extended Identifier bits (Page 00h, byte 129 bits 6-7) indicate that its power consumption is less than 1.5W then the module shall be fully functional independent of whether it is in low power or high power mode.``` 

#### Additional Information (Optional)

