### PR TITLE
Adding host electrical interface ID for 800G and 100G

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -1967,7 +1967,7 @@ class CmisApi(XcvrApi):
                 break
             key = "{}_{}".format(prefix, app)
             val = dic.get(key)
-            if val in [None, 'Unknown', 'Undefined']:
+            if val in [None, 'Unknown']:
                 break
             buf['module_media_interface_id'] = val
 

--- a/sonic_platform_base/sonic_xcvr/codes/public/sff8024.py
+++ b/sonic_platform_base/sonic_xcvr/codes/public/sff8024.py
@@ -250,8 +250,12 @@ class Sff8024(XcvrCodes):
         64: 'FOIC4.8 (ITU-T G.709.1 G.Sup58)',
         65: 'CAUI-4 C2M (Annex 83E) without FEC',
         66: 'CAUI-4 C2M (Annex 83E) with RS(528,514) FEC',
+        75: '100GAUI-1-S C2M (Annex 120G)',
+        76: '100GAUI-1-L C2M (Annex 120G)',
         79: '400GAUI-4-S C2M (Annex 120G)',
-        80: '400GAUI-4-L C2M (Annex 120G)'
+        80: '400GAUI-4-L C2M (Annex 120G)',
+        81: '800G S C2M (placeholder)',
+        82: '800G L C2M (placeholder)'
     }
 
     NM_850_MEDIA_INTERFACE = {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
Adding host electrical interface ID for 800G and 100G

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
- Added host electrical interface ID for 800G and 100G.
- Also, allowing to populate application dict  if module_media_interface_id is undefined (value as 0) for an application. This is done to ensure applications after the application with module_media_interface_id as unknown can be evaluated by xcvrd to find the desired application.
 
#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Verified with a breakout optic to ensure that xcvrd finds the appropriate application

#### Additional Information (Optional)

