### PR TITLE
Move tx_disable/tx_disabled_channel/rx_los/tx_fault  to get_transceiver_status API

### DIFF
--- a/sonic_platform_base/sfp_base.py
+++ b/sonic_platform_base/sfp_base.py
@@ -161,9 +161,6 @@ class SfpBase(device_base.DeviceBase):
         tx_fault                   |BOOLEAN        |TX fault status, True if has TX fault, False if not.
         reset_status               |BOOLEAN        |reset status, True if SFP in reset, False if not.
         lp_mode                    |BOOLEAN        |low power mode status, True in lp mode, False if not.
-        tx_disable                 |BOOLEAN        |TX disable status, True TX disabled, False if not.
-        tx_disabled_channel        |HEX            |disabled TX channels in hex, bits 0 to 3 represent channel 0
-                                   |               |to channel 3.
         temperature                |INT            |module temperature in Celsius
         voltage                    |INT            |supply voltage in mV
         tx<n>bias                  |INT            |TX Bias Current in mA, n is the channel number,

--- a/sonic_platform_base/sonic_xcvr/api/public/c_cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/c_cmis.py
@@ -644,7 +644,7 @@ class CCmisApi(CmisApi):
         tuning_in_progress           = BOOLEAN                          ; tuning in progress status
         wavelength_unlock_status     = BOOLEAN                          ; laser unlocked status
         target_output_power_oor      = BOOLEAN                          ; target output power out of range flag
-        fine_tuning_oor              = BOOLEAN                          ; fine tuning  out of range flag
+        fine_tuning_oor              = BOOLEAN                          ; fine tuning out of range flag
         tuning_not_accepted          = BOOLEAN                          ; tuning not accepted flag
         invalid_channel_num          = BOOLEAN                          ; invalid channel number flag
         tuning_complete              = BOOLEAN                          ; tuning complete flag

--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -1728,9 +1728,11 @@ class CmisApi(XcvrApi):
             if rx_output_status_dict:
                 for lane in range(1, self.NUM_CHANNELS+1):
                     trans_status['rxoutput_status_hostlane%d' % lane] = rx_output_status_dict.get('RxOutputStatus%d' % lane)
-            if self.get_tx_disable_support():
-                trans_status['tx_disabled_channel'] = self.get_tx_disable_channel()
-                tx_disable = self.get_tx_disable()
+            tx_disabled_channel = self.get_tx_disable_channel()
+            if tx_disabled_channel is not None:
+                trans_status['tx_disabled_channel'] = tx_disabled_channel
+            tx_disable = self.get_tx_disable()
+            if tx_disable is not None:
                 for lane in range(1, self.NUM_CHANNELS+1):
                     trans_status['tx%ddisable' % lane] = tx_disable[lane - 1]
             tx_fault = self.get_tx_fault()

--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -1620,6 +1620,8 @@ class CmisApi(XcvrApi):
         rxoutput_status_hostlane6    = BOOLEAN                          ; rx output status on host lane 6
         rxoutput_status_hostlane7    = BOOLEAN                          ; rx output status on host lane 7
         rxoutput_status_hostlane8    = BOOLEAN                          ; rx output status on host lane 8
+        tx_disable                   = BOOLEAN                          ; tx disable status
+        tx_disabled_channel          = INTEGER                          ; disabled TX channels
         txfault                      = BOOLEAN                          ; tx fault flag on media lane
         txlos_hostlane1              = BOOLEAN                          ; tx loss of signal flag on host lane 1
         txlos_hostlane2              = BOOLEAN                          ; tx loss of signal flag on host lane 2
@@ -1738,6 +1740,11 @@ class CmisApi(XcvrApi):
             if rx_output_status_dict:
                 for lane in range(1, self.NUM_CHANNELS+1):
                     trans_status['rxoutput_status_hostlane%d' % lane] = rx_output_status_dict.get('RxOutputStatus%d' % lane)
+            if self.get_tx_disable_support():
+                trans_status['tx_disabled_channel'] = self.get_tx_disable_channel()
+                tx_disable = self.get_tx_disable()
+                for lane in range(1, self.NUM_CHANNELS+1):
+                    trans_status['tx%ddisable' % lane] = tx_disable[lane - 1]
             tx_fault = self.get_tx_fault()
             if tx_fault:
                 for lane in range(1, self.NUM_CHANNELS+1):

--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -176,20 +176,12 @@ class CmisApi(XcvrApi):
             return xcvr_info
 
     def get_transceiver_bulk_status(self):
-        rx_los = self.get_rx_los()
-        tx_fault = self.get_tx_fault()
-        tx_disable = self.get_tx_disable()
-        tx_disabled_channel = self.get_tx_disable_channel()
         temp = self.get_module_temperature()
         voltage = self.get_voltage()
         tx_bias = self.get_tx_bias()
         rx_power = self.get_rx_power()
         tx_power = self.get_tx_power()
-        read_failed = rx_los is None or \
-                      tx_fault is None or \
-                      tx_disable is None or \
-                      tx_disabled_channel is None or \
-                      temp is None or \
+        read_failed = temp is None or \
                       voltage is None or \
                       tx_bias is None or \
                       rx_power is None or \
@@ -198,15 +190,11 @@ class CmisApi(XcvrApi):
             return None
 
         bulk_status = {
-            "rx_los": all(rx_los) if self.get_rx_los_support() else 'N/A',
-            "tx_fault": all(tx_fault) if self.get_tx_fault_support() else 'N/A',
-            "tx_disabled_channel": tx_disabled_channel,
             "temperature": temp,
             "voltage": voltage
         }
 
         for i in range(1, self.NUM_CHANNELS + 1):
-            bulk_status["tx%ddisable" % i] = tx_disable[i-1] if self.get_tx_disable_support() else 'N/A'
             bulk_status["tx%dbias" % i] = tx_bias[i - 1]
             bulk_status["rx%dpower" % i] = float("{:.3f}".format(self.mw_to_dbm(rx_power[i - 1]))) if rx_power[i - 1] != 'N/A' else 'N/A'
             bulk_status["tx%dpower" % i] = float("{:.3f}".format(self.mw_to_dbm(tx_power[i - 1]))) if tx_power[i - 1] != 'N/A' else 'N/A'

--- a/sonic_platform_base/sonic_xcvr/api/public/sff8436.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/sff8436.py
@@ -68,17 +68,34 @@ class Sff8436Api(XcvrApi):
 
         return xcvr_info
 
-    def get_transceiver_bulk_status(self):
+    def get_transceiver_status(self):
         rx_los = self.get_rx_los()
         tx_fault = self.get_tx_fault()
+        tx_disable = self.get_tx_disable()
+        tx_disabled_channel = self.get_tx_disable_channel()
+        read_failed = rx_los is None or \
+                      tx_fault is None or \
+                      tx_disable is None or \
+                      tx_disabled_channel is None
+        if read_failed:
+            return None
+
+        trans_status = {
+            "rx_los": all(rx_los) if self.get_rx_los_support() else 'N/A',
+            "tx_fault": all(tx_fault) if self.get_tx_fault_support() else 'N/A',
+            "tx_disable": all(tx_disable),
+            "tx_disabled_channel": tx_disabled_channel
+        }
+
+        return trans_status
+
+    def get_transceiver_bulk_status(self):
         temp = self.get_module_temperature()
         voltage = self.get_voltage()
         tx_bias = self.get_tx_bias()
         rx_power = self.get_rx_power()
         tx_power = self.get_tx_power()
-        read_failed = rx_los is None or \
-                      tx_fault is None or \
-                      temp is None or \
+        read_failed = temp is None or \
                       voltage is None or \
                       tx_bias is None or \
                       rx_power is None or \
@@ -87,8 +104,6 @@ class Sff8436Api(XcvrApi):
             return None
 
         bulk_status = {
-            "rx_los": all(rx_los) if self.get_rx_los_support() else 'N/A',
-            "tx_fault": all(tx_fault) if self.get_tx_fault_support() else 'N/A',
             "temperature": temp,
             "voltage": voltage
         }

--- a/sonic_platform_base/sonic_xcvr/api/public/sff8436.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/sff8436.py
@@ -71,8 +71,6 @@ class Sff8436Api(XcvrApi):
     def get_transceiver_bulk_status(self):
         rx_los = self.get_rx_los()
         tx_fault = self.get_tx_fault()
-        tx_disable = self.get_tx_disable()
-        tx_disabled_channel = self.get_tx_disable_channel()
         temp = self.get_module_temperature()
         voltage = self.get_voltage()
         tx_bias = self.get_tx_bias()
@@ -80,8 +78,6 @@ class Sff8436Api(XcvrApi):
         tx_power = self.get_tx_power()
         read_failed = rx_los is None or \
                       tx_fault is None or \
-                      tx_disable is None or \
-                      tx_disabled_channel is None or \
                       temp is None or \
                       voltage is None or \
                       tx_bias is None or \
@@ -93,8 +89,6 @@ class Sff8436Api(XcvrApi):
         bulk_status = {
             "rx_los": all(rx_los) if self.get_rx_los_support() else 'N/A',
             "tx_fault": all(tx_fault) if self.get_tx_fault_support() else 'N/A',
-            "tx_disable": all(tx_disable),
-            "tx_disabled_channel": tx_disabled_channel,
             "temperature": temp,
             "voltage": voltage
         }

--- a/sonic_platform_base/sonic_xcvr/api/public/sff8436.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/sff8436.py
@@ -80,12 +80,14 @@ class Sff8436Api(XcvrApi):
         if read_failed:
             return None
 
-        trans_status = {
-            "rx_los": all(rx_los) if self.get_rx_los_support() else 'N/A',
-            "tx_fault": all(tx_fault) if self.get_tx_fault_support() else 'N/A',
-            "tx_disable": all(tx_disable),
-            "tx_disabled_channel": tx_disabled_channel
-        }
+        trans_status = dict()
+        for lane in range(1, len(rx_los) + 1):
+            trans_status['rxlos%d' % lane] = rx_los[lane - 1]
+        for lane in range(1, len(tx_fault) + 1):
+            trans_status['txfault%d' % lane] = tx_fault[lane - 1]
+        for lane in range(1, len(tx_disable) + 1):
+            trans_status['tx%ddisable' % lane] = tx_disable[lane - 1]
+        trans_status['tx_disabled_channel'] = tx_disabled_channel
 
         return trans_status
 

--- a/sonic_platform_base/sonic_xcvr/api/public/sff8472.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/sff8472.py
@@ -72,12 +72,14 @@ class Sff8472Api(XcvrApi):
         if read_failed:
             return None
 
-        trans_status = {
-            "rx_los": all(rx_los) if self.get_rx_los_support() else 'N/A',
-            "tx_fault": all(tx_fault) if self.get_tx_fault_support() else 'N/A',
-            "tx_disable": all(tx_disable),
-            "tx_disabled_channel": tx_disabled_channel
-        }
+        trans_status = dict()
+        for lane in range(1, len(rx_los) + 1):
+            trans_status['rxlos%d' % lane] = rx_los[lane - 1]
+        for lane in range(1, len(tx_fault) + 1):
+            trans_status['txfault%d' % lane] = tx_fault[lane - 1]
+        for lane in range(1, len(tx_disable) + 1):
+            trans_status['tx%ddisable' % lane] = tx_disable[lane - 1]
+        trans_status['tx_disabled_channel'] = tx_disabled_channel
 
         return trans_status
 

--- a/sonic_platform_base/sonic_xcvr/api/public/sff8472.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/sff8472.py
@@ -63,8 +63,6 @@ class Sff8472Api(XcvrApi):
     def get_transceiver_bulk_status(self):
         rx_los = self.get_rx_los()
         tx_fault = self.get_tx_fault()
-        tx_disable = self.get_tx_disable()
-        tx_disabled_channel = self.get_tx_disable_channel()
         temp = self.get_module_temperature()
         voltage = self.get_voltage()
         tx_bias = self.get_tx_bias()
@@ -72,8 +70,6 @@ class Sff8472Api(XcvrApi):
         tx_power = self.get_tx_power()
         read_failed = rx_los is None or \
                       tx_fault is None or \
-                      tx_disable is None or \
-                      tx_disabled_channel is None or \
                       temp is None or \
                       voltage is None or \
                       tx_bias is None or \
@@ -85,8 +81,6 @@ class Sff8472Api(XcvrApi):
         bulk_status = {
             "rx_los": all(rx_los) if self.get_rx_los_support() else 'N/A',
             "tx_fault": all(tx_fault) if self.get_tx_fault_support() else 'N/A',
-            "tx_disable": all(tx_disable),
-            "tx_disabled_channel": tx_disabled_channel,
             "temperature": temp,
             "voltage": voltage
         }

--- a/sonic_platform_base/sonic_xcvr/api/public/sff8472.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/sff8472.py
@@ -60,17 +60,34 @@ class Sff8472Api(XcvrApi):
 
         return xcvr_info
 
-    def get_transceiver_bulk_status(self):
+    def get_transceiver_status(self):
         rx_los = self.get_rx_los()
         tx_fault = self.get_tx_fault()
+        tx_disable = self.get_tx_disable()
+        tx_disabled_channel = self.get_tx_disable_channel()
+        read_failed = rx_los is None or \
+                      tx_fault is None or \
+                      tx_disable is None or \
+                      tx_disabled_channel is None
+        if read_failed:
+            return None
+
+        trans_status = {
+            "rx_los": all(rx_los) if self.get_rx_los_support() else 'N/A',
+            "tx_fault": all(tx_fault) if self.get_tx_fault_support() else 'N/A',
+            "tx_disable": all(tx_disable),
+            "tx_disabled_channel": tx_disabled_channel
+        }
+
+        return trans_status
+
+    def get_transceiver_bulk_status(self):
         temp = self.get_module_temperature()
         voltage = self.get_voltage()
         tx_bias = self.get_tx_bias()
         rx_power = self.get_rx_power()
         tx_power = self.get_tx_power()
-        read_failed = rx_los is None or \
-                      tx_fault is None or \
-                      temp is None or \
+        read_failed = temp is None or \
                       voltage is None or \
                       tx_bias is None or \
                       rx_power is None or \
@@ -79,8 +96,6 @@ class Sff8472Api(XcvrApi):
             return None
 
         bulk_status = {
-            "rx_los": all(rx_los) if self.get_rx_los_support() else 'N/A',
-            "tx_fault": all(tx_fault) if self.get_tx_fault_support() else 'N/A',
             "temperature": temp,
             "voltage": voltage
         }

--- a/sonic_platform_base/sonic_xcvr/api/public/sff8636.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/sff8636.py
@@ -87,12 +87,14 @@ class Sff8636Api(XcvrApi):
         if read_failed:
             return None
 
-        trans_status = {
-            "rx_los": all(rx_los) if self.get_rx_los_support() else 'N/A',
-            "tx_fault": all(tx_fault) if self.get_tx_fault_support() else 'N/A',
-            "tx_disable": all(tx_disable),
-            "tx_disabled_channel": tx_disabled_channel
-        }
+        trans_status = dict()
+        for lane in range(1, len(rx_los) + 1):
+            trans_status['rxlos%d' % lane] = rx_los[lane - 1]
+        for lane in range(1, len(tx_fault) + 1):
+            trans_status['txfault%d' % lane] = tx_fault[lane - 1]
+        for lane in range(1, len(tx_disable) + 1):
+            trans_status['tx%ddisable' % lane] = tx_disable[lane - 1]
+        trans_status['tx_disabled_channel'] = tx_disabled_channel
 
         return trans_status
 

--- a/sonic_platform_base/sonic_xcvr/api/public/sff8636.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/sff8636.py
@@ -75,17 +75,34 @@ class Sff8636Api(XcvrApi):
 
         return xcvr_info
 
-    def get_transceiver_bulk_status(self):
+    def get_transceiver_status(self):
         rx_los = self.get_rx_los()
         tx_fault = self.get_tx_fault()
+        tx_disable = self.get_tx_disable()
+        tx_disabled_channel = self.get_tx_disable_channel()
+        read_failed = rx_los is None or \
+                      tx_fault is None or \
+                      tx_disable is None or \
+                      tx_disabled_channel is None
+        if read_failed:
+            return None
+
+        trans_status = {
+            "rx_los": all(rx_los) if self.get_rx_los_support() else 'N/A',
+            "tx_fault": all(tx_fault) if self.get_tx_fault_support() else 'N/A',
+            "tx_disable": all(tx_disable),
+            "tx_disabled_channel": tx_disabled_channel
+        }
+
+        return trans_status
+
+    def get_transceiver_bulk_status(self):
         temp = self.get_module_temperature()
         voltage = self.get_voltage()
         tx_bias = self.get_tx_bias()
         rx_power = self.get_rx_power()
         tx_power = self.get_tx_power()
-        read_failed = rx_los is None or \
-                      tx_fault is None or \
-                      temp is None or \
+        read_failed = temp is None or \
                       voltage is None or \
                       tx_bias is None or \
                       rx_power is None or \
@@ -94,8 +111,6 @@ class Sff8636Api(XcvrApi):
             return None
 
         bulk_status = {
-            "rx_los": all(rx_los) if self.get_rx_los_support() else 'N/A',
-            "tx_fault": all(tx_fault) if self.get_tx_fault_support() else 'N/A',
             "temperature": temp,
             "voltage": voltage
         }

--- a/sonic_platform_base/sonic_xcvr/api/public/sff8636.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/sff8636.py
@@ -78,8 +78,6 @@ class Sff8636Api(XcvrApi):
     def get_transceiver_bulk_status(self):
         rx_los = self.get_rx_los()
         tx_fault = self.get_tx_fault()
-        tx_disable = self.get_tx_disable()
-        tx_disabled_channel = self.get_tx_disable_channel()
         temp = self.get_module_temperature()
         voltage = self.get_voltage()
         tx_bias = self.get_tx_bias()
@@ -87,8 +85,6 @@ class Sff8636Api(XcvrApi):
         tx_power = self.get_tx_power()
         read_failed = rx_los is None or \
                       tx_fault is None or \
-                      tx_disable is None or \
-                      tx_disabled_channel is None or \
                       temp is None or \
                       voltage is None or \
                       tx_bias is None or \
@@ -100,8 +96,6 @@ class Sff8636Api(XcvrApi):
         bulk_status = {
             "rx_los": all(rx_los) if self.get_rx_los_support() else 'N/A',
             "tx_fault": all(tx_fault) if self.get_tx_fault_support() else 'N/A',
-            "tx_disable": all(tx_disable),
-            "tx_disabled_channel": tx_disabled_channel,
             "temperature": temp,
             "voltage": voltage
         }

--- a/sonic_platform_base/sonic_xcvr/api/xcvr_api.py
+++ b/sonic_platform_base/sonic_xcvr/api/xcvr_api.py
@@ -81,9 +81,6 @@ class XcvrApi(object):
         ---------------------------|---------------|----------------------------
         rx_los                     |bool           |RX loss-of-signal status, True if has RX los, False if not.
         tx_fault                   |bool           |TX fault status, True if has TX fault, False if not.
-        tx_disable                 |bool           |TX disable status, True TX disabled, False if not.
-        tx_disabled_channel        |int            |disabled TX channels in hex, bits 0 to 3 represent channel 0
-                                   |               |to channel 3 (for example).
         temperature                |float          |module temperature in Celsius
         voltage                    |float          |supply voltage in mV
         tx<n>bias                  |float          |TX Bias Current in mA, n is the channel number,

--- a/sonic_platform_base/sonic_xcvr/api/xcvr_api.py
+++ b/sonic_platform_base/sonic_xcvr/api/xcvr_api.py
@@ -79,8 +79,6 @@ class XcvrApi(object):
         ========================================================================
         keys                       |Value Format   |Information
         ---------------------------|---------------|----------------------------
-        rx_los                     |bool           |RX loss-of-signal status, True if has RX los, False if not.
-        tx_fault                   |bool           |TX fault status, True if has TX fault, False if not.
         temperature                |float          |module temperature in Celsius
         voltage                    |float          |supply voltage in mV
         tx<n>bias                  |float          |TX Bias Current in mA, n is the channel number,
@@ -132,7 +130,7 @@ class XcvrApi(object):
 
     def get_transceiver_status(self):
         """
-        Retrieves transceiver status of this SFP (applicable for CMIS/C-CMIS)
+        Retrieves transceiver status of this SFP
 
         Returns:
             A dict which may contain following keys/values (there could be more for C-CMIS) :

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -1268,10 +1268,6 @@ class TestCmis(object):
     @pytest.mark.parametrize("mock_response, expected",[
         (
             [
-                [False, False, False, False, False, False, False, False],
-                [False, False, False, False, False, False, False, False],
-                [False, False, False, False, False, False, False, False],
-                0,
                 50,
                 3.3,
                 [70, 70, 70, 70, 70, 70, 70, 70],
@@ -1296,11 +1292,6 @@ class TestCmis(object):
                 'rx5power': -10.0, 'rx6power': -10.0, 'rx7power': -10.0, 'rx8power': -10.0,
                 'tx1bias': 70, 'tx2bias': 70, 'tx3bias': 70, 'tx4bias': 70,
                 'tx5bias': 70, 'tx6bias': 70, 'tx7bias': 70, 'tx8bias': 70,
-                'rx_los': False,
-                'tx_fault': False,
-                'tx1disable': False, 'tx2disable': False, 'tx3disable': False, 'tx4disable': False,
-                'tx5disable': False, 'tx6disable': False, 'tx7disable': False, 'tx8disable': False,
-                'tx_disabled_channel': 0,
                 'laser_temperature': 40,
                 'prefec_ber': 0.001,
                 'postfec_ber_min': 0,
@@ -1311,10 +1302,6 @@ class TestCmis(object):
         ),
         (
             [
-                ['N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A'],
-                ['N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A'],
-                ['N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A'],
-                'N/A',
                 50, 3.3,
                 ['N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A'],
                 None,
@@ -1327,10 +1314,6 @@ class TestCmis(object):
         ),
         (
             [
-                ['N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A'],
-                ['N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A'],
-                ['N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A'],
-                'N/A',
                 50, 3.3,
                 ['N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A'],
                 ['N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A'],
@@ -1348,50 +1331,37 @@ class TestCmis(object):
                 'rx5power': 'N/A', 'rx6power': 'N/A', 'rx7power': 'N/A', 'rx8power': 'N/A',
                 'tx1bias': 'N/A', 'tx2bias': 'N/A', 'tx3bias': 'N/A', 'tx4bias': 'N/A',
                 'tx5bias': 'N/A', 'tx6bias': 'N/A', 'tx7bias': 'N/A', 'tx8bias': 'N/A',
-                'rx_los': 'N/A',
-                'tx_fault': 'N/A',
-                'tx1disable': 'N/A', 'tx2disable': 'N/A', 'tx3disable': 'N/A', 'tx4disable': 'N/A',
-                'tx5disable': 'N/A', 'tx6disable': 'N/A', 'tx7disable': 'N/A', 'tx8disable': 'N/A',
-                'tx_disabled_channel': 'N/A',
                 'laser_temperature': 40
             }
         )
     ])
     def test_get_transceiver_bulk_status(self, mock_response, expected):
-        self.api.get_rx_los = MagicMock()
-        self.api.get_rx_los.return_value = mock_response[0]
-        self.api.get_tx_fault = MagicMock()
-        self.api.get_tx_fault.return_value = mock_response[1]
-        self.api.get_tx_disable = MagicMock()
-        self.api.get_tx_disable.return_value = mock_response[2]
-        self.api.get_tx_disable_channel = MagicMock()
-        self.api.get_tx_disable_channel.return_value = mock_response[3]
         self.api.get_module_temperature = MagicMock()
-        self.api.get_module_temperature.return_value = mock_response[4]
+        self.api.get_module_temperature.return_value = mock_response[0]
         self.api.get_voltage = MagicMock()
-        self.api.get_voltage.return_value = mock_response[5]
+        self.api.get_voltage.return_value = mock_response[1]
         self.api.get_tx_bias = MagicMock()
-        self.api.get_tx_bias.return_value = mock_response[6]
+        self.api.get_tx_bias.return_value = mock_response[2]
         self.api.get_rx_power = MagicMock()
-        self.api.get_rx_power.return_value = mock_response[7]
+        self.api.get_rx_power.return_value = mock_response[3]
         self.api.get_tx_power = MagicMock()
-        self.api.get_tx_power.return_value = mock_response[8]
+        self.api.get_tx_power.return_value = mock_response[4]
         self.api.get_rx_los_support = MagicMock()
-        self.api.get_rx_los_support.return_value = mock_response[9]
+        self.api.get_rx_los_support.return_value = mock_response[5]
         self.api.get_tx_fault_support = MagicMock()
-        self.api.get_tx_fault_support.return_value = mock_response[10]
+        self.api.get_tx_fault_support.return_value = mock_response[6]
         self.api.get_tx_disable_support = MagicMock()
-        self.api.get_tx_disable_support.return_value = mock_response[11]
+        self.api.get_tx_disable_support.return_value = mock_response[7]
         self.api.get_tx_bias_support = MagicMock()
-        self.api.get_tx_bias_support.return_value = mock_response[12]
+        self.api.get_tx_bias_support.return_value = mock_response[8]
         self.api.get_tx_power_support = MagicMock()
-        self.api.get_tx_power_support.return_value = mock_response[13]
+        self.api.get_tx_power_support.return_value = mock_response[9]
         self.api.get_rx_power_support = MagicMock()
-        self.api.get_rx_power_support.return_value = mock_response[14]
+        self.api.get_rx_power_support.return_value = mock_response[10]
         self.api.get_laser_temperature = MagicMock()
-        self.api.get_laser_temperature.return_value = mock_response[15]
+        self.api.get_laser_temperature.return_value = mock_response[11]
         self.api.get_vdm = MagicMock()
-        self.api.get_vdm.return_value = mock_response[16]
+        self.api.get_vdm.return_value = mock_response[12]
         result = self.api.get_transceiver_bulk_status()
         assert result == expected
 

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -1601,7 +1601,8 @@ class TestCmis(object):
                 {
                     'Pre-FEC BER Average Media Input':{1:[0.001, 0.0125, 0, 0.01, 0, False, False, False, False]},
                     'Errored Frames Average Media Input':{1:[0, 1, 0, 1, 0, False, False, False, False]},
-                }
+                },
+                True, 0, [False, False, False, False, False, False, False, False]
             ],
             {
                 'module_state': 'ModuleReady',
@@ -1633,6 +1634,15 @@ class TestCmis(object):
                 'rxoutput_status_hostlane6': True,
                 'rxoutput_status_hostlane7': True,
                 'rxoutput_status_hostlane8': True,
+                "tx_disabled_channel": 0,
+                "tx1disable": False,
+                "tx2disable": False,
+                "tx3disable": False,
+                "tx4disable": False,
+                "tx5disable": False,
+                "tx6disable": False,
+                "tx7disable": False,
+                "tx8disable": False,
                 'txfault1': False,
                 'txfault2': False,
                 'txfault3': False,
@@ -1835,7 +1845,8 @@ class TestCmis(object):
                 {
                     'Pre-FEC BER Average Media Input':{1:[0.001, 0.0125, 0, 0.01, 0, False, False, False, False]},
                     'Errored Frames Average Media Input':{1:[0, 1, 0, 1, 0, False, False, False, False]},
-                }
+                },
+                False, 0, [False, False, False, False, False, False, False, False]
             ],
             {
                 'module_state': 'ModuleReady',
@@ -1894,6 +1905,12 @@ class TestCmis(object):
         self.api.get_tx_bias_flag.return_value = mock_response[18]
         self.api.get_vdm = MagicMock()
         self.api.get_vdm.return_value = mock_response[19]
+        self.api.get_tx_disable_support = MagicMock()
+        self.api.get_tx_disable_support.return_value = mock_response[20]
+        self.api.get_tx_disable_channel = MagicMock()
+        self.api.get_tx_disable_channel.return_value = mock_response[21]
+        self.api.get_tx_disable = MagicMock()
+        self.api.get_tx_disable.return_value = mock_response[22]
         result = self.api.get_transceiver_status()
         assert result == expected
 

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -1572,7 +1572,7 @@ class TestCmis(object):
                     'Pre-FEC BER Average Media Input':{1:[0.001, 0.0125, 0, 0.01, 0, False, False, False, False]},
                     'Errored Frames Average Media Input':{1:[0, 1, 0, 1, 0, False, False, False, False]},
                 },
-                True, 0, [False, False, False, False, False, False, False, False]
+                0, [False, False, False, False, False, False, False, False]
             ],
             {
                 'module_state': 'ModuleReady',
@@ -1816,7 +1816,7 @@ class TestCmis(object):
                     'Pre-FEC BER Average Media Input':{1:[0.001, 0.0125, 0, 0.01, 0, False, False, False, False]},
                     'Errored Frames Average Media Input':{1:[0, 1, 0, 1, 0, False, False, False, False]},
                 },
-                False, 0, [False, False, False, False, False, False, False, False]
+                None, None
             ],
             {
                 'module_state': 'ModuleReady',
@@ -1875,12 +1875,10 @@ class TestCmis(object):
         self.api.get_tx_bias_flag.return_value = mock_response[18]
         self.api.get_vdm = MagicMock()
         self.api.get_vdm.return_value = mock_response[19]
-        self.api.get_tx_disable_support = MagicMock()
-        self.api.get_tx_disable_support.return_value = mock_response[20]
         self.api.get_tx_disable_channel = MagicMock()
-        self.api.get_tx_disable_channel.return_value = mock_response[21]
+        self.api.get_tx_disable_channel.return_value = mock_response[20]
         self.api.get_tx_disable = MagicMock()
-        self.api.get_tx_disable.return_value = mock_response[22]
+        self.api.get_tx_disable.return_value = mock_response[21]
         result = self.api.get_transceiver_status()
         assert result == expected
 

--- a/tests/sonic_xcvr/test_sff8436.py
+++ b/tests/sonic_xcvr/test_sff8436.py
@@ -27,6 +27,7 @@ class TestSff8436(object):
         self.api.get_transceiver_info()
         self.api.get_transceiver_bulk_status()
         self.api.get_transceiver_threshold_info()
+        self.api.get_transceiver_status()
         self.api.get_rx_los()
         self.api.get_tx_fault()
         self.api.get_tx_disable()

--- a/tests/sonic_xcvr/test_sff8436.py
+++ b/tests/sonic_xcvr/test_sff8436.py
@@ -156,3 +156,48 @@ class TestSff8436(object):
         self.api.get_power_override_support.return_value = False
         assert not self.api.set_lpmode(True)
 
+    @pytest.mark.parametrize("mock_response, expected",[
+        (
+            [
+                [False, False, False, False],
+                [False, False, False, False],
+                0,
+                [False, False, False, False]
+            ],
+            {
+                "tx_disabled_channel": 0,
+                "tx1disable": False,
+                "tx2disable": False,
+                "tx3disable": False,
+                "tx4disable": False,
+                'txfault1': False,
+                'txfault2': False,
+                'txfault3': False,
+                'txfault4': False,
+                'rxlos1': False,
+                'rxlos2': False,
+                'rxlos3': False,
+                'rxlos4': False,
+            }
+        ),
+        (
+            [
+                None,
+                None,
+                None,
+                None
+            ],
+            None
+        )
+    ])
+    def test_get_transceiver_status(self, mock_response, expected):
+        self.api.get_rx_los = MagicMock()
+        self.api.get_rx_los.return_value = mock_response[0]
+        self.api.get_tx_fault = MagicMock()
+        self.api.get_tx_fault.return_value = mock_response[1]
+        self.api.get_tx_disable_channel = MagicMock()
+        self.api.get_tx_disable_channel.return_value = mock_response[2]
+        self.api.get_tx_disable = MagicMock()
+        self.api.get_tx_disable.return_value = mock_response[3]
+        result = self.api.get_transceiver_status()
+        assert result == expected

--- a/tests/sonic_xcvr/test_sff8472.py
+++ b/tests/sonic_xcvr/test_sff8472.py
@@ -206,3 +206,40 @@ class TestSff8472(object):
             except:
                 assert 0, traceback.format_exc()
             run_num -= 1
+
+    @pytest.mark.parametrize("mock_response, expected",[
+        (
+            [
+                [False],
+                [False],
+                0,
+                [False]
+            ],
+            {
+                "tx_disabled_channel": 0,
+                "tx1disable": False,
+                'txfault1': False,
+                'rxlos1': False,
+            }
+        ),
+        (
+            [
+                None,
+                None,
+                None,
+                None
+            ],
+            None
+        )
+    ])
+    def test_get_transceiver_status(self, mock_response, expected):
+        self.api.get_rx_los = MagicMock()
+        self.api.get_rx_los.return_value = mock_response[0]
+        self.api.get_tx_fault = MagicMock()
+        self.api.get_tx_fault.return_value = mock_response[1]
+        self.api.get_tx_disable_channel = MagicMock()
+        self.api.get_tx_disable_channel.return_value = mock_response[2]
+        self.api.get_tx_disable = MagicMock()
+        self.api.get_tx_disable.return_value = mock_response[3]
+        result = self.api.get_transceiver_status()
+        assert result == expected

--- a/tests/sonic_xcvr/test_sff8472.py
+++ b/tests/sonic_xcvr/test_sff8472.py
@@ -29,6 +29,7 @@ class TestSff8472(object):
         self.api.get_transceiver_info()
         self.api.get_transceiver_bulk_status()
         self.api.get_transceiver_threshold_info()
+        self.api.get_transceiver_status()
         self.api.get_rx_los()
         self.api.get_tx_fault()
         self.api.get_tx_disable()

--- a/tests/sonic_xcvr/test_sff8636.py
+++ b/tests/sonic_xcvr/test_sff8636.py
@@ -155,3 +155,49 @@ class TestSff8636(object):
         self.api.get_lpmode_support.return_value = False
         self.api.get_power_override_support.return_value = False
         assert not self.api.set_lpmode(True)
+
+    @pytest.mark.parametrize("mock_response, expected",[
+        (
+            [
+                [False, False, False, False],
+                [False, False, False, False],
+                0,
+                [False, False, False, False]
+            ],
+            {
+                "tx_disabled_channel": 0,
+                "tx1disable": False,
+                "tx2disable": False,
+                "tx3disable": False,
+                "tx4disable": False,
+                'txfault1': False,
+                'txfault2': False,
+                'txfault3': False,
+                'txfault4': False,
+                'rxlos1': False,
+                'rxlos2': False,
+                'rxlos3': False,
+                'rxlos4': False,
+            }
+        ),
+        (
+            [
+                None,
+                None,
+                None,
+                None
+            ],
+            None
+        )
+    ])
+    def test_get_transceiver_status(self, mock_response, expected):
+        self.api.get_rx_los = MagicMock()
+        self.api.get_rx_los.return_value = mock_response[0]
+        self.api.get_tx_fault = MagicMock()
+        self.api.get_tx_fault.return_value = mock_response[1]
+        self.api.get_tx_disable_channel = MagicMock()
+        self.api.get_tx_disable_channel.return_value = mock_response[2]
+        self.api.get_tx_disable = MagicMock()
+        self.api.get_tx_disable.return_value = mock_response[3]
+        result = self.api.get_transceiver_status()
+        assert result == expected

--- a/tests/sonic_xcvr/test_sff8636.py
+++ b/tests/sonic_xcvr/test_sff8636.py
@@ -26,6 +26,7 @@ class TestSff8636(object):
         self.api.get_transceiver_info()
         self.api.get_transceiver_bulk_status()
         self.api.get_transceiver_threshold_info()
+        self.api.get_transceiver_status()
         self.api.get_rx_los()
         self.api.get_tx_fault()
         self.api.get_tx_disable()


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
Move tx_disable/tx_disabled_channel from get_transceiver_status API (which serves DOM_SENSOR table) to get_transceiver_status API (which serves STATUS table)
Also, add get_transceiver_status API for non-CMIS optics for the following fields: rx_los tx_fault tx_disable tx_disabled_channel

> **Note**
> Separate PR in SONiC repo will take care of the table schema change. https://github.com/sonic-net/SONiC/pull/1316

#### Motivation and Context
According to updated [schema of STATUS table in HLD](https://github.com/sonic-net/SONiC/blob/master/doc/platform_api/CMIS_and_C-CMIS_support_for_ZR.md#214-transceiver-status-table), tx_disable/tx_disabled_channel should belong to STATUS table instead of DOM_SENSOR table.

#### How Has This Been Tested?
Verified on 400G optics, tx_disable/tx_disabled_channel are in the output of new status API, and in the DB as well.

```
>>> api35
<sonic_platform_base.sonic_xcvr.api.public.sff8636.Sff8636Api object at 0x7f4d97b67190>
>>> api35.get_transceiver_status()
{'rxlos1': False, 'rxlos2': False, 'rxlos3': False, 'rxlos4': False, 'txfault1': False, 'txfault2': False, 'txfault3': False, 'txfault4': False, 'tx1disable': False, 'tx2disable': False, 'tx3disable': False, 'tx4disable': False, 'tx_disabled_channel': 0}


>>> api34
<sonic_platform_base.sonic_xcvr.api.public.c_cmis.CCmisApi object at 0x7fe52cd11e50>
>>> api34.get_transceiver_status()
{'module_state': 'ModuleReady', 'module_fault_cause': 'No Fault detected', 'datapath_firmware_fault': False, 'module_firmware_fault': False, 'module_state_changed': True, 'temphighalarm_flag': False, 'templowalarm_flag': False, 'temphighwarning_flag': False, 'templowwarning_flag': False, 'vcchighalarm_flag': False, 'vcclowalarm_flag': False, 'vcchighwarning_flag': False, 'vcclowwarning_flag': False, 'lasertemphighalarm_flag': False, 'lasertemplowalarm_flag': False, 'lasertemphighwarning_flag': False, 'lasertemplowwarning_flag': False, 'DP1State': 'DataPathActivated', 'DP2State': 'DataPathActivated', 'DP3State': 'DataPathActivated', 'DP4State': 'DataPathActivated', 'DP5State': 'DataPathActivated', 'DP6State': 'DataPathActivated', 'DP7State': 'DataPathActivated', 'DP8State': 'DataPathActivated', 'txoutput_status1': False, 'txoutput_status2': False, 'txoutput_status3': False, 'txoutput_status4': False, 'txoutput_status5': False, 'txoutput_status6': False, 'txoutput_status7': False, 'txoutput_status8': False, 'rxoutput_status_hostlane1': True, 'rxoutput_status_hostlane2': True, 'rxoutput_status_hostlane3': True, 'rxoutput_status_hostlane4': True, 'rxoutput_status_hostlane5': True, 'rxoutput_status_hostlane6': True, 'rxoutput_status_hostlane7': True, 'rxoutput_status_hostlane8': True, 'tx_disabled_channel': 0, 'tx1disable': False, 'tx2disable': False, 'tx3disable': False, 'tx4disable': False, 'tx5disable': False, 'tx6disable': False, 'tx7disable': False, 'tx8disable': False, 'txfault1': False, 'txfault2': False, 'txfault3': False, 'txfault4': False, 'txfault5': False, 'txfault6': False, 'txfault7': False, 'txfault8': False, 'txlos_hostlane1': False, 'txlos_hostlane2': False, 'txlos_hostlane3': False, 'txlos_hostlane4': False, 'txlos_hostlane5': False, 'txlos_hostlane6': False, 'txlos_hostlane7': False, 'txlos_hostlane8': False, 'txcdrlol_hostlane1': False, 'txcdrlol_hostlane2': False, 'txcdrlol_hostlane3': False, 'txcdrlol_hostlane4': False, 'txcdrlol_hostlane5': False, 'txcdrlol_hostlane6': False, 'txcdrlol_hostlane7': False, 'txcdrlol_hostlane8': False, 'rxlos1': False, 'rxlos2': False, 'rxlos3': False, 'rxlos4': False, 'rxlos5': False, 'rxlos6': False, 'rxlos7': False, 'rxlos8': False, 'rxcdrlol1': False, 'rxcdrlol2': False, 'rxcdrlol3': False, 'rxcdrlol4': False, 'rxcdrlol5': False, 'rxcdrlol6': False, 'rxcdrlol7': False, 'rxcdrlol8': False, 'config_state_hostlane1': 'ConfigSuccess', 'config_state_hostlane2': 'ConfigSuccess', 'config_state_hostlane3': 'ConfigSuccess', 'config_state_hostlane4': 'ConfigSuccess', 'config_state_hostlane5': 'ConfigSuccess', 'config_state_hostlane6': 'ConfigSuccess', 'config_state_hostlane7': 'ConfigSuccess', 'config_state_hostlane8': 'ConfigSuccess', 'dpinit_pending_hostlane1': False, 'dpinit_pending_hostlane2': False, 'dpinit_pending_hostlane3': False, 'dpinit_pending_hostlane4': False, 'dpinit_pending_hostlane5': False, 'dpinit_pending_hostlane6': False, 'dpinit_pending_hostlane7': False, 'dpinit_pending_hostlane8': False, 'txpowerhighalarm_flag1': False, 'txpowerlowalarm_flag1': False, 'txpowerhighwarning_flag1': False, 'txpowerlowwarning_flag1': False, 'txpowerhighalarm_flag2': False, 'txpowerlowalarm_flag2': False, 'txpowerhighwarning_flag2': False, 'txpowerlowwarning_flag2': False, 'txpowerhighalarm_flag3': False, 'txpowerlowalarm_flag3': False, 'txpowerhighwarning_flag3': False, 'txpowerlowwarning_flag3': False, 'txpowerhighalarm_flag4': False, 'txpowerlowalarm_flag4': False, 'txpowerhighwarning_flag4': False, 'txpowerlowwarning_flag4': False, 'txpowerhighalarm_flag5': False, 'txpowerlowalarm_flag5': False, 'txpowerhighwarning_flag5': False, 'txpowerlowwarning_flag5': False, 'txpowerhighalarm_flag6': False, 'txpowerlowalarm_flag6': False, 'txpowerhighwarning_flag6': False, 'txpowerlowwarning_flag6': False, 'txpowerhighalarm_flag7': False, 'txpowerlowalarm_flag7': False, 'txpowerhighwarning_flag7': False, 'txpowerlowwarning_flag7': False, 'txpowerhighalarm_flag8': False, 'txpowerlowalarm_flag8': False, 'txpowerhighwarning_flag8': False, 'txpowerlowwarning_flag8': False, 'rxpowerhighalarm_flag1': False, 'rxpowerlowalarm_flag1': False, 'rxpowerhighwarning_flag1': False, 'rxpowerlowwarning_flag1': False, 'rxpowerhighalarm_flag2': False, 'rxpowerlowalarm_flag2': False, 'rxpowerhighwarning_flag2': False, 'rxpowerlowwarning_flag2': False, 'rxpowerhighalarm_flag3': False, 'rxpowerlowalarm_flag3': False, 'rxpowerhighwarning_flag3': False, 'rxpowerlowwarning_flag3': False, 'rxpowerhighalarm_flag4': False, 'rxpowerlowalarm_flag4': False, 'rxpowerhighwarning_flag4': False, 'rxpowerlowwarning_flag4': False, 'rxpowerhighalarm_flag5': False, 'rxpowerlowalarm_flag5': False, 'rxpowerhighwarning_flag5': False, 'rxpowerlowwarning_flag5': False, 'rxpowerhighalarm_flag6': False, 'rxpowerlowalarm_flag6': False, 'rxpowerhighwarning_flag6': False, 'rxpowerlowwarning_flag6': False, 'rxpowerhighalarm_flag7': False, 'rxpowerlowalarm_flag7': False, 'rxpowerhighwarning_flag7': False, 'rxpowerlowwarning_flag7': False, 'rxpowerhighalarm_flag8': False, 'rxpowerlowalarm_flag8': False, 'rxpowerhighwarning_flag8': False, 'rxpowerlowwarning_flag8': False, 'txbiashighalarm_flag1': False, 'txbiaslowalarm_flag1': False, 'txbiashighwarning_flag1': False, 'txbiaslowwarning_flag1': False, 'txbiashighalarm_flag2': False, 'txbiaslowalarm_flag2': False, 'txbiashighwarning_flag2': False, 'txbiaslowwarning_flag2': False, 'txbiashighalarm_flag3': False, 'txbiaslowalarm_flag3': False, 'txbiashighwarning_flag3': False, 'txbiaslowwarning_flag3': False, 'txbiashighalarm_flag4': False, 'txbiaslowalarm_flag4': False, 'txbiashighwarning_flag4': False, 'txbiaslowwarning_flag4': False, 'txbiashighalarm_flag5': False, 'txbiaslowalarm_flag5': False, 'txbiashighwarning_flag5': False, 'txbiaslowwarning_flag5': False, 'txbiashighalarm_flag6': False, 'txbiaslowalarm_flag6': False, 'txbiashighwarning_flag6': False, 'txbiaslowwarning_flag6': False, 'txbiashighalarm_flag7': False, 'txbiaslowalarm_flag7': False, 'txbiashighwarning_flag7': False, 'txbiaslowwarning_flag7': False, 'txbiashighalarm_flag8': False, 'txbiaslowalarm_flag8': False, 'txbiashighwarning_flag8': False, 'txbiaslowwarning_flag8': False, 'prefecberhighalarm_flag': False, 'prefecberlowalarm_flag': False, 'prefecberhighwarning_flag': False, 'prefecberlowwarning_flag': False, 'postfecberhighalarm_flag': False, 'postfecberlowalarm_flag': False, 'postfecberhighwarning_flag': False, 'postfecberlowwarning_flag': False, 'tuning_in_progress': False, 'wavelength_unlock_status': False, 'target_output_power_oor': False, 'fine_tuning_oor': False, 'tuning_not_accepted': False, 'invalid_channel_num': False, 'tuning_complete': False, 'biasxihighalarm_flag': False, 'biasxilowalarm_flag': False, 'biasxihighwarning_flag': False, 'biasxilowwarning_flag': False, 'biasxqhighalarm_flag': False, 'biasxqlowalarm_flag': False, 'biasxqhighwarning_flag': False, 'biasxqlowwarning_flag': False, 'biasxphighalarm_flag': False, 'biasxplowalarm_flag': False, 'biasxphighwarning_flag': False, 'biasxplowwarning_flag': False, 'biasyihighalarm_flag': False, 'biasyilowalarm_flag': False, 'biasyihighwarning_flag': False, 'biasyilowwarning_flag': False, 'biasyqhighalarm_flag': False, 'biasyqlowalarm_flag': False, 'biasyqhighwarning_flag': False, 'biasyqlowwarning_flag': False, 'biasyphighalarm_flag': False, 'biasyplowalarm_flag': False, 'biasyphighwarning_flag': False, 'biasyplowwarning_flag': False, 'cdshorthighalarm_flag': False, 'cdshortlowalarm_flag': False, 'cdshorthighwarning_flag': False, 'cdshortlowwarning_flag': False, 'cdlonghighalarm_flag': False, 'cdlonglowalarm_flag': False, 'cdlonghighwarning_flag': False, 'cdlonglowwarning_flag': False, 'dgdhighalarm_flag': False, 'dgdlowalarm_flag': False, 'dgdhighwarning_flag': False, 'dgdlowwarning_flag': False, 'pdlhighalarm_flag': False, 'pdllowalarm_flag': False, 'pdlhighwarning_flag': False, 'pdllowwarning_flag': False, 'osnrhighalarm_flag': False, 'osnrlowalarm_flag': False, 'osnrhighwarning_flag': False, 'osnrlowwarning_flag': False, 'esnrhighalarm_flag': False, 'esnrlowalarm_flag': False, 'esnrhighwarning_flag': False, 'esnrlowwarning_flag': False, 'cfohighalarm_flag': False, 'cfolowalarm_flag': False, 'cfohighwarning_flag': False, 'cfolowwarning_flag': False, 'txcurrpowerhighalarm_flag': False, 'txcurrpowerlowalarm_flag': False, 'txcurrpowerhighwarning_flag': False, 'txcurrpowerlowwarning_flag': False, 'rxtotpowerhighalarm_flag': False, 'rxtotpowerlowalarm_flag': False, 'rxtotpowerhighwarning_flag': False, 'rxtotpowerlowwarning_flag': False}

>>> api0
<sonic_platform_base.sonic_xcvr.api.public.cmis.CmisApi object at 0x7fe52cdc20d0>
>>> api0.get_transceiver_status()
{'module_state': 'ModuleReady', 'module_fault_cause': 'No Fault detected', 'datapath_firmware_fault': False, 'module_firmware_fault': False, 'module_state_changed': False, 'temphighalarm_flag': False, 'templowalarm_flag': False, 'temphighwarning_flag': False, 'templowwarning_flag': False, 'vcchighalarm_flag': False, 'vcclowalarm_flag': False, 'vcchighwarning_flag': False, 'vcclowwarning_flag': False, 'lasertemphighalarm_flag': False, 'lasertemplowalarm_flag': False, 'lasertemphighwarning_flag': False, 'lasertemplowwarning_flag': False, 'DP1State': 'DataPathActivated', 'DP2State': 'DataPathActivated', 'DP3State': 'DataPathActivated', 'DP4State': 'DataPathActivated', 'DP5State': 'DataPathActivated', 'DP6State': 'DataPathActivated', 'DP7State': 'DataPathActivated', 'DP8State': 'DataPathActivated', 'txoutput_status1': False, 'txoutput_status2': False, 'txoutput_status3': False, 'txoutput_status4': False, 'txoutput_status5': False, 'txoutput_status6': False, 'txoutput_status7': False, 'txoutput_status8': False, 'rxoutput_status_hostlane1': False, 'rxoutput_status_hostlane2': False, 'rxoutput_status_hostlane3': False, 'rxoutput_status_hostlane4': False, 'rxoutput_status_hostlane5': False, 'rxoutput_status_hostlane6': False, 'rxoutput_status_hostlane7': False, 'rxoutput_status_hostlane8': False, 'tx_disabled_channel': 0, 'tx1disable': False, 'tx2disable': False, 'tx3disable': False, 'tx4disable': False, 'tx5disable': False, 'tx6disable': False, 'tx7disable': False, 'tx8disable': False, 'txfault1': False, 'txfault2': False, 'txfault3': False, 'txfault4': False, 'txfault5': False, 'txfault6': False, 'txfault7': False, 'txfault8': False, 'txlos_hostlane1': False, 'txlos_hostlane2': False, 'txlos_hostlane3': False, 'txlos_hostlane4': False, 'txlos_hostlane5': False, 'txlos_hostlane6': False, 'txlos_hostlane7': False, 'txlos_hostlane8': False, 'txcdrlol_hostlane1': False, 'txcdrlol_hostlane2': False, 'txcdrlol_hostlane3': False, 'txcdrlol_hostlane4': False, 'txcdrlol_hostlane5': False, 'txcdrlol_hostlane6': False, 'txcdrlol_hostlane7': False, 'txcdrlol_hostlane8': False, 'rxlos1': False, 'rxlos2': False, 'rxlos3': False, 'rxlos4': False, 'rxlos5': False, 'rxlos6': False, 'rxlos7': False, 'rxlos8': False, 'rxcdrlol1': False, 'rxcdrlol2': False, 'rxcdrlol3': False, 'rxcdrlol4': False, 'rxcdrlol5': False, 'rxcdrlol6': False, 'rxcdrlol7': False, 'rxcdrlol8': False, 'config_state_hostlane1': 'ConfigSuccess', 'config_state_hostlane2': 'ConfigSuccess', 'config_state_hostlane3': 'ConfigSuccess', 'config_state_hostlane4': 'ConfigSuccess', 'config_state_hostlane5': 'ConfigSuccess', 'config_state_hostlane6': 'ConfigSuccess', 'config_state_hostlane7': 'ConfigSuccess', 'config_state_hostlane8': 'ConfigSuccess', 'dpinit_pending_hostlane1': False, 'dpinit_pending_hostlane2': False, 'dpinit_pending_hostlane3': False, 'dpinit_pending_hostlane4': False, 'dpinit_pending_hostlane5': False, 'dpinit_pending_hostlane6': False, 'dpinit_pending_hostlane7': False, 'dpinit_pending_hostlane8': False, 'txpowerhighalarm_flag1': False, 'txpowerlowalarm_flag1': False, 'txpowerhighwarning_flag1': False, 'txpowerlowwarning_flag1': False, 'txpowerhighalarm_flag2': False, 'txpowerlowalarm_flag2': False, 'txpowerhighwarning_flag2': False, 'txpowerlowwarning_flag2': False, 'txpowerhighalarm_flag3': False, 'txpowerlowalarm_flag3': False, 'txpowerhighwarning_flag3': False, 'txpowerlowwarning_flag3': False, 'txpowerhighalarm_flag4': False, 'txpowerlowalarm_flag4': False, 'txpowerhighwarning_flag4': False, 'txpowerlowwarning_flag4': False, 'txpowerhighalarm_flag5': False, 'txpowerlowalarm_flag5': False, 'txpowerhighwarning_flag5': False, 'txpowerlowwarning_flag5': False, 'txpowerhighalarm_flag6': False, 'txpowerlowalarm_flag6': False, 'txpowerhighwarning_flag6': False, 'txpowerlowwarning_flag6': False, 'txpowerhighalarm_flag7': False, 'txpowerlowalarm_flag7': False, 'txpowerhighwarning_flag7': False, 'txpowerlowwarning_flag7': False, 'txpowerhighalarm_flag8': False, 'txpowerlowalarm_flag8': False, 'txpowerhighwarning_flag8': False, 'txpowerlowwarning_flag8': False, 'rxpowerhighalarm_flag1': False, 'rxpowerlowalarm_flag1': False, 'rxpowerhighwarning_flag1': False, 'rxpowerlowwarning_flag1': False, 'rxpowerhighalarm_flag2': False, 'rxpowerlowalarm_flag2': False, 'rxpowerhighwarning_flag2': False, 'rxpowerlowwarning_flag2': False, 'rxpowerhighalarm_flag3': False, 'rxpowerlowalarm_flag3': False, 'rxpowerhighwarning_flag3': False, 'rxpowerlowwarning_flag3': False, 'rxpowerhighalarm_flag4': False, 'rxpowerlowalarm_flag4': False, 'rxpowerhighwarning_flag4': False, 'rxpowerlowwarning_flag4': False, 'rxpowerhighalarm_flag5': False, 'rxpowerlowalarm_flag5': False, 'rxpowerhighwarning_flag5': False, 'rxpowerlowwarning_flag5': False, 'rxpowerhighalarm_flag6': False, 'rxpowerlowalarm_flag6': False, 'rxpowerhighwarning_flag6': False, 'rxpowerlowwarning_flag6': False, 'rxpowerhighalarm_flag7': False, 'rxpowerlowalarm_flag7': False, 'rxpowerhighwarning_flag7': False, 'rxpowerlowwarning_flag7': False, 'rxpowerhighalarm_flag8': False, 'rxpowerlowalarm_flag8': False, 'rxpowerhighwarning_flag8': False, 'rxpowerlowwarning_flag8': False, 'txbiashighalarm_flag1': False, 'txbiaslowalarm_flag1': False, 'txbiashighwarning_flag1': False, 'txbiaslowwarning_flag1': False, 'txbiashighalarm_flag2': False, 'txbiaslowalarm_flag2': False, 'txbiashighwarning_flag2': False, 'txbiaslowwarning_flag2': False, 'txbiashighalarm_flag3': False, 'txbiaslowalarm_flag3': False, 'txbiashighwarning_flag3': False, 'txbiaslowwarning_flag3': False, 'txbiashighalarm_flag4': False, 'txbiaslowalarm_flag4': False, 'txbiashighwarning_flag4': False, 'txbiaslowwarning_flag4': False, 'txbiashighalarm_flag5': False, 'txbiaslowalarm_flag5': False, 'txbiashighwarning_flag5': False, 'txbiaslowwarning_flag5': False, 'txbiashighalarm_flag6': False, 'txbiaslowalarm_flag6': False, 'txbiashighwarning_flag6': False, 'txbiaslowwarning_flag6': False, 'txbiashighalarm_flag7': False, 'txbiaslowalarm_flag7': False, 'txbiashighwarning_flag7': False, 'txbiaslowwarning_flag7': False, 'txbiashighalarm_flag8': False, 'txbiaslowalarm_flag8': False, 'txbiashighwarning_flag8': False, 'txbiaslowwarning_flag8': False}
```
#### Additional Information (Optional)

