### PR TITLE
SFF-8472: Fix tx_disable_channel to avoid write to read-only bit

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/sff8472.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/sff8472.py
@@ -247,20 +247,7 @@ class Sff8472Api(XcvrApi):
         return self.xcvr_eeprom.write(consts.TX_DISABLE_SELECT_FIELD, tx_disable)
 
     def tx_disable_channel(self, channel, disable):
-        channel_state = self.get_tx_disable_channel()
-        if channel_state is None or channel_state == "N/A":
-            return False
-
-        for i in range(self.NUM_CHANNELS):
-            mask = (1 << i)
-            if not (channel & mask):
-                continue
-            if disable:
-                channel_state |= mask
-            else:
-                channel_state &= ~mask
-
-        return self.xcvr_eeprom.write(consts.TX_DISABLE_FIELD, channel_state)
+        return self.tx_disable(disable) if channel != 0 else True
 
     def is_flat_memory(self):
         return not self.xcvr_eeprom.read(consts.PAGING_SUPPORT_FIELD)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
It seems that currently, test_tx_disable_channel testcase in sonic-mgmt is failing for SFF-8472. The failure is seen because we are trying to write to a read-only bit.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
As part of calling tx_disable_channel for SFF-8472 based transceiver, we are writing to TX_DISABLE_FIELD (Page A2h, byte 110, bit 7). However, this is a read only bit based on the spec.
![image](https://user-images.githubusercontent.com/112018033/232687006-2b18e6c4-08ce-488d-945a-a7bf2fa893b3.png)

We are now calling tx_disable as part of calling tx_disable_channel.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
The test_tx_disable_channel has now been verified for SFF-8472 as well as QSFP-DD.

#### Additional Information (Optional)

