### PR TITLE
Modify sfputil show fwversion to display FW version using CMD 100h

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -1286,10 +1286,16 @@ class CmisApi(XcvrApi):
                 factory_image = '%d.%d.%d' % (rpl[74], rpl[75], ((rpl[76] << 8) | rpl[77]))
                 txt += 'Factory Image Version: %s\n' %factory_image
 
+            ActiveFirmware = 'N/A'
+            InactiveFirmware = 'N/A'
             if ImageARunning == 1:
                 RunningImage = 'A'
+                ActiveFirmware = ImageA
+                InactiveFirmware = ImageB
             elif ImageBRunning == 1:
                 RunningImage = 'B'
+                ActiveFirmware = ImageB
+                InactiveFirmware = ImageA
             else:
                 RunningImage = 'N/A'
             if ImageACommitted == 1:
@@ -1300,8 +1306,8 @@ class CmisApi(XcvrApi):
                 CommittedImage = 'N/A'
             txt += 'Running Image: %s\n' % (RunningImage)
             txt += 'Committed Image: %s\n' % (CommittedImage)
-            txt += 'Active Firmware: {}\n'.format(self.get_module_active_firmware())
-            txt += 'Inactive Firmware: {}\n'.format(self.get_module_inactive_firmware())
+            txt += 'Active Firmware: {}\n'.format(ActiveFirmware)
+            txt += 'Inactive Firmware: {}\n'.format(InactiveFirmware)
         else:
             txt += 'Reply payload check code error\n'
             return {'status': False, 'info': txt, 'result': None}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
We need to modify the o/p of "sfputil show fwversion <port>" to show the build version as part of the active and inactive firmware fields.

Snippet of the current o/p
root@sonic:/home/admin# sfputil show fwversion Ethernet144
Image A Version: a.b.c
Image B Version: d.e.f
Factory Image Version: 1.1.1
Running Image: A
Committed Image: A
Active Firmware: a.b
Inactive Firmware: d.e

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
We need to display the active and Inactive Firmware fields using CMD 100h to ensure that the build version is printed. The current way of directly reading from the EEPROM doesn't display build version for both the fields.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
The changes have been tested with CDB upgrade on 800G module, 400ZR and 2x100G AOC.

Snippet of new o/p
root@sonic:/home/admin# sfputil show fwversion Ethernet144
Image A Version: a.b.c
Image B Version: d.e.f
Factory Image Version: 1.1.1
Running Image: A
Committed Image: A
Active Firmware: a.b.c
Inactive Firmware: d.e.f

#### Additional Information (Optional)

