### PR TITLE
Move tx_disable/tx_disabled_channel/rx_los/tx_fault  to get_transceiver_status API (cherry-pick to 202205)

### DIFF
--- a/sonic_platform_base/sfp_base.py
+++ b/sonic_platform_base/sfp_base.py
@@ -161,9 +161,6 @@ class SfpBase(device_base.DeviceBase):
         tx_fault                   |BOOLEAN        |TX fault status, True if has TX fault, False if not.
         reset_status               |BOOLEAN        |reset status, True if SFP in reset, False if not.
         lp_mode                    |BOOLEAN        |low power mode status, True in lp mode, False if not.
-        tx_disable                 |BOOLEAN        |TX disable status, True TX disabled, False if not.
-        tx_disabled_channel        |HEX            |disabled TX channels in hex, bits 0 to 3 represent channel 0
-                                   |               |to channel 3.
         temperature                |INT            |module temperature in Celsius
         voltage                    |INT            |supply voltage in mV
         tx<n>bias                  |INT            |TX Bias Current in mA, n is the channel number,

--- a/sonic_platform_base/sonic_xcvr/api/public/c_cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/c_cmis.py
@@ -629,7 +629,7 @@ class CCmisApi(CmisApi):
         tuning_in_progress           = BOOLEAN                          ; tuning in progress status
         wavelength_unlock_status     = BOOLEAN                          ; laser unlocked status
         target_output_power_oor      = BOOLEAN                          ; target output power out of range flag
-        fine_tuning_oor              = BOOLEAN                          ; fine tuning  out of range flag
+        fine_tuning_oor              = BOOLEAN                          ; fine tuning out of range flag
         tuning_not_accepted          = BOOLEAN                          ; tuning not accepted flag
         invalid_channel_num          = BOOLEAN                          ; invalid channel number flag
         tuning_complete              = BOOLEAN                          ; tuning complete flag

--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -187,20 +187,12 @@ class CmisApi(XcvrApi):
         return [ActiveFirmware, InactiveFirmware]
 
     def get_transceiver_bulk_status(self):
-        rx_los = self.get_rx_los()
-        tx_fault = self.get_tx_fault()
-        tx_disable = self.get_tx_disable()
-        tx_disabled_channel = self.get_tx_disable_channel()
         temp = self.get_module_temperature()
         voltage = self.get_voltage()
         tx_bias = self.get_tx_bias()
         rx_power = self.get_rx_power()
         tx_power = self.get_tx_power()
-        read_failed = rx_los is None or \
-                      tx_fault is None or \
-                      tx_disable is None or \
-                      tx_disabled_channel is None or \
-                      temp is None or \
+        read_failed = temp is None or \
                       voltage is None or \
                       tx_bias is None or \
                       rx_power is None or \
@@ -209,15 +201,11 @@ class CmisApi(XcvrApi):
             return None
 
         bulk_status = {
-            "rx_los": all(rx_los) if self.get_rx_los_support() else 'N/A',
-            "tx_fault": all(tx_fault) if self.get_tx_fault_support() else 'N/A',
-            "tx_disabled_channel": tx_disabled_channel,
             "temperature": temp,
             "voltage": voltage
         }
 
         for i in range(1, self.NUM_CHANNELS + 1):
-            bulk_status["tx%ddisable" % i] = tx_disable[i-1] if self.get_tx_disable_support() else 'N/A'
             bulk_status["tx%dbias" % i] = tx_bias[i - 1]
             bulk_status["rx%dpower" % i] = float("{:.3f}".format(self.mw_to_dbm(rx_power[i - 1]))) if rx_power[i - 1] != 'N/A' else 'N/A'
             bulk_status["tx%dpower" % i] = float("{:.3f}".format(self.mw_to_dbm(tx_power[i - 1]))) if tx_power[i - 1] != 'N/A' else 'N/A'
@@ -1659,6 +1647,8 @@ class CmisApi(XcvrApi):
         rxoutput_status_hostlane6    = BOOLEAN                          ; rx output status on host lane 6
         rxoutput_status_hostlane7    = BOOLEAN                          ; rx output status on host lane 7
         rxoutput_status_hostlane8    = BOOLEAN                          ; rx output status on host lane 8
+        tx_disable                   = BOOLEAN                          ; tx disable status
+        tx_disabled_channel          = INTEGER                          ; disabled TX channels
         txfault                      = BOOLEAN                          ; tx fault flag on media lane
         txlos_hostlane1              = BOOLEAN                          ; tx loss of signal flag on host lane 1
         txlos_hostlane2              = BOOLEAN                          ; tx loss of signal flag on host lane 2
@@ -1777,6 +1767,13 @@ class CmisApi(XcvrApi):
             if rx_output_status_dict:
                 for lane in range(1, self.NUM_CHANNELS+1):
                     trans_status['rxoutput_status_hostlane%d' % lane] = rx_output_status_dict.get('RxOutputStatus%d' % lane)
+            tx_disabled_channel = self.get_tx_disable_channel()
+            if tx_disabled_channel is not None:
+                trans_status['tx_disabled_channel'] = tx_disabled_channel
+            tx_disable = self.get_tx_disable()
+            if tx_disable is not None:
+                for lane in range(1, self.NUM_CHANNELS+1):
+                    trans_status['tx%ddisable' % lane] = tx_disable[lane - 1]
             tx_fault = self.get_tx_fault()
             if tx_fault:
                 for lane in range(1, self.NUM_CHANNELS+1):

--- a/sonic_platform_base/sonic_xcvr/api/public/sff8436.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/sff8436.py
@@ -68,21 +68,36 @@ class Sff8436Api(XcvrApi):
 
         return xcvr_info
 
-    def get_transceiver_bulk_status(self):
+    def get_transceiver_status(self):
         rx_los = self.get_rx_los()
         tx_fault = self.get_tx_fault()
         tx_disable = self.get_tx_disable()
         tx_disabled_channel = self.get_tx_disable_channel()
+        read_failed = rx_los is None or \
+                      tx_fault is None or \
+                      tx_disable is None or \
+                      tx_disabled_channel is None
+        if read_failed:
+            return None
+
+        trans_status = dict()
+        for lane in range(1, len(rx_los) + 1):
+            trans_status['rxlos%d' % lane] = rx_los[lane - 1]
+        for lane in range(1, len(tx_fault) + 1):
+            trans_status['txfault%d' % lane] = tx_fault[lane - 1]
+        for lane in range(1, len(tx_disable) + 1):
+            trans_status['tx%ddisable' % lane] = tx_disable[lane - 1]
+        trans_status['tx_disabled_channel'] = tx_disabled_channel
+
+        return trans_status
+
+    def get_transceiver_bulk_status(self):
         temp = self.get_module_temperature()
         voltage = self.get_voltage()
         tx_bias = self.get_tx_bias()
         rx_power = self.get_rx_power()
         tx_power = self.get_tx_power()
-        read_failed = rx_los is None or \
-                      tx_fault is None or \
-                      tx_disable is None or \
-                      tx_disabled_channel is None or \
-                      temp is None or \
+        read_failed = temp is None or \
                       voltage is None or \
                       tx_bias is None or \
                       rx_power is None or \
@@ -91,10 +106,6 @@ class Sff8436Api(XcvrApi):
             return None
 
         bulk_status = {
-            "rx_los": all(rx_los) if self.get_rx_los_support() else 'N/A',
-            "tx_fault": all(tx_fault) if self.get_tx_fault_support() else 'N/A',
-            "tx_disable": all(tx_disable),
-            "tx_disabled_channel": tx_disabled_channel,
             "temperature": temp,
             "voltage": voltage
         }

--- a/sonic_platform_base/sonic_xcvr/api/public/sff8472.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/sff8472.py
@@ -60,21 +60,36 @@ class Sff8472Api(XcvrApi):
 
         return xcvr_info
 
-    def get_transceiver_bulk_status(self):
+    def get_transceiver_status(self):
         rx_los = self.get_rx_los()
         tx_fault = self.get_tx_fault()
         tx_disable = self.get_tx_disable()
         tx_disabled_channel = self.get_tx_disable_channel()
+        read_failed = rx_los is None or \
+                      tx_fault is None or \
+                      tx_disable is None or \
+                      tx_disabled_channel is None
+        if read_failed:
+            return None
+
+        trans_status = dict()
+        for lane in range(1, len(rx_los) + 1):
+            trans_status['rxlos%d' % lane] = rx_los[lane - 1]
+        for lane in range(1, len(tx_fault) + 1):
+            trans_status['txfault%d' % lane] = tx_fault[lane - 1]
+        for lane in range(1, len(tx_disable) + 1):
+            trans_status['tx%ddisable' % lane] = tx_disable[lane - 1]
+        trans_status['tx_disabled_channel'] = tx_disabled_channel
+
+        return trans_status
+
+    def get_transceiver_bulk_status(self):
         temp = self.get_module_temperature()
         voltage = self.get_voltage()
         tx_bias = self.get_tx_bias()
         rx_power = self.get_rx_power()
         tx_power = self.get_tx_power()
-        read_failed = rx_los is None or \
-                      tx_fault is None or \
-                      tx_disable is None or \
-                      tx_disabled_channel is None or \
-                      temp is None or \
+        read_failed = temp is None or \
                       voltage is None or \
                       tx_bias is None or \
                       rx_power is None or \
@@ -83,10 +98,6 @@ class Sff8472Api(XcvrApi):
             return None
 
         bulk_status = {
-            "rx_los": all(rx_los) if self.get_rx_los_support() else 'N/A',
-            "tx_fault": all(tx_fault) if self.get_tx_fault_support() else 'N/A',
-            "tx_disable": all(tx_disable),
-            "tx_disabled_channel": tx_disabled_channel,
             "temperature": temp,
             "voltage": voltage
         }

--- a/sonic_platform_base/sonic_xcvr/api/public/sff8636.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/sff8636.py
@@ -75,21 +75,36 @@ class Sff8636Api(XcvrApi):
 
         return xcvr_info
 
-    def get_transceiver_bulk_status(self):
+    def get_transceiver_status(self):
         rx_los = self.get_rx_los()
         tx_fault = self.get_tx_fault()
         tx_disable = self.get_tx_disable()
         tx_disabled_channel = self.get_tx_disable_channel()
+        read_failed = rx_los is None or \
+                      tx_fault is None or \
+                      tx_disable is None or \
+                      tx_disabled_channel is None
+        if read_failed:
+            return None
+
+        trans_status = dict()
+        for lane in range(1, len(rx_los) + 1):
+            trans_status['rxlos%d' % lane] = rx_los[lane - 1]
+        for lane in range(1, len(tx_fault) + 1):
+            trans_status['txfault%d' % lane] = tx_fault[lane - 1]
+        for lane in range(1, len(tx_disable) + 1):
+            trans_status['tx%ddisable' % lane] = tx_disable[lane - 1]
+        trans_status['tx_disabled_channel'] = tx_disabled_channel
+
+        return trans_status
+
+    def get_transceiver_bulk_status(self):
         temp = self.get_module_temperature()
         voltage = self.get_voltage()
         tx_bias = self.get_tx_bias()
         rx_power = self.get_rx_power()
         tx_power = self.get_tx_power()
-        read_failed = rx_los is None or \
-                      tx_fault is None or \
-                      tx_disable is None or \
-                      tx_disabled_channel is None or \
-                      temp is None or \
+        read_failed = temp is None or \
                       voltage is None or \
                       tx_bias is None or \
                       rx_power is None or \
@@ -98,10 +113,6 @@ class Sff8636Api(XcvrApi):
             return None
 
         bulk_status = {
-            "rx_los": all(rx_los) if self.get_rx_los_support() else 'N/A',
-            "tx_fault": all(tx_fault) if self.get_tx_fault_support() else 'N/A',
-            "tx_disable": all(tx_disable),
-            "tx_disabled_channel": tx_disabled_channel,
             "temperature": temp,
             "voltage": voltage
         }

--- a/sonic_platform_base/sonic_xcvr/api/xcvr_api.py
+++ b/sonic_platform_base/sonic_xcvr/api/xcvr_api.py
@@ -89,11 +89,6 @@ class XcvrApi(object):
         ========================================================================
         keys                       |Value Format   |Information
         ---------------------------|---------------|----------------------------
-        rx_los                     |bool           |RX loss-of-signal status, True if has RX los, False if not.
-        tx_fault                   |bool           |TX fault status, True if has TX fault, False if not.
-        tx_disable                 |bool           |TX disable status, True TX disabled, False if not.
-        tx_disabled_channel        |int            |disabled TX channels in hex, bits 0 to 3 represent channel 0
-                                   |               |to channel 3 (for example).
         temperature                |float          |module temperature in Celsius
         voltage                    |float          |supply voltage in mV
         tx<n>bias                  |float          |TX Bias Current in mA, n is the channel number,
@@ -145,7 +140,7 @@ class XcvrApi(object):
 
     def get_transceiver_status(self):
         """
-        Retrieves transceiver status of this SFP (applicable for CMIS/C-CMIS)
+        Retrieves transceiver status of this SFP
 
         Returns:
             A dict which may contain following keys/values (there could be more for C-CMIS) :

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -1323,10 +1323,6 @@ class TestCmis(object):
     @pytest.mark.parametrize("mock_response, expected",[
         (
             [
-                [False, False, False, False, False, False, False, False],
-                [False, False, False, False, False, False, False, False],
-                [False, False, False, False, False, False, False, False],
-                0,
                 50,
                 3.3,
                 [70, 70, 70, 70, 70, 70, 70, 70],
@@ -1351,11 +1347,6 @@ class TestCmis(object):
                 'rx5power': -10.0, 'rx6power': -10.0, 'rx7power': -10.0, 'rx8power': -10.0,
                 'tx1bias': 70, 'tx2bias': 70, 'tx3bias': 70, 'tx4bias': 70,
                 'tx5bias': 70, 'tx6bias': 70, 'tx7bias': 70, 'tx8bias': 70,
-                'rx_los': False,
-                'tx_fault': False,
-                'tx1disable': False, 'tx2disable': False, 'tx3disable': False, 'tx4disable': False,
-                'tx5disable': False, 'tx6disable': False, 'tx7disable': False, 'tx8disable': False,
-                'tx_disabled_channel': 0,
                 'laser_temperature': 40,
                 'prefec_ber': 0.001,
                 'postfec_ber_min': 0,
@@ -1366,10 +1357,6 @@ class TestCmis(object):
         ),
         (
             [
-                ['N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A'],
-                ['N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A'],
-                ['N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A'],
-                'N/A',
                 50, 3.3,
                 ['N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A'],
                 None,
@@ -1382,10 +1369,6 @@ class TestCmis(object):
         ),
         (
             [
-                ['N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A'],
-                ['N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A'],
-                ['N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A'],
-                'N/A',
                 50, 3.3,
                 ['N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A'],
                 ['N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A'],
@@ -1403,50 +1386,37 @@ class TestCmis(object):
                 'rx5power': 'N/A', 'rx6power': 'N/A', 'rx7power': 'N/A', 'rx8power': 'N/A',
                 'tx1bias': 'N/A', 'tx2bias': 'N/A', 'tx3bias': 'N/A', 'tx4bias': 'N/A',
                 'tx5bias': 'N/A', 'tx6bias': 'N/A', 'tx7bias': 'N/A', 'tx8bias': 'N/A',
-                'rx_los': 'N/A',
-                'tx_fault': 'N/A',
-                'tx1disable': 'N/A', 'tx2disable': 'N/A', 'tx3disable': 'N/A', 'tx4disable': 'N/A',
-                'tx5disable': 'N/A', 'tx6disable': 'N/A', 'tx7disable': 'N/A', 'tx8disable': 'N/A',
-                'tx_disabled_channel': 'N/A',
                 'laser_temperature': 40
             }
         )
     ])
     def test_get_transceiver_bulk_status(self, mock_response, expected):
-        self.api.get_rx_los = MagicMock()
-        self.api.get_rx_los.return_value = mock_response[0]
-        self.api.get_tx_fault = MagicMock()
-        self.api.get_tx_fault.return_value = mock_response[1]
-        self.api.get_tx_disable = MagicMock()
-        self.api.get_tx_disable.return_value = mock_response[2]
-        self.api.get_tx_disable_channel = MagicMock()
-        self.api.get_tx_disable_channel.return_value = mock_response[3]
         self.api.get_module_temperature = MagicMock()
-        self.api.get_module_temperature.return_value = mock_response[4]
+        self.api.get_module_temperature.return_value = mock_response[0]
         self.api.get_voltage = MagicMock()
-        self.api.get_voltage.return_value = mock_response[5]
+        self.api.get_voltage.return_value = mock_response[1]
         self.api.get_tx_bias = MagicMock()
-        self.api.get_tx_bias.return_value = mock_response[6]
+        self.api.get_tx_bias.return_value = mock_response[2]
         self.api.get_rx_power = MagicMock()
-        self.api.get_rx_power.return_value = mock_response[7]
+        self.api.get_rx_power.return_value = mock_response[3]
         self.api.get_tx_power = MagicMock()
-        self.api.get_tx_power.return_value = mock_response[8]
+        self.api.get_tx_power.return_value = mock_response[4]
         self.api.get_rx_los_support = MagicMock()
-        self.api.get_rx_los_support.return_value = mock_response[9]
+        self.api.get_rx_los_support.return_value = mock_response[5]
         self.api.get_tx_fault_support = MagicMock()
-        self.api.get_tx_fault_support.return_value = mock_response[10]
+        self.api.get_tx_fault_support.return_value = mock_response[6]
         self.api.get_tx_disable_support = MagicMock()
-        self.api.get_tx_disable_support.return_value = mock_response[11]
+        self.api.get_tx_disable_support.return_value = mock_response[7]
         self.api.get_tx_bias_support = MagicMock()
-        self.api.get_tx_bias_support.return_value = mock_response[12]
+        self.api.get_tx_bias_support.return_value = mock_response[8]
         self.api.get_tx_power_support = MagicMock()
-        self.api.get_tx_power_support.return_value = mock_response[13]
+        self.api.get_tx_power_support.return_value = mock_response[9]
         self.api.get_rx_power_support = MagicMock()
-        self.api.get_rx_power_support.return_value = mock_response[14]
+        self.api.get_rx_power_support.return_value = mock_response[10]
         self.api.get_laser_temperature = MagicMock()
-        self.api.get_laser_temperature.return_value = mock_response[15]
+        self.api.get_laser_temperature.return_value = mock_response[11]
         self.api.get_vdm = MagicMock()
-        self.api.get_vdm.return_value = mock_response[16]
+        self.api.get_vdm.return_value = mock_response[12]
         result = self.api.get_transceiver_bulk_status()
         assert result == expected
 
@@ -1656,7 +1626,8 @@ class TestCmis(object):
                 {
                     'Pre-FEC BER Average Media Input':{1:[0.001, 0.0125, 0, 0.01, 0, False, False, False, False]},
                     'Errored Frames Average Media Input':{1:[0, 1, 0, 1, 0, False, False, False, False]},
-                }
+                },
+                0, [False, False, False, False, False, False, False, False]
             ],
             {
                 'module_state': 'ModuleReady',
@@ -1688,6 +1659,15 @@ class TestCmis(object):
                 'rxoutput_status_hostlane6': True,
                 'rxoutput_status_hostlane7': True,
                 'rxoutput_status_hostlane8': True,
+                "tx_disabled_channel": 0,
+                "tx1disable": False,
+                "tx2disable": False,
+                "tx3disable": False,
+                "tx4disable": False,
+                "tx5disable": False,
+                "tx6disable": False,
+                "tx7disable": False,
+                "tx8disable": False,
                 'txfault1': False,
                 'txfault2': False,
                 'txfault3': False,
@@ -1890,7 +1870,8 @@ class TestCmis(object):
                 {
                     'Pre-FEC BER Average Media Input':{1:[0.001, 0.0125, 0, 0.01, 0, False, False, False, False]},
                     'Errored Frames Average Media Input':{1:[0, 1, 0, 1, 0, False, False, False, False]},
-                }
+                },
+                None, None
             ],
             {
                 'module_state': 'ModuleReady',
@@ -1949,6 +1930,10 @@ class TestCmis(object):
         self.api.get_tx_bias_flag.return_value = mock_response[18]
         self.api.get_vdm = MagicMock()
         self.api.get_vdm.return_value = mock_response[19]
+        self.api.get_tx_disable_channel = MagicMock()
+        self.api.get_tx_disable_channel.return_value = mock_response[20]
+        self.api.get_tx_disable = MagicMock()
+        self.api.get_tx_disable.return_value = mock_response[21]
         result = self.api.get_transceiver_status()
         assert result == expected
 

--- a/tests/sonic_xcvr/test_sff8436.py
+++ b/tests/sonic_xcvr/test_sff8436.py
@@ -27,6 +27,7 @@ class TestSff8436(object):
         self.api.get_transceiver_info()
         self.api.get_transceiver_bulk_status()
         self.api.get_transceiver_threshold_info()
+        self.api.get_transceiver_status()
         self.api.get_rx_los()
         self.api.get_tx_fault()
         self.api.get_tx_disable()
@@ -154,3 +155,49 @@ class TestSff8436(object):
         self.api.get_lpmode_support.return_value = False
         self.api.get_power_override_support.return_value = False
         assert not self.api.set_lpmode(True)
+
+    @pytest.mark.parametrize("mock_response, expected",[
+        (
+            [
+                [False, False, False, False],
+                [False, False, False, False],
+                0,
+                [False, False, False, False]
+            ],
+            {
+                "tx_disabled_channel": 0,
+                "tx1disable": False,
+                "tx2disable": False,
+                "tx3disable": False,
+                "tx4disable": False,
+                'txfault1': False,
+                'txfault2': False,
+                'txfault3': False,
+                'txfault4': False,
+                'rxlos1': False,
+                'rxlos2': False,
+                'rxlos3': False,
+                'rxlos4': False,
+            }
+        ),
+        (
+            [
+                None,
+                None,
+                None,
+                None
+            ],
+            None
+        )
+    ])
+    def test_get_transceiver_status(self, mock_response, expected):
+        self.api.get_rx_los = MagicMock()
+        self.api.get_rx_los.return_value = mock_response[0]
+        self.api.get_tx_fault = MagicMock()
+        self.api.get_tx_fault.return_value = mock_response[1]
+        self.api.get_tx_disable_channel = MagicMock()
+        self.api.get_tx_disable_channel.return_value = mock_response[2]
+        self.api.get_tx_disable = MagicMock()
+        self.api.get_tx_disable.return_value = mock_response[3]
+        result = self.api.get_transceiver_status()
+        assert result == expected

--- a/tests/sonic_xcvr/test_sff8472.py
+++ b/tests/sonic_xcvr/test_sff8472.py
@@ -29,6 +29,7 @@ class TestSff8472(object):
         self.api.get_transceiver_info()
         self.api.get_transceiver_bulk_status()
         self.api.get_transceiver_threshold_info()
+        self.api.get_transceiver_status()
         self.api.get_rx_los()
         self.api.get_tx_fault()
         self.api.get_tx_disable()
@@ -205,3 +206,40 @@ class TestSff8472(object):
             except:
                 assert 0, traceback.format_exc()
             run_num -= 1
+
+    @pytest.mark.parametrize("mock_response, expected",[
+        (
+            [
+                [False],
+                [False],
+                0,
+                [False]
+            ],
+            {
+                "tx_disabled_channel": 0,
+                "tx1disable": False,
+                'txfault1': False,
+                'rxlos1': False,
+            }
+        ),
+        (
+            [
+                None,
+                None,
+                None,
+                None
+            ],
+            None
+        )
+    ])
+    def test_get_transceiver_status(self, mock_response, expected):
+        self.api.get_rx_los = MagicMock()
+        self.api.get_rx_los.return_value = mock_response[0]
+        self.api.get_tx_fault = MagicMock()
+        self.api.get_tx_fault.return_value = mock_response[1]
+        self.api.get_tx_disable_channel = MagicMock()
+        self.api.get_tx_disable_channel.return_value = mock_response[2]
+        self.api.get_tx_disable = MagicMock()
+        self.api.get_tx_disable.return_value = mock_response[3]
+        result = self.api.get_transceiver_status()
+        assert result == expected

--- a/tests/sonic_xcvr/test_sff8636.py
+++ b/tests/sonic_xcvr/test_sff8636.py
@@ -26,6 +26,7 @@ class TestSff8636(object):
         self.api.get_transceiver_info()
         self.api.get_transceiver_bulk_status()
         self.api.get_transceiver_threshold_info()
+        self.api.get_transceiver_status()
         self.api.get_rx_los()
         self.api.get_tx_fault()
         self.api.get_tx_disable()
@@ -154,3 +155,49 @@ class TestSff8636(object):
         self.api.get_lpmode_support.return_value = False
         self.api.get_power_override_support.return_value = False
         assert not self.api.set_lpmode(True)
+
+    @pytest.mark.parametrize("mock_response, expected",[
+        (
+            [
+                [False, False, False, False],
+                [False, False, False, False],
+                0,
+                [False, False, False, False]
+            ],
+            {
+                "tx_disabled_channel": 0,
+                "tx1disable": False,
+                "tx2disable": False,
+                "tx3disable": False,
+                "tx4disable": False,
+                'txfault1': False,
+                'txfault2': False,
+                'txfault3': False,
+                'txfault4': False,
+                'rxlos1': False,
+                'rxlos2': False,
+                'rxlos3': False,
+                'rxlos4': False,
+            }
+        ),
+        (
+            [
+                None,
+                None,
+                None,
+                None
+            ],
+            None
+        )
+    ])
+    def test_get_transceiver_status(self, mock_response, expected):
+        self.api.get_rx_los = MagicMock()
+        self.api.get_rx_los.return_value = mock_response[0]
+        self.api.get_tx_fault = MagicMock()
+        self.api.get_tx_fault.return_value = mock_response[1]
+        self.api.get_tx_disable_channel = MagicMock()
+        self.api.get_tx_disable_channel.return_value = mock_response[2]
+        self.api.get_tx_disable = MagicMock()
+        self.api.get_tx_disable.return_value = mock_response[3]
+        result = self.api.get_transceiver_status()
+        assert result == expected


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
All the related PRs for status CLI:
| Repo | PR Title | 
| --- | --- | 
| sonic-platform-common | [Move tx_disable/tx_disabled_channel/rx_los/tx_fault to get_transceiver_status API (cherry-pick to 202205) #395](https://github.com/sonic-net/sonic-platform-common/pull/395) | 
| sonic-utilities | [Add transceiver status CLI to show output from TRANSCEIVER_STATUS table (cherry-pick to 202205)](https://github.com/sonic-net/sonic-utilities/pull/2950) | 


#### Description
<!--
     Describe your changes in detail
-->
Cherry pick below PR [Move tx_disable/tx_disabled_channel/rx_los/tx_fault to get_transceiver_status API](https://github.com/sonic-net/sonic-platform-common/pull/359) to 202205 branch.
Auto-cherry-pick has conflicts.


#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Verified status CLI output on a testbed running 202205 sonic-buildimage with 100G/400G optics plugged in. 
[status_cli_202205_ut.txt](https://github.com/sonic-net/sonic-platform-common/files/12402460/status_cli_202205_ut.txt)

#### Additional Information (Optional)

