### PR TITLE
Handle NotImplementedError exception while calling get_eeprom_path API

### DIFF
--- a/sonic_platform_base/sonic_xcvr/sfp_optoe_base.py
+++ b/sonic_platform_base/sonic_xcvr/sfp_optoe_base.py
@@ -167,7 +167,10 @@ class SfpOptoeBase(SfpBase):
         return api.set_lpmode(lpmode) if api is not None else None
 
     def set_optoe_write_max(self, write_max):
-        sys_path = self.get_eeprom_path()
+        try:
+            sys_path = self.get_eeprom_path()
+        except NotImplementedError:
+            return
         sys_path = sys_path.replace("eeprom", "write_max")
         try:
             with open(sys_path, mode='w') as f:

--- a/tests/sonic_xcvr/test_sfp_optoe_base.py
+++ b/tests/sonic_xcvr/test_sfp_optoe_base.py
@@ -1,0 +1,10 @@
+from unittest.mock import patch
+from mock import MagicMock
+import pytest
+from sonic_platform_base.sonic_xcvr.sfp_optoe_base import SfpOptoeBase
+
+class TestSfpOptoeBase(object):
+    optoebase = SfpOptoeBase()
+
+    def test_set_optoe_write_max_with_exception(self):
+        self.optoebase.set_optoe_write_max(1)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
For platforms which do not implement get_eeprom_path API, NotImplementedError will be returned.
We need to handle such case and allow FW download to proceed since the corresponding platform may not support Optoe driver and would have get_eeprom_path not implemented.

https://github.com/sonic-net/sonic-platform-common/blob/master/sonic_platform_base/sonic_xcvr/sfp_optoe_base.py#L169

https://github.com/sonic-net/sonic-platform-common/blob/master/sonic_platform_base/sonic_xcvr/sfp_optoe_base.py#L148

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
Error seen while initiating FW download when get_eeprom_path is not defined

```
root@dut:/firmware# sfputil firmware download Ethernet144 fw.bin
CDB: Starting firmware download
Traceback (most recent call last):
  File "/usr/local/bin/sfputil", line 8, in <module>
    sys.exit(cli())
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.9/dist-packages/sfputil/main.py", line 1508, in download
    status = download_firmware(port_name, filepath)
  File "/usr/local/lib/python3.9/dist-packages/sfputil/main.py", line 1365, in download_firmware
    sfp.set_optoe_write_max(SMBUS_BLOCK_WRITE_SIZE)
  File "/usr/local/lib/python3.9/dist-packages/sonic_platform_base/sonic_xcvr/sfp_optoe_base.py", line 170, in set_optoe_write_max
    sys_path = self.get_eeprom_path()
  File "/usr/local/lib/python3.9/dist-packages/sonic_platform_base/sonic_xcvr/sfp_optoe_base.py", line 149, in get_eeprom_path
    raise NotImplementedError
NotImplementedError
root@dut:/firmware#
```

With the current change, "sfputil firmware download <port> <fw_path>" CLI will not exit due to exception and will be allowed to proceed further when get_eeprom_path is not implemented

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
The "sfputil firmware download <port> <fw_path>" CLI was verified successfully in the following scenarios
1. When get_eeprom_path API is implemented
2. When get_eeprom_path API is not implemented

#### Additional Information (Optional)

