### PR TITLE
[Backport] [202211] Fix issue: should always check return value of a function if the function may return None

### DIFF
--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -1,5 +1,7 @@
 from mock import MagicMock
 import pytest
+import traceback
+import random
 from sonic_platform_base.sonic_xcvr.api.public.cmis import CmisApi
 from sonic_platform_base.sonic_xcvr.mem_maps.public.cmis import CmisMemMap
 from sonic_platform_base.sonic_xcvr.xcvr_eeprom import XcvrEeprom
@@ -13,6 +15,7 @@ class TestCmis(object):
     reader = MagicMock(return_value=None)
     writer = MagicMock()
     eeprom = XcvrEeprom(reader, writer, mem_map)
+    old_read_func = eeprom.read
     api = CmisApi(eeprom)
 
     @pytest.mark.parametrize("mock_response, expected", [
@@ -2126,3 +2129,22 @@ class TestCmis(object):
 
         result = self.api.get_error_description()
         assert result is None
+
+    def test_random_read_fail(self):
+        def mock_read_raw(offset, size):
+            i = random.randint(0, 1)
+            return None if i == 0 else b'0' * size
+
+        self.api.xcvr_eeprom.read = self.old_read_func
+        self.api.xcvr_eeprom.reader = mock_read_raw
+
+        run_num = 5
+        while run_num > 0:
+            try:
+                self.api.get_transceiver_bulk_status()
+                self.api.get_transceiver_info()
+                self.api.get_transceiver_threshold_info()
+                self.api.get_transceiver_status()
+            except:
+                assert 0, traceback.format_exc()
+            run_num -= 1

--- a/tests/sonic_xcvr/test_sff8436.py
+++ b/tests/sonic_xcvr/test_sff8436.py
@@ -1,9 +1,12 @@
 from mock import MagicMock, patch
+import traceback
+import random
 
 from sonic_platform_base.sonic_xcvr.api.public.sff8436 import Sff8436Api
 from sonic_platform_base.sonic_xcvr.codes.public.sff8436 import Sff8436Codes
 from sonic_platform_base.sonic_xcvr.mem_maps.public.sff8436 import Sff8436MemMap
 from sonic_platform_base.sonic_xcvr.xcvr_eeprom import XcvrEeprom
+
 
 class TestSff8436(object):
     codes = Sff8436Codes
@@ -73,3 +76,20 @@ class TestSff8436(object):
             assert not self.api.get_rx_power_support()
             assert not self.api.get_temperature_support()
             assert not self.api.get_voltage_support()
+
+    def test_random_read_fail(self):
+        def mock_read_raw(offset, size):
+            i = random.randint(0, 1)
+            return None if i == 0 else b'0' * size
+
+        self.api.xcvr_eeprom.reader = mock_read_raw
+
+        run_num = 5
+        while run_num > 0:
+            try:
+                self.api.get_transceiver_bulk_status()
+                self.api.get_transceiver_info()
+                self.api.get_transceiver_threshold_info()
+            except:
+                assert 0, traceback.format_exc()
+            run_num -= 1

--- a/tests/sonic_xcvr/test_sff8472.py
+++ b/tests/sonic_xcvr/test_sff8472.py
@@ -1,5 +1,7 @@
 from mock import MagicMock
 import sys
+import random
+import traceback
 
 from sonic_platform_base.sonic_xcvr.api.public.sff8472 import Sff8472Api
 from sonic_platform_base.sonic_xcvr.codes.public.sff8472 import Sff8472Codes
@@ -170,3 +172,20 @@ class TestSff8472(object):
         }
         decoded = rx_power_field.decode(data, **deps)
         assert decoded == 209.713
+
+    def test_random_read_fail(self):
+        def mock_read_raw(offset, size):
+            i = random.randint(0, 1)
+            return None if i == 0 else b'0' * size
+
+        self.api.xcvr_eeprom.reader = mock_read_raw
+
+        run_num = 5
+        while run_num > 0:
+            try:
+                self.api.get_transceiver_bulk_status()
+                self.api.get_transceiver_info()
+                self.api.get_transceiver_threshold_info()
+            except:
+                assert 0, traceback.format_exc()
+            run_num -= 1

--- a/tests/sonic_xcvr/test_sff8636.py
+++ b/tests/sonic_xcvr/test_sff8636.py
@@ -1,4 +1,6 @@
 from mock import MagicMock, patch
+import random
+import traceback
 
 from sonic_platform_base.sonic_xcvr.api.public.sff8636 import Sff8636Api
 from sonic_platform_base.sonic_xcvr.codes.public.sff8636 import Sff8636Codes
@@ -71,3 +73,20 @@ class TestSff8636(object):
             assert not self.api.get_rx_power_support()
             assert not self.api.get_temperature_support()
             assert not self.api.get_voltage_support()
+
+    def test_random_read_fail(self):
+        def mock_read_raw(offset, size):
+            i = random.randint(0, 1)
+            return None if i == 0 else b'0' * size
+
+        self.api.xcvr_eeprom.reader = mock_read_raw
+
+        run_num = 5
+        while run_num > 0:
+            try:
+                self.api.get_transceiver_bulk_status()
+                self.api.get_transceiver_info()
+                self.api.get_transceiver_threshold_info()
+            except:
+                assert 0, traceback.format_exc()
+            run_num -= 1


### PR DESCRIPTION
Backport https://github.com/sonic-net/sonic-platform-common/pull/355 to 202211
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

When a function may return None, caller should always check the return value before using it. This PR is to fix such issues in sonic-xcvr.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

When a function may return None, caller should always check the return value before using it. This PR is to fix such issues in sonic-xcvr.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

Created unit test cases to avoid such thing happening

#### Additional Information (Optional)
