### PR TITLE
Comment out tx power validation check and program the passed value 

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/c_cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/c_cmis.py
@@ -143,10 +143,6 @@ class CCmisApi(CmisApi):
         Return True if the provision succeeds, False if it fails
         '''
         min_prog_tx_output_power, max_prog_tx_output_power = self.get_supported_power_config()
-        #Comment out validation for now.
-        #if tx_power > max_prog_tx_output_power or tx_power < min_prog_tx_output_power:
-        #    raise ValueError('Provisioned TX power out of range. Max: %.1f; Min: %.1f dBm.' 
-        #                     %(max_prog_tx_output_power, min_prog_tx_output_power))
         status = self.xcvr_eeprom.write(consts.TX_CONFIG_POWER, tx_power)
         time.sleep(1)
         return status

--- a/sonic_platform_base/sonic_xcvr/api/public/c_cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/c_cmis.py
@@ -143,9 +143,10 @@ class CCmisApi(CmisApi):
         Return True if the provision succeeds, False if it fails
         '''
         min_prog_tx_output_power, max_prog_tx_output_power = self.get_supported_power_config()
-        if tx_power > max_prog_tx_output_power or tx_power < min_prog_tx_output_power:
-            raise ValueError('Provisioned TX power out of range. Max: %.1f; Min: %.1f dBm.' 
-                             %(max_prog_tx_output_power, min_prog_tx_output_power))
+        #Comment out validation for now.
+        #if tx_power > max_prog_tx_output_power or tx_power < min_prog_tx_output_power:
+        #    raise ValueError('Provisioned TX power out of range. Max: %.1f; Min: %.1f dBm.' 
+        #                     %(max_prog_tx_output_power, min_prog_tx_output_power))
         status = self.xcvr_eeprom.write(consts.TX_CONFIG_POWER, tx_power)
         time.sleep(1)
         return status


### PR DESCRIPTION
What I did:

Comment out tx power validation check and program the passed value  to eeprom write function

MSFT ADO: 17893499

Why I did:

For some of our 400G ZR optics calibrated value of tx power is not in min and max range of advertised value which causes xcvrd to crash and then links do not come up . This fix is short term solution to skip the validation check.


How I verify:
After this change not seeing xcvrd crash.