### PR TITLE
Fix issue '<' not supported between instances of 'NoneType' and 'int'

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -501,8 +501,12 @@ class CmisApi(XcvrApi):
         if not tx_bias_support:
             return ["N/A" for _ in range(self.NUM_CHANNELS)]
         scale_raw = self.xcvr_eeprom.read(consts.TX_BIAS_SCALE)
+        if scale_raw is None:
+            return ["N/A" for _ in range(self.NUM_CHANNELS)]
         scale = 2**scale_raw if scale_raw < 3 else 1
         tx_bias = self.xcvr_eeprom.read(consts.TX_BIAS_FIELD)
+        if tx_bias is None:
+            return ["N/A" for _ in range(self.NUM_CHANNELS)]
         for key, value in tx_bias.items():
             tx_bias[key] *= scale
         return [tx_bias['LaserBiasTx%dField' % i] for i in range(1, self.NUM_CHANNELS + 1)]
@@ -874,7 +878,7 @@ class CmisApi(XcvrApi):
                            'high warn': laser_temp_high_warn,
                            'low warn': laser_temp_low_warn}
         return laser_temp_dict
-    
+
     def _get_laser_temp_threshold(self, field):
         LASER_TEMP_SCALE = 256.0
         value = self.xcvr_eeprom.read(field)

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -377,6 +377,16 @@ class TestCmis(object):
         result = self.api.get_tx_bias()
         assert result == expected
 
+    def test_get_tx_bias_neg(self):
+        self.api.get_tx_bias_support = MagicMock(return_value=True)
+        self.api.xcvr_eeprom.read = MagicMock()
+        # scale_raw is None, verify no crash
+        self.api.xcvr_eeprom.read.return_value = None
+        self.api.get_tx_bias()
+        # scale_raw is 1, tx_bias is None, verify no crash
+        self.api.xcvr_eeprom.read.side_effect = [1, None]
+        self.api.get_tx_bias()
+
     @pytest.mark.parametrize("mock_response, expected", [
         ([False, True], True)
     ])


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
Fix a crash issue in cmis.py

#### Motivation and Context
Crash stack:
```
May  8 03:08:31.091994 sonic ERR pmon#xcvrd: Exception occured at DomInfoUpdateTask thread due to TypeError("'<' not supported between instances of 'NoneType' and 'int'")
May  8 03:08:31.095191 sonic ERR pmon#xcvrd: Traceback (most recent call last):
May  8 03:08:31.095191 sonic ERR pmon#xcvrd:   File "/usr/local/lib/python3.9/dist-packages/xcvrd/xcvrd.py", line 1735, in run
May  8 03:08:31.095218 sonic ERR pmon#xcvrd:     self.task_worker()
May  8 03:08:31.095218 sonic ERR pmon#xcvrd:   File "/usr/local/lib/python3.9/dist-packages/xcvrd/xcvrd.py", line 1720, in task_worker
May  8 03:08:31.095252 sonic ERR pmon#xcvrd:     post_port_dom_info_to_db(logical_port_name, self.port_mapping, self.xcvr_table_helper.get_dom_tbl(asic_index), self.task_stopping_event, dom_info_cache=dom_info_cache)
May  8 03:08:31.095267 sonic ERR pmon#xcvrd:   File "/usr/local/lib/python3.9/dist-packages/xcvrd/xcvrd.py", line 503, in post_port_dom_info_to_db
May  8 03:08:31.095323 sonic ERR pmon#xcvrd:     dom_info_dict = _wrapper_get_transceiver_dom_info(physical_port)
May  8 03:08:31.095339 sonic ERR pmon#xcvrd:   File "/usr/local/lib/python3.9/dist-packages/xcvrd/xcvrd.py", line 181, in _wrapper_get_transceiver_dom_info
May  8 03:08:31.095355 sonic ERR pmon#xcvrd:     return platform_chassis.get_sfp(physical_port).get_transceiver_bulk_status()
May  8 03:08:31.095372 sonic ERR pmon#xcvrd:   File "/usr/local/lib/python3.9/dist-packages/sonic_platform_base/sonic_xcvr/sfp_optoe_base.py", line 28, in get_transceiver_bulk_status
May  8 03:08:31.095388 sonic ERR pmon#xcvrd:     return api.get_transceiver_bulk_status() if api is not None else None
May  8 03:08:31.095404 sonic ERR pmon#xcvrd:   File "/usr/local/lib/python3.9/dist-packages/sonic_platform_base/sonic_xcvr/api/public/cmis.py", line 185, in get_transceiver_bulk_status
May  8 03:08:31.095420 sonic ERR pmon#xcvrd:     tx_bias = self.get_tx_bias()
May  8 03:08:31.095437 sonic ERR pmon#xcvrd:   File "/usr/local/lib/python3.9/dist-packages/sonic_platform_base/sonic_xcvr/api/public/cmis.py", line 504, in get_tx_bias
May  8 03:08:31.095454 sonic ERR pmon#xcvrd:     scale = 2**scale_raw if scale_raw < 3 else 1
May  8 03:08:31.095484 sonic ERR pmon#xcvrd: TypeError: '<' not supported between instances of 'NoneType' and 'int'
May  8 03:08:31.095538 sonic ERR pmon#xcvrd: Xcvrd: exception found at child thread DomInfoUpdateTask due to TypeError("'<' not supported between instances of 'NoneType' and 'int'")
May  8 03:08:31.095562 sonic ERR pmon#xcvrd: Exiting main loop as child thread raised exception!
```

Root cause: cmis.py does not check return value of EEPROM read.

```
    def get_tx_bias(self):
        '''
        This function returns TX bias current on each media lane
        '''
        tx_bias_support = self.get_tx_bias_support()
        if tx_bias_support is None:
            return None
        if not tx_bias_support:
            return ["N/A" for _ in range(self.NUM_CHANNELS)]
        scale_raw = self.xcvr_eeprom.read(consts.TX_BIAS_SCALE)     ====> scale_raw might be None
        scale = 2**scale_raw if scale_raw < 3 else 1
        tx_bias = self.xcvr_eeprom.read(consts.TX_BIAS_FIELD)       ====> tx_bias might be None
        for key, value in tx_bias.items():
            tx_bias[key] *= scale
        return [tx_bias['LaserBiasTx%dField' % i] for i in range(1, self.NUM_CHANNELS + 1)]
```

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Manual test

#### Additional Information (Optional)

