### PR TITLE
Render Media lane and Media assignment options info from Application Code

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -730,13 +730,18 @@ class CmisApi(XcvrApi):
         '''
         return self.xcvr_eeprom.read(consts.HOST_LANE_COUNT)
 
-    def get_media_lane_count(self):
+    def get_media_lane_count(self, appl=1):
         '''
         This function returns number of media lanes for default application
         '''
         if self.is_flat_memory():
             return 0
-        return self.xcvr_eeprom.read(consts.MEDIA_LANE_COUNT)
+        
+        if (appl <= 0):
+            return 0
+        
+        appl_advt = self.get_application_advertisement()
+        return appl_advt[appl]['media_lane_count'] if len(appl_advt) >= appl else 0
 
     def get_media_interface_technology(self):
         '''
@@ -757,13 +762,18 @@ class CmisApi(XcvrApi):
         appl_advt = self.get_application_advertisement()
         return appl_advt[appl]['host_lane_assignment_options'] if len(appl_advt) >= appl else 0
 
-    def get_media_lane_assignment_option(self):
+    def get_media_lane_assignment_option(self, appl=1):
         '''
         This function returns the media lane that the application is allowed to begin on
         '''
         if self.is_flat_memory():
             return 'N/A'
-        return self.xcvr_eeprom.read(consts.MEDIA_LANE_ASSIGNMENT_OPTION)
+        
+        if (appl <= 0):
+            return 0
+        
+        appl_advt = self.get_application_advertisement()
+        return appl_advt[appl]['media_lane_assignment_options'] if len(appl_advt) >= appl else 0
 
     def get_active_apsel_hostlane(self):
         '''

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -702,7 +702,7 @@ class TestCmis(object):
                 'module_media_interface_id': '400GBASE-DR4 (Cl 124)',
                 'media_lane_count': 4,
                 'host_lane_count': 8,
-                'host_lane_assignment_options': 1
+                'host_lane_assignment_options': 1,
                 'media_lane_assignment_options': 1
             },
             2: {
@@ -710,7 +710,7 @@ class TestCmis(object):
                 'module_media_interface_id': '100G-LR/100GBASE-LR1 (Cl 140)',
                 'media_lane_count': 1,
                 'host_lane_count': 2,
-                'host_lane_assignment_options': 85
+                'host_lane_assignment_options': 85,
                 'media_lane_assignment_options': 15
             }
         }

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -769,7 +769,7 @@ class TestCmis(object):
                 'module_media_interface_id': '400GBASE-DR4 (Cl 124)',
                 'media_lane_count': 4,
                 'host_lane_count': 8,
-                'host_lane_assignment_options': 1
+                'host_lane_assignment_options': 1,
                 'media_lane_assignment_options': 1
             },
             2: {
@@ -777,7 +777,7 @@ class TestCmis(object):
                 'module_media_interface_id': '100G-LR/100GBASE-LR1 (Cl 140)',
                 'media_lane_count': 1,
                 'host_lane_count': 2,
-                'host_lane_assignment_options': 85
+                'host_lane_assignment_options': 85,
                 'media_lane_assignment_options': 15
             }
         }

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -689,13 +689,34 @@ class TestCmis(object):
         result = self.api.get_host_lane_count()
         assert result == expected
 
-    @pytest.mark.parametrize("mock_response, expected", [
-        (1, 1)
+    @pytest.mark.parametrize("appl, expected", [
+        (0, 0),
+        (1, 4),
+        (2, 1)
+        (3, 0)
     ])
-    def test_get_media_lane_count(self, mock_response, expected):
-        self.api.xcvr_eeprom.read = MagicMock()
-        self.api.xcvr_eeprom.read.return_value = mock_response
-        result = self.api.get_media_lane_count()
+    @patch('sonic_platform_base.sonic_xcvr.api.public.cmis.CmisApi.get_application_advertisement', MagicMock(return_value =
+        {
+            1: {
+                'host_electrical_interface_id': '400GAUI-8 C2M (Annex 120E)',
+                'module_media_interface_id': '400GBASE-DR4 (Cl 124)',
+                'media_lane_count': 4,
+                'host_lane_count': 8,
+                'host_lane_assignment_options': 1
+                'media_lane_assignment_options': 1
+            },
+            2: {
+                'host_electrical_interface_id': '100GAUI-2 C2M (Annex 135G)',
+                'module_media_interface_id': '100G-LR/100GBASE-LR1 (Cl 140)',
+                'media_lane_count': 1,
+                'host_lane_count': 2,
+                'host_lane_assignment_options': 85
+                'media_lane_assignment_options': 15
+            }
+        }
+    ))
+    def test_get_media_lane_count(self, appl, expected):
+        result = self.api.get_media_lane_count(appl)
         assert result == expected
 
     @pytest.mark.parametrize("mock_response, expected", [
@@ -735,13 +756,34 @@ class TestCmis(object):
         result = self.api.get_host_lane_assignment_option(appl)
         assert result == expected
 
-    @pytest.mark.parametrize("mock_response, expected", [
-        (1, 1)
+    @pytest.mark.parametrize("appl, expected", [
+        (0, 0),
+        (1, 1),
+        (2, 15)
+        (3, 0)
     ])
-    def test_get_media_lane_assignment_option(self, mock_response, expected):
-        self.api.xcvr_eeprom.read = MagicMock()
-        self.api.xcvr_eeprom.read.return_value = mock_response
-        result = self.api.get_media_lane_assignment_option()
+    @patch('sonic_platform_base.sonic_xcvr.api.public.cmis.CmisApi.get_application_advertisement', MagicMock(return_value =
+        {
+            1: {
+                'host_electrical_interface_id': '400GAUI-8 C2M (Annex 120E)',
+                'module_media_interface_id': '400GBASE-DR4 (Cl 124)',
+                'media_lane_count': 4,
+                'host_lane_count': 8,
+                'host_lane_assignment_options': 1
+                'media_lane_assignment_options': 1
+            },
+            2: {
+                'host_electrical_interface_id': '100GAUI-2 C2M (Annex 135G)',
+                'module_media_interface_id': '100G-LR/100GBASE-LR1 (Cl 140)',
+                'media_lane_count': 1,
+                'host_lane_count': 2,
+                'host_lane_assignment_options': 85
+                'media_lane_assignment_options': 15
+            }
+        }
+    ))
+    def test_get_media_lane_assignment_option(self, appl, expected):
+        result = self.api.get_media_lane_assignment_option(appl)
         assert result == expected
 
     @pytest.mark.parametrize("mock_response, expected", [

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -692,7 +692,7 @@ class TestCmis(object):
     @pytest.mark.parametrize("appl, expected", [
         (0, 0),
         (1, 4),
-        (2, 1)
+        (2, 1),
         (3, 0)
     ])
     @patch('sonic_platform_base.sonic_xcvr.api.public.cmis.CmisApi.get_application_advertisement', MagicMock(return_value =
@@ -759,7 +759,7 @@ class TestCmis(object):
     @pytest.mark.parametrize("appl, expected", [
         (0, 0),
         (1, 1),
-        (2, 15)
+        (2, 15),
         (3, 0)
     ])
     @patch('sonic_platform_base.sonic_xcvr.api.public.cmis.CmisApi.get_application_advertisement', MagicMock(return_value =


### PR DESCRIPTION
#### Description
 
   Existing cmis api renders media_lane_count and media_lane_assignment_options from the first application code.
These api's are updated to support the modules with multiple app code, 

#### Motivation and Context
  
   Not able to retrieve media information from the selected application to control the media

#### How Has This Been Tested?

  Create data path using any app code other than the first one advertised in the module and control the media lane 
 (i.e) create breakout subports and control individual channel 

