### PR TITLE
replace exit() with sys.exit()

### DIFF
--- a/sonic_platform_base/sonic_eeprom/eeprom_base.py
+++ b/sonic_platform_base/sonic_eeprom/eeprom_base.py
@@ -14,6 +14,7 @@ try:
     import binascii
     import os
     import io
+    import sys
     import struct
     import fcntl
 except ImportError as e:
@@ -83,7 +84,7 @@ class EepromDecoder(object):
         elif self.checksum_field_size() == 1:
             return struct.pack('>B', crc)
         print('checksum type not yet supported')
-        exit(1)
+        sys.exit(1)
 
     def compute_2s_complement(self, e, size):
         crc = 0
@@ -122,7 +123,7 @@ class EepromDecoder(object):
         if self.checksum_type() == 'dell-crc':
             return self.compute_dell_crc(e)
         print('checksum type not yet supported')
-        exit(1)
+        sys.exit(1)
 
     def is_checksum_valid(self, e):
         offset = 0 - self.checksum_field_size()
@@ -169,7 +170,7 @@ class EepromDecoder(object):
                 v = v.strip()
                 if k not in fields:
                     print("Error: invalid field '%s'" %(k))
-                    exit(1)
+                    sys.exit(1)
                 ndict[k] = v
 
         for I in self.f:

--- a/sonic_platform_base/sonic_eeprom/eeprom_tlvinfo.py
+++ b/sonic_platform_base/sonic_eeprom/eeprom_tlvinfo.py
@@ -193,7 +193,7 @@ class TlvInfoDecoder(eeprom_base.EepromDecoder):
         self.decode_eeprom(new_e)
         if len(new_e) > min(self._TLV_INFO_MAX_LEN, self.eeprom_max_len):
             sys.stderr.write("\nERROR: There is not enough room in the EEPROM to save data.\n")
-            exit(1)
+            sys.exit(1)
         return new_e
 
 
@@ -601,7 +601,7 @@ class TlvInfoDecoder(eeprom_base.EepromDecoder):
                 sys.stderr.write("Error: '" + "0x%02X" % (I[0],) + "' -- Unable to set the read-only Quanta codes.\n")
             else:
                 sys.stderr.write("Error: '" + "0x%02X" % (I[0],) + "' correct format is " + errstr + "\n")
-            exit(0)
+            sys.exit(0)
 
         return bytearray([I[0]]) + bytearray([len(value)]) + value
 

--- a/tests/eeprom_base_test.py
+++ b/tests/eeprom_base_test.py
@@ -151,7 +151,7 @@ class TestEepromTlvinfo:
         # Test adding invalid field
         (is_valid, t) = eeprom_class.get_tlv_field(eeprom_new, 0x20)
         assert(not is_valid)
-        with mock.patch('builtins.exit') as exit_mock:
+        with mock.patch('sys.exit') as exit_mock:
             eeprom_new = eeprom_class.set_eeprom(eeprom, ['0x20 = Invalid'])
             assert exit_mock.called
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
Replace exit() by sys.exit()
#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
sys.exit is better than exit, considered good to use in production code.
Ref:
https://stackoverflow.com/questions/6501121/difference-between-exit-and-sys-exit-in-python
https://stackoverflow.com/questions/19747371/python-exit-commands-why-so-many-and-when-should-each-be-used
#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)

