### PR TITLE
Fix exception occurred during decode vendor name and vendor pn

### DIFF
--- a/sonic_platform_base/sonic_xcvr/xcvr_api_factory.py
+++ b/sonic_platform_base/sonic_xcvr/xcvr_api_factory.py
@@ -62,10 +62,10 @@ class XcvrApiFactory(object):
     def create_xcvr_api(self):
         # TODO: load correct classes from id_mapping file
         id = self._get_id()
-        vendor_name = self._get_vendor_name()
-        vendor_pn = self._get_vendor_part_num()
         # QSFP-DD or OSFP
         if id == 0x18 or id == 0x19 or id == 0x1e:
+            vendor_name = self._get_vendor_name()
+            vendor_pn = self._get_vendor_part_num()
             if vendor_name == 'Credo' and vendor_pn == 'CAC81X321M2MC1MS':
                 codes = CmisAec800gCodes
                 mem_map = CmisAec800gMemMap(CmisAec800gCodes)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
Fix exception occurred during decode vendor name and vendor pn. This exception occurs for non CMIS modules. The vendor name and vendor pn are at different offsets. 

#### Motivation and Context
fixes: https://github.com/sonic-net/sonic-buildimage/issues/16838

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)

