### PR TITLE
Update host electrical interface for 2x400G breakout cable

### DIFF
--- a/sonic_platform_base/sonic_xcvr/codes/public/sff8024.py
+++ b/sonic_platform_base/sonic_xcvr/codes/public/sff8024.py
@@ -249,7 +249,9 @@ class Sff8024(XcvrCodes):
         63: 'FOIC4.16 (ITU-T G.709.1 G.Sup58)',
         64: 'FOIC4.8 (ITU-T G.709.1 G.Sup58)',
         65: 'CAUI-4 C2M (Annex 83E) without FEC',
-        66: 'CAUI-4 C2M (Annex 83E) with RS(528,514) FEC'
+        66: 'CAUI-4 C2M (Annex 83E) with RS(528,514) FEC',
+        79: '400GAUI-4-S C2M (Annex 120G)',
+        80: '400GAUI-4-L C2M (Annex 120G)'
     }
 
     NM_850_MEDIA_INTERFACE = {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
Update host electrical interface for 2x400G breakout cable

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
It seems that the host electrical interface for 2x400G breakout cable was not part of HOST_ELECTRICAL_INTERFACE. The corresponding change has now been made.
Snippet of the host electrical interface code from SFF-8024 spec, Rev 4.10 (Table 4-5)
![image](https://user-images.githubusercontent.com/112018033/232179098-05d3aec6-6ac6-4a64-ad61-9a54ce4a8f1d.png)
![image](https://user-images.githubusercontent.com/112018033/232179036-7f96145f-5301-435d-80d6-d06f32f7b545.png)

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Verified that 2x100G AOC is detected and CMIS init code is triggered

#### Additional Information (Optional)

