### PR TITLE
Retrieve FW version using CDB command for CMIS transceivers + handle single bank FW versioning

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -161,9 +161,9 @@ class CmisApi(XcvrApi):
         xcvr_info['media_interface_technology'] = self.get_media_interface_technology()
         xcvr_info['vendor_rev'] = self.get_vendor_rev()
         xcvr_info['cmis_rev'] = self.get_cmis_rev()
-        xcvr_info['active_firmware'] = self.get_module_active_firmware()
-        xcvr_info['inactive_firmware'] = self.get_module_inactive_firmware()
         xcvr_info['specification_compliance'] = self.get_module_media_type()
+
+        xcvr_info['active_firmware'], xcvr_info['inactive_firmware'] = self.get_transceiver_info_firmware_versions()
 
         # In normal case will get a valid value for each of the fields. If get a 'None' value
         # means there was a failure while reading the EEPROM, either because the EEPROM was
@@ -174,6 +174,17 @@ class CmisApi(XcvrApi):
             return None
         else:
             return xcvr_info
+
+    def get_transceiver_info_firmware_versions(self):
+        result = self.get_module_fw_info()
+        if result is None:
+            return ["N/A", "N/A"]
+        try:
+            ( _, _, _, _, _, _, _, _, ActiveFirmware, InactiveFirmware) = result['result']
+        except (ValueError, TypeError):
+            return ["N/A", "N/A"]
+
+        return [ActiveFirmware, InactiveFirmware]
 
     def get_transceiver_bulk_status(self):
         rx_los = self.get_rx_los()
@@ -1291,11 +1302,19 @@ class CmisApi(XcvrApi):
             if ImageARunning == 1:
                 RunningImage = 'A'
                 ActiveFirmware = ImageA
-                InactiveFirmware = ImageB
+                if ImageBValid == 0:
+                    InactiveFirmware = ImageB
+                else:
+                    #In case of single bank module, inactive firmware version can be read from EEPROM
+                    InactiveFirmware = self.get_module_inactive_firmware() + ".0"
             elif ImageBRunning == 1:
                 RunningImage = 'B'
                 ActiveFirmware = ImageB
-                InactiveFirmware = ImageA
+                if ImageAValid == 0:
+                    InactiveFirmware = ImageA
+                else:
+                    #In case of single bank module, inactive firmware version can be read from EEPROM
+                    InactiveFirmware = self.get_module_inactive_firmware() + ".0"
             else:
                 RunningImage = 'N/A'
             if ImageACommitted == 1:
@@ -1311,7 +1330,7 @@ class CmisApi(XcvrApi):
         else:
             txt += 'Reply payload check code error\n'
             return {'status': False, 'info': txt, 'result': None}
-        return {'status': True, 'info': txt, 'result': (ImageA, ImageARunning, ImageACommitted, ImageAValid, ImageB, ImageBRunning, ImageBCommitted, ImageBValid)}
+        return {'status': True, 'info': txt, 'result': (ImageA, ImageARunning, ImageACommitted, ImageAValid, ImageB, ImageBRunning, ImageBCommitted, ImageBValid, ActiveFirmware, InactiveFirmware)}
 
     def cdb_run_firmware(self, mode = 0x01):
         # run module FW (CMD 0109h)
@@ -1538,7 +1557,7 @@ class CmisApi(XcvrApi):
         """
         result = self.get_module_fw_info()
         try:
-            _, _, _, _, _, _, _, _ = result['result']
+            _, _, _, _, _, _, _, _, _, _ = result['result']
         except (ValueError, TypeError):
             return result['status'], result['info']
         result = self.get_module_fw_mgmt_feature()
@@ -1565,7 +1584,7 @@ class CmisApi(XcvrApi):
         result = self.get_module_fw_info()
         try:
             (ImageA_init, ImageARunning_init, ImageACommitted_init, ImageAValid_init,
-             ImageB_init, ImageBRunning_init, ImageBCommitted_init, ImageBValid_init) = result['result']
+             ImageB_init, ImageBRunning_init, ImageBCommitted_init, ImageBValid_init, _, _) = result['result']
         except (ValueError, TypeError):
             return result['status'], result['info']
         if ImageAValid_init == 0 and ImageBValid_init == 0:
@@ -1573,7 +1592,7 @@ class CmisApi(XcvrApi):
             time.sleep(60)
             self.module_fw_commit()
             (ImageA, ImageARunning, ImageACommitted, ImageAValid,
-             ImageB, ImageBRunning, ImageBCommitted, ImageBValid) = self.get_module_fw_info()['result']
+             ImageB, ImageBRunning, ImageBCommitted, ImageBValid, _, _) = self.get_module_fw_info()['result']
             # detect if image switch happened
             txt += 'Before switch Image A: %s; Run: %d Commit: %d, Valid: %d\n' %(
                 ImageA_init, ImageARunning_init, ImageACommitted_init, ImageAValid_init

--- a/sonic_platform_base/sonic_xcvr/api/xcvr_api.py
+++ b/sonic_platform_base/sonic_xcvr/api/xcvr_api.py
@@ -70,6 +70,16 @@ class XcvrApi(object):
         """
         raise NotImplementedError
 
+    def get_transceiver_info_firmware_versions(self):
+        """
+        Retrieves active and inactive firmware versions of the xcvr
+
+        Returns:
+            A list with active and inactive firmware versions of the xcvr
+            [active_firmware, inactive_firmware]
+        """
+        raise NotImplementedError
+
     def get_transceiver_bulk_status(self):
         """
         Retrieves bulk status info for this xcvr

--- a/sonic_platform_base/sonic_xcvr/sfp_optoe_base.py
+++ b/sonic_platform_base/sonic_xcvr/sfp_optoe_base.py
@@ -23,6 +23,10 @@ class SfpOptoeBase(SfpBase):
         api = self.get_xcvr_api()
         return api.get_transceiver_info() if api is not None else None
 
+    def get_transceiver_info_firmware_versions(self):
+        api = self.get_xcvr_api()
+        return api.get_transceiver_info_firmware_versions() if api is not None else None
+
     def get_transceiver_bulk_status(self):
         api = self.get_xcvr_api()
         return api.get_transceiver_bulk_status() if api is not None else None

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -1125,7 +1125,7 @@ class TestCmis(object):
     @pytest.mark.parametrize("input_param, mock_response, expected", [
         (
             'abc',
-            [{'status': True, 'info': '', 'result': ('a', 1, 1, 0, 'b', 0, 0, 0)}, {'status': True, 'info': '', 'result': (112, 2048, True, True, 2048)}, (True, ''), (True, '')],
+            [{'status': True, 'info': '', 'result': ('a', 1, 1, 0, 'b', 0, 0, 0, 'a', 'b')}, {'status': True, 'info': '', 'result': (112, 2048, True, True, 2048)}, (True, ''), (True, '')],
             (True, '')
         ),
         (
@@ -1135,12 +1135,12 @@ class TestCmis(object):
         ),
         (
             'abc',
-            [{'status': True, 'info': '', 'result': ('a', 1, 1, 0, 'b', 0, 0, 0)}, {'status': False, 'info': '', 'result': None}, (True, ''), (True, '')],
+            [{'status': True, 'info': '', 'result': ('a', 1, 1, 0, 'b', 0, 0, 0, 'a', 'b')}, {'status': False, 'info': '', 'result': None}, (True, ''), (True, '')],
             (False, '')
         ),
         (
             'abc',
-            [{'status': True, 'info': '', 'result': ('a', 1, 1, 0, 'b', 0, 0, 0)}, {'status': True, 'info': '', 'result': (112, 2048, True, True, 2048)}, (False, ''), (True, '')],
+            [{'status': True, 'info': '', 'result': ('a', 1, 1, 0, 'b', 0, 0, 0, 'a', 'b')}, {'status': True, 'info': '', 'result': (112, 2048, True, True, 2048)}, (False, ''), (True, '')],
             (False, '')
         ),
     ])
@@ -1157,7 +1157,7 @@ class TestCmis(object):
         assert result == expected
 
     @pytest.mark.parametrize("mock_response, expected",[
-        ([None, None, None, None, None, None, None, None, None, None, None, None, None, None], None),
+        ([None, None, None, None, None, None, None, None, None, None, None, None, None, None, None], None),
         (
             [
                 {
@@ -1185,7 +1185,8 @@ class TestCmis(object):
                 '5.0',
                 '0.1',
                 '0.0',
-                'sm_media_interface'
+                'sm_media_interface',
+                {'status': True,  'result': ("0.3.0", 1, 1, 0, "0.2.0", 0, 0, 0, "0.3.0", "0.2.0")}
             ],
             {   'type': 'QSFP-DD Double Density 8X Pluggable Transceiver',
                 'type_abbrv_name': 'QSFP-DD',
@@ -1198,9 +1199,9 @@ class TestCmis(object):
                 'nominal_bit_rate': 0,
                 'specification_compliance': 'sm_media_interface',
                 'application_advertisement': 'N/A',
-                'active_firmware': '0.1',
+                'active_firmware': '0.3.0',
                 'media_lane_count': 1,
-                'inactive_firmware': '0.0',
+                'inactive_firmware': '0.2.0',
                 'vendor_rev': '0.0',
                 'host_electrical_interface': '400GAUI-8 C2M (Annex 120E)',
                 'vendor_oui': 'xx-xx-xx',
@@ -1249,14 +1250,12 @@ class TestCmis(object):
         self.api.get_vendor_rev.return_value = mock_response[9]
         self.api.get_cmis_rev = MagicMock()
         self.api.get_cmis_rev.return_value = mock_response[10]
-        self.api.get_module_active_firmware = MagicMock()
-        self.api.get_module_active_firmware.return_value = mock_response[11]
-        self.api.get_module_inactive_firmware = MagicMock()
-        self.api.get_module_inactive_firmware.return_value = mock_response[12]
+        self.api.get_module_fw_info = MagicMock()
         self.api.get_module_media_type = MagicMock()
         self.api.get_module_media_type.return_value = mock_response[13]
         self.api.get_module_hardware_revision = MagicMock()
         self.api.get_module_hardware_revision.return_value = '0.0'
+        self.api.get_module_fw_info.return_value = mock_response[14]
         self.api.is_flat_memory = MagicMock()
         self.api.is_flat_memory.return_value = False
         result = self.api.get_transceiver_info()

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -1134,6 +1134,8 @@ class TestCmis(object):
         ((None, 1, [0] * 128),  {'status': False, 'info': "", 'result': 0}),
         ((128, None, [0] * 128),  {'status': False, 'info': "", 'result': 0}),
         ((128, 0, [0] * 128),  {'status': False, 'info': "", 'result': None}),
+        ((128, 1, [67, 3, 2, 2, 3, 183] + [0] * 104),  {'status': True, 'info': "", 'result': None}),
+        ((128, 1, [52, 3, 2, 2, 3, 183] + [0] * 104),  {'status': True, 'info': "", 'result': None}),
         ((110, 1, [3, 3, 2, 2, 3, 183] + [0] * 104),  {'status': True, 'info': "", 'result': None}),
         ((110, 1, [48, 3, 2, 2, 3, 183] + [0] * 104),  {'status': True, 'info': "", 'result': None}),
     ])
@@ -2249,3 +2251,14 @@ class TestCmis(object):
             except:
                 assert 0, traceback.format_exc()
             run_num -= 1
+
+    def test_get_transceiver_info_firmware_versions_negative_tests(self):
+        self.api.get_module_fw_info = MagicMock()
+        self.api.get_module_fw_info.return_value = None
+        result = self.api.get_transceiver_info_firmware_versions()
+        assert result == ["N/A", "N/A"]
+
+        self.api.get_module_fw_info = MagicMock()
+        self.api.get_module_fw_info.side_effect = {'result': TypeError}
+        result = self.api.get_transceiver_info_firmware_versions()
+        assert result == ["N/A", "N/A"]


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
It seems that currently, "sfputil show fwversion" doesn't display the inactive FW version from EEPROM after CDB FW is downloaded on a module with single bank.
We need to display the inactive FW version from EEPROM in such case to ensure that user doesn't re-download the target FW if it is already residing on the module but is not activated.

Also, the TRANSCEIVER_INFO table currently doesn't display the build version for active/inactive FWs.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
 "sfputil show fwversion" doesn't display the inactive FW version from EEPROM after CDB FW is downloaded on the module with single bank. Hence, this PR will track the fix for it.

Also, the TRANSCEIVER_INFO table currently doesn't display the build version for active/inactive FWs. We are now displaying the FW version using CDB command and not through EEPROM to display the build version.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Single bank FW o/p

show int transceiver info Ethernet32

Ethernet32: SFP EEPROM detected
        Active Firmware: x.y.z
        Active application selected code assigned to host lane 1: 1
        Active application selected code assigned to host lane 2: 1
        Active application selected code assigned to host lane 3: 1
        Active application selected code assigned to host lane 4: 1
        Active application selected code assigned to host lane 5: 1
        Active application selected code assigned to host lane 6: 1
        Active application selected code assigned to host lane 7: 1
        Active application selected code assigned to host lane 8: 1
        Application Advertisement: CAUI-4 C2M (Annex 83E) - Host Assign (0x11) - Active Cable assembly with BER < 5x10^-5 - Media Assign (0x1
1)
        CMIS Rev: A.B
        Connector: No separable connector
        Encoding: N/A
        Extended Identifier: Power Class 3 (3.75W Max)
        Extended RateSelect Compliance: N/A
        Host Lane Count: 4
        Identifier: QSFP-DD Double Density 8X Pluggable Transceiver
        Inactive Firmware: d.e.0
        Length Cable Assembly(m): 6.0
        Media Interface Technology: 850 nm VCSEL
        Media Lane Count: 4
        Module Hardware Rev: 0.0
        Nominal Bit Rate(100Mbs): 0
        Specification compliance: active_cable_media_interface
        Supported Max Laser Frequency: N/A
        Supported Max TX Power: N/A
        Supported Min Laser Frequency: N/A
        Supported Min TX Power: N/A
        Vendor Date Code(YYYY-MM-DD Lot): XXXX-XX-XX
        Vendor Name: ABC
        Vendor OUI: ab-cd-ef
        Vendor PN: XXXX-XX-XX
        Vendor Rev: XX
        Vendor SN: XXXXXXXX

sfputil show fwversion Ethernet32
Image A Version: x.y.z
Image B Version: N/A
Factory Image Version: 0.0.0
Running Image: A
Committed Image: A
Active Firmware: x.y.z
Inactive Firmware: d.e.0



2 Bank module
show int transceiver info Ethernet160
Ethernet160: SFP EEPROM detected
        Active Firmware: x.y.z
        Active application selected code assigned to host lane 1: 1
        Active application selected code assigned to host lane 2: 1
        Active application selected code assigned to host lane 3: 1
        Active application selected code assigned to host lane 4: 1
        Active application selected code assigned to host lane 5: 1
        Active application selected code assigned to host lane 6: 1
        Active application selected code assigned to host lane 7: 1
        Active application selected code assigned to host lane 8: 1
        Application Advertisement: 400GAUI-8 C2M (Annex 120E) - Host Assign (0x1) - 400ZR, DWDM, amplified - Media Assign (0x1)
                                   100GAUI-2 C2M (Annex 135G) - Host Assign (0x55) - 400ZR, DWDM, amplified - Media Assign (0x1)
        CMIS Rev: A.B
        Connector: LC
        Encoding: N/A
        Extended Identifier: Power Class 8 (18.0W Max)
        Extended RateSelect Compliance: N/A
        Host Lane Count: 8
        Identifier: QSFP-DD Double Density 8X Pluggable Transceiver
        Inactive Firmware: d.e.f
        Length Cable Assembly(m): 0.0
        Media Interface Technology: C-band tunable laser
        Media Lane Count: 1
        Module Hardware Rev: 0.0
        Nominal Bit Rate(100Mbs): 0
        Specification compliance: sm_media_interface
        Supported Max Laser Frequency: 196100
        Supported Max TX Power: -10.2
        Supported Min Laser Frequency: 191300
        Supported Min TX Power: -14.0
        Vendor Date Code(YYYY-MM-DD Lot): XXXX-XX-XX
        Vendor Name: ABC
        Vendor OUI: ab-cd-ef
        Vendor PN: XXXX-XX-XX
        Vendor Rev: XX
        Vendor SN: XXXXXXXX

sfputil show fwversion Ethernet160
Image A Version: x.y.z
Image B Version: d.e.f
Factory Image Version: x.y.c
Running Image: B
Committed Image: B
Active Firmware: d.e.f
Inactive Firmware: x.y.z

#### Additional Information (Optional)

