### PR TITLE
APIs to help in finding NPU SI settings

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -43,7 +43,7 @@ class CmisApi(XcvrApi):
         '''
         return self.xcvr_eeprom.read(consts.VENDOR_PART_NO_FIELD)
 
-    def get_cable_type(self):
+    def get_cable_length_type(self):
         '''
         This function returns the cable type of the module
         '''
@@ -171,7 +171,7 @@ class CmisApi(XcvrApi):
         xcvr_info['media_lane_count'] = self.get_media_lane_count()
         xcvr_info['host_lane_assignment_option'] = self.get_host_lane_assignment_option()
         xcvr_info['media_lane_assignment_option'] = self.get_media_lane_assignment_option()
-        xcvr_info['cable_type'] = self.get_cable_type()
+        xcvr_info['cable_type'] = self.get_cable_length_type()
         apsel_dict = self.get_active_apsel_hostlane()
         for lane in range(1, self.NUM_CHANNELS+1):
             xcvr_info["%s%d" % ("active_apsel_hostlane", lane)] = \

--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -43,6 +43,18 @@ class CmisApi(XcvrApi):
         '''
         return self.xcvr_eeprom.read(consts.VENDOR_PART_NO_FIELD)
 
+    def get_cable_type(self):
+        '''
+        This function returns the cable type of the module
+        '''
+        return "Length Cable Assembly(m)"
+
+    def get_cable_length(self):
+        '''
+        This function returns the cable length of the module
+        '''
+        return self.xcvr_eeprom.read(consts.LENGTH_ASSEMBLY_FIELD)
+
     def get_vendor_rev(self):
         '''
         This function returns the revision level for part number provided by vendor
@@ -146,7 +158,6 @@ class CmisApi(XcvrApi):
             "encoding": "N/A", # Not supported
             "ext_identifier": "%s (%sW Max)" % (power_class, max_power),
             "ext_rateselect_compliance": "N/A", # Not supported
-            "cable_type": "Length Cable Assembly(m)",
             "cable_length": float(admin_info[consts.LENGTH_ASSEMBLY_FIELD]),
             "nominal_bit_rate": 0, # Not supported
             "vendor_date": admin_info[consts.VENDOR_DATE_FIELD],
@@ -160,6 +171,7 @@ class CmisApi(XcvrApi):
         xcvr_info['media_lane_count'] = self.get_media_lane_count()
         xcvr_info['host_lane_assignment_option'] = self.get_host_lane_assignment_option()
         xcvr_info['media_lane_assignment_option'] = self.get_media_lane_assignment_option()
+        xcvr_info['cable_type'] = self.get_cable_type()
         apsel_dict = self.get_active_apsel_hostlane()
         for lane in range(1, self.NUM_CHANNELS+1):
             xcvr_info["%s%d" % ("active_apsel_hostlane", lane)] = \

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -32,6 +32,19 @@ class TestCmis(object):
         result = self.api.get_model()
         assert result == expected
 
+    def test_get_cable_type(self):
+        assert self.api.get_cable_type() == "Length Cable Assembly(m)"
+
+    @pytest.mark.parametrize("mock_response, expected", [
+        ("0.0", "0.0"),
+        ("1.2", "1.2")
+    ])
+    def test_get_cable_length(self, mock_response, expected):
+        self.api.xcvr_eeprom.read = MagicMock()
+        self.api.xcvr_eeprom.read.return_value = mock_response
+        result = self.api.get_cable_length()
+        assert result == expected
+
     @pytest.mark.parametrize("mock_response, expected", [
         ("0.0", "0.0"),
         ("1.2", "1.2")

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -32,8 +32,8 @@ class TestCmis(object):
         result = self.api.get_model()
         assert result == expected
 
-    def test_get_cable_type(self):
-        assert self.api.get_cable_type() == "Length Cable Assembly(m)"
+    def test_get_cable_length_type(self):
+        assert self.api.get_cable_length_type() == "Length Cable Assembly(m)"
 
     @pytest.mark.parametrize("mock_response, expected", [
         ("0.0", "0.0"),


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
This PR has definition of APIs to retrieve transceiver specific information.
The change set is part of implementation of the HLD [OA crash handling to reinitialize port through xcvrd](https://github.com/sonic-net/SONiC/pull/1432)

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Please refer to https://github.com/sonic-net/sonic-platform-daemons/pull/403 for the test results.

#### Additional Information (Optional)

