### PR TITLE
Fix the order of the SfpUtilHelper.logical (#415)

### DIFF
--- a/sonic_platform_base/sonic_sfp/sfputilhelper.py
+++ b/sonic_platform_base/sonic_sfp/sfputilhelper.py
@@ -90,7 +90,7 @@ class SfpUtilHelper(object):
             self.logical_to_asic[intf_name] = asic_inst
 
         self.logical.extend(logical)
-        self.logical = list(set(self.logical))
+        self.logical = list(OrderedDict.fromkeys(self.logical).keys())
         self.logical_to_physical.update(logical_to_physical)
         self.physical_to_logical.update(physical_to_logical)
 

--- a/tests/sfputilhelper_test.py
+++ b/tests/sfputilhelper_test.py
@@ -78,10 +78,11 @@ class TestSfpUtilHelper(object):
         sfputil_helper.read_porttab_mappings(self.port_config_file, 0)
 
         logical_port_list = sfputil_helper.logical
+
         assert len(logical_port_list) == len(PORT_LIST)
 
-        for logical_port_name in logical_port_list:
-            assert logical_port_name in PORT_LIST
+        for logical_port, port in zip(logical_port_list, PORT_LIST):
+            assert logical_port == port
 
 
     @mock.patch('portconfig.get_hwsku_file_name', mock.MagicMock(return_value=hwsku_json_file))
@@ -90,13 +91,15 @@ class TestSfpUtilHelper(object):
         sfputil_helper = sfputilhelper.SfpUtilHelper()
         sfputil_helper.logical = []
         sfputil_helper.logical_to_physical = {}
-        sfputil_helper.physical_to_logica = {}
+        sfputil_helper.physical_to_logical = {}
         sfputil_helper.read_all_porttab_mappings(self.platform_dir, 2)
         logical_port_list = sfputil_helper.logical
 
         assert len(logical_port_list) == len(PORT_LIST)
-        for logical_port_name in logical_port_list:
-            assert logical_port_name in PORT_LIST
+
+        for logical_port, port in zip(logical_port_list, PORT_LIST):
+            assert logical_port == port
+
         assert sfputil_helper.logical_to_physical == LOGICAL_TO_PHYSICAL
         assert sfputil_helper.physical_to_logical == PHYSICAL_TO_LOGICAL
 
@@ -104,14 +107,14 @@ class TestSfpUtilHelper(object):
 
         sfputil_helper.logical = []
         sfputil_helper.logical_to_physical = {}
-        sfputil_helper.physical_to_logica = {}
+        sfputil_helper.physical_to_logical = {}
         sfputil_helper.read_all_porttab_mappings(self.platform_json_dir, 2)
         logical_port_list = sfputil_helper.logical
 
         assert len(logical_port_list) == len(PORT_LIST)
 
-        for logical_port_name in logical_port_list:
-            assert logical_port_name in PORT_LIST
+        for logical_port, port in zip(logical_port_list, PORT_LIST):
+            assert logical_port == port
 
         assert sfputil_helper.logical_to_physical == LOGICAL_TO_PHYSICAL
         assert sfputil_helper.physical_to_logical == PHYSICAL_TO_LOGICAL


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description

* Fix the order of the SfpUtilHelper.logical
* Update test_read_port_mappings, test_read_all_port_mappings to check every port element to make sure the order is right
* Fix typo physical_to_logica -> physical_to_logical

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

Fix #415 

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

I've modified the test to check each port order is correct.

```
root@sonic:/home/admin# sfputil show eeprom
Ethernet0: SFP EEPROM detected
        Active App Selection Host Lane 1: N/A
        Active App Selection Host Lane 2: N/A
        Active App Selection Host Lane 3: N/A
        Active App Selection Host Lane 4: N/A
        Active App Selection Host Lane 5: N/A
        Active App Selection Host Lane 6: N/A
        Active App Selection Host Lane 7: N/A
        Active App Selection Host Lane 8: N/A
        Active Firmware Version: N/A
        Application Advertisement: 400G CR8 - Host Assign (0x1) - Copper cable - Media Assign (Unknown)
                                   200GBASE-CR4 (Clause 136) - Host Assign (0x11) - Copper cable - Media Assign (Unknown)
                                   100GBASE-CR2 (Clause 136) - Host Assign (0x55) - Copper cable - Media Assign (Unknown)
                                   50GBASE-CR (Clause 126) - Host Assign (0xff) - Copper cable - Media Assign (Unknown)
                                   100GBASE-CR4 (Clause 92) - Host Assign (0x11) - Copper cable - Media Assign (Unknown)
                                   25GBASE-CR CA-N (Clause 110) - Host Assign (0xff) - Copper cable - Media Assign (Unknown)
                                   25GBASE-CR CA-S (Clause 110) - Host Assign (0xff) - Copper cable - Media Assign (Unknown)
                                   25GBASE-CR CA-L (Clause 110) - Host Assign (0xff) - Copper cable - Media Assign (Unknown)
        CMIS Revision: 3.0
        Connector: No separable connector
        Encoding: N/A
        Extended Identifier: Power Class 1 (0.25W Max)
        Extended RateSelect Compliance: N/A
        Hardware Revision: 0.0
        Host Electrical Interface: N/A
        Host Lane Assignment Options: 1
        Host Lane Count: 8
        Identifier: QSFP-DD Double Density 8X Pluggable Transceiver
        Inactive Firmware Version: N/A
        Length Cable Assembly(m): 2.5
        Media Interface Code: Copper cable
        Media Interface Technology: Copper cable unequalized
        Media Lane Assignment Options: N/A
        Media Lane Count: 0
        Nominal Bit Rate(100Mbs): 0
        Specification compliance: passive_copper_media_interface
        Vendor Date Code(YYYY-MM-DD Lot): 2022-07-20
        Vendor Name: MITS
        Vendor OUI: 00-00-00
        Vendor PN: QDD/QDD-28-2.5
        Vendor Rev: 00
        Vendor SN: 202207080006
 
Ethernet8: SFP EEPROM not detected
 
Ethernet16: SFP EEPROM not detected
 
Ethernet24: SFP EEPROM not detected
 
Ethernet32: SFP EEPROM not detected
 
Ethernet40: SFP EEPROM detected
        Active App Selection Host Lane 1: N/A
        Active App Selection Host Lane 2: N/A
        Active App Selection Host Lane 3: N/A
        Active App Selection Host Lane 4: N/A
        Active App Selection Host Lane 5: N/A
        Active App Selection Host Lane 6: N/A
        Active App Selection Host Lane 7: N/A
        Active App Selection Host Lane 8: N/A
        Active Firmware Version: N/A
        Application Advertisement: 400GAUI-8 C2M (Annex 120E) - Host Assign (0x1) - Active Cable assembly with BER < 2.6x10^-4 - Media Assign (0x1)
                                   200GAUI-4 C2M (Annex 120E) - Host Assign (0x11) - Active Cable assembly with BER < 2.6x10^-4 - Media Assign (0x11)
                                   100GAUI-2 C2M (Annex 135G) - Host Assign (0x55) - Active Cable assembly with BER < 2.6x10^-4 - Media Assign (0x55)
                                   50GAUI-1 C2M (Annex 135G) - Host Assign (0xff) - Active Cable assembly with BER < 2.6x10^-4 - Media Assign (0xff)
        CMIS Revision: 4.0
        Connector: No separable connector
        Encoding: N/A
        Extended Identifier: Power Class 5 (10.0W Max)
        Extended RateSelect Compliance: N/A
        Hardware Revision: 1.0
        Host Electrical Interface: 400GAUI-8 C2M (Annex 120E)
        Host Lane Assignment Options: 1
        Host Lane Count: 8
        Identifier: QSFP-DD Double Density 8X Pluggable Transceiver
        Inactive Firmware Version: N/A
        Length Cable Assembly(m): 5.0
        Media Interface Code: Active Cable assembly with BER < 2.6x10^-4
        Media Interface Technology: 850 nm VCSEL
        Media Lane Assignment Options: 1
        Media Lane Count: 8
        Nominal Bit Rate(100Mbs): 0
        Specification compliance: active_cable_media_interface
        Vendor Date Code(YYYY-MM-DD Lot): 2022-10-19
        Vendor Name: Eoptolink
        Vendor OUI: 70-ee-a3
        Vendor PN: EOLD4HGPCT05451
        Vendor Rev: 01
        Vendor SN: DNAC340001
 
Ethernet48: SFP EEPROM not detected
 
Ethernet56: SFP EEPROM not detected
 
Ethernet64: SFP EEPROM not detected
 
Ethernet72: SFP EEPROM not detected
 
Ethernet80: SFP EEPROM not detected
 
Ethernet88: SFP EEPROM detected
        Application Advertisement: N/A
        Connector: No separable connector
        Encoding: Unspecified
        Extended Identifier: Power Class 1 Module (1.5W max.), No CLEI code present in Page 02h, No CDR in TX, No CDR in RX
        Extended RateSelect Compliance: Unknown
        Identifier: QSFP28 or later
        Length Cable Assembly(m): 3.0
        Nominal Bit Rate(100Mbs): 255
        Specification compliance:
                10/40G Ethernet Compliance Code: Extended
                Extended Specification Compliance: 100GBASE-CR4, 25GBASE-CR CA-25G-L or 50GBASE-CR2 with RS
                Fibre Channel Link Length: Unknown
                Fibre Channel Speed: Unknown
                Fibre Channel Transmission Media: Twin Axial Pair (TW)
                Fibre Channel Transmitter Technology: Unknown
                Gigabit Ethernet Compliant Codes: Unknown
                SAS/SATA Compliance Codes: Unknown
                SONET Compliance Codes: Unknown
        Vendor Date Code(YYYY-MM-DD Lot): 2022-08-29
        Vendor Name: OEM
        Vendor OUI: 00-00-00
        Vendor PN: Q28/Q28-30-3-H1
        Vendor Rev: E
        Vendor SN: 20220824-0087
 
Ethernet96: SFP EEPROM not detected
 
Ethernet104: SFP EEPROM not detected
 
Ethernet112: SFP EEPROM detected
        Application Advertisement: N/A
        Connector: No separable connector
        Encoding: Unspecified
        Extended Identifier: Unknown, No CLEI code present in Page 02h, No CDR in TX, No CDR in RX
        Extended RateSelect Compliance: Unknown
        Identifier: QSFP28 or later
        Unknown: 0.0
        Nominal Bit Rate(100Mbs): 255
        Specification compliance:
                10/40G Ethernet Compliance Code: Unknown
                Extended Specification Compliance: 100GBASE-CR4, 25GBASE-CR CA-25G-L or 50GBASE-CR2 with RS
                Fibre Channel Link Length: Short distance (S)
                Fibre Channel Speed: Unknown
                Fibre Channel Transmission Media: Twin Axial Pair (TW)
                Fibre Channel Transmitter Technology: Unknown
                Gigabit Ethernet Compliant Codes: Unknown
                SAS/SATA Compliance Codes: Unknown
                SONET Compliance Codes: Unknown
        Vendor Date Code(YYYY-MM-DD Lot): 2019-03-18
        Vendor Name: ALL BEST
        Vendor OUI: 00-00-00
        Vendor PN: R-LB-ZQ1-1CP7-01
        Vendor Rev: A
        Vendor SN: MAR1
 
Ethernet120: SFP EEPROM not detected
 
Ethernet128: SFP EEPROM not detected
 
Ethernet136: SFP EEPROM not detected
 
Ethernet144: SFP EEPROM not detected
 
Ethernet152: SFP EEPROM not detected
 
Ethernet160: SFP EEPROM not detected
 
Ethernet168: SFP EEPROM not detected
 
Ethernet176: SFP EEPROM detected
        Application Advertisement: N/A
        Connector: No separable connector
        Encoding: Unspecified
        Extended Identifier: Unknown, No CLEI code present in Page 02h, No CDR in TX, No CDR in RX
        Extended RateSelect Compliance: Unknown
        Identifier: QSFP28 or later
        Length Cable Assembly(m): 1.0
        Nominal Bit Rate(100Mbs): 255
        Specification compliance:
                10/40G Ethernet Compliance Code: Unknown
                Extended Specification Compliance: 100GBASE-CR4, 25GBASE-CR CA-25G-L or 50GBASE-CR2 with RS
                Fibre Channel Link Length: Short distance (S)
                Fibre Channel Speed: Unknown
                Fibre Channel Transmission Media: Twin Axial Pair (TW)
                Fibre Channel Transmitter Technology: Unknown
                Gigabit Ethernet Compliant Codes: Unknown
                SAS/SATA Compliance Codes: Unknown
                SONET Compliance Codes: Unknown
        Vendor Date Code(YYYY-MM-DD Lot): 2021-06-25
        Vendor Name:
        Vendor OUI: 00-00-00
        Vendor PN:
        Vendor Rev: 00
        Vendor SN: 202106000002
 
Ethernet184: SFP EEPROM not detected
 
Ethernet192: SFP EEPROM detected
        Application Advertisement: N/A
        Connector: No separable connector
        Encoding: 256B/257B (transcoded FEC-enabled data)
        Extended Identifier: Power Class 4 Module (3.5W max.), No CLEI code present in Page 02h, CDR present in TX, CDR present in RX
        Extended RateSelect Compliance: Unknown
        Identifier: QSFP28 or later
        Length Cable Assembly(m): 5.0
        Nominal Bit Rate(100Mbs): 255
        Specification compliance:
                10/40G Ethernet Compliance Code: Extended
                Extended Specification Compliance: 100G AOC (Active Optical Cable) or 25GAUI C2M AOC
                Fibre Channel Link Length: Unknown
                Fibre Channel Speed: Unknown
                Fibre Channel Transmission Media: Unknown
                Fibre Channel Transmitter Technology: Unknown
                Gigabit Ethernet Compliant Codes: Unknown
                SAS/SATA Compliance Codes: Unknown
                SONET Compliance Codes: Unknown
        Vendor Date Code(YYYY-MM-DD Lot): 2018-10-17
        Vendor Name: FINISAR CORP
        Vendor OUI: 00-90-65
        Vendor PN: FCBN425QE1C05
        Vendor Rev: A1
        Vendor SN: W0FAFY4
 
Ethernet200: SFP EEPROM not detected
 
Ethernet208: SFP EEPROM not detected
 
Ethernet216: SFP EEPROM not detected
 
Ethernet224: SFP EEPROM detected
        Active App Selection Host Lane 1: N/A
        Active App Selection Host Lane 2: N/A
        Active App Selection Host Lane 3: N/A
        Active App Selection Host Lane 4: N/A
        Active App Selection Host Lane 5: N/A
        Active App Selection Host Lane 6: N/A
        Active App Selection Host Lane 7: N/A
        Active App Selection Host Lane 8: N/A
        Active Firmware Version: N/A
        Application Advertisement: N/A
        CMIS Revision: 4.0
        Connector: Unknown or unspecified
        Encoding: N/A
        Extended Identifier: Power Class 8 (16.0W Max)
        Extended RateSelect Compliance: N/A
        Hardware Revision: 4.3
        Host Electrical Interface: Undefined
        Host Lane Assignment Options: 0
        Host Lane Count: 0
        Identifier: QSFP-DD Double Density 8X Pluggable Transceiver
        Inactive Firmware Version: N/A
        Length Cable Assembly(m): 0.0
        Media Interface Code: Unknown media interface
        Media Interface Technology: 850 nm VCSEL
        Media Lane Assignment Options: 0
        Media Lane Count: 0
        Nominal Bit Rate(100Mbs): 0
        Specification compliance: Undefined
        Vendor Date Code(YYYY-MM-DD Lot): 2019-09-17 01
        Vendor Name: MULTILANE
        Vendor OUI: 00-00-00
        Vendor PN: ML4062-SLB
        Vendor Rev: 6
        Vendor SN: 152058
 
Ethernet232: SFP EEPROM not detected
 
Ethernet240: SFP EEPROM not detected
 
Ethernet248: SFP EEPROM not detected
 
 
root@sonic:/home/admin# sfputil show error-status
Port         Error Status
-----------  --------------
Ethernet0    OK
Ethernet8    Unplugged
Ethernet16   Unplugged
Ethernet24   Unplugged
Ethernet32   Unplugged
Ethernet40   OK
Ethernet48   Unplugged
Ethernet56   Unplugged
Ethernet64   Unplugged
Ethernet72   Unplugged
Ethernet80   Unplugged
Ethernet88   OK
Ethernet96   Unplugged
Ethernet104  Unplugged
Ethernet112  OK
Ethernet120  Unplugged
Ethernet128  Unplugged
Ethernet136  Unplugged
Ethernet144  Unplugged
Ethernet152  Unplugged
Ethernet160  Unplugged
Ethernet168  Unplugged
Ethernet176  OK
Ethernet184  Unplugged
Ethernet192  OK
Ethernet200  Unplugged
Ethernet208  Unplugged
Ethernet216  Unplugged
Ethernet224  OK
Ethernet232  Unplugged
Ethernet240  Unplugged
Ethernet248  Unplugged
root@sonic:/home/admin#
root@sonic:/home/admin#
root@sonic:/home/admin#
root@sonic:/home/admin#
root@sonic:/home/admin#
root@sonic:/home/admin# sfputil show presence
Port         Presence
-----------  -----------
Ethernet0    Present
Ethernet8    Not present
Ethernet16   Not present
Ethernet24   Not present
Ethernet32   Not present
Ethernet40   Present
Ethernet48   Not present
Ethernet56   Not present
Ethernet64   Not present
Ethernet72   Not present
Ethernet80   Not present
Ethernet88   Present
Ethernet96   Not present
Ethernet104  Not present
Ethernet112  Present
Ethernet120  Not present
Ethernet128  Not present
Ethernet136  Not present
Ethernet144  Not present
Ethernet152  Not present
Ethernet160  Not present
Ethernet168  Not present
Ethernet176  Present
Ethernet184  Not present
Ethernet192  Present
Ethernet200  Not present
Ethernet208  Not present
Ethernet216  Not present
Ethernet224  Present
Ethernet232  Not present
Ethernet240  Not present
Ethernet248  Not present

root@sonic:/home/admin# sfputil show lpmode
Port         Low-power Mode
-----------  ----------------
Ethernet0    Off
Ethernet8    Off
Ethernet16   Off
Ethernet24   Off
Ethernet32   Off
Ethernet40   Off
Ethernet48   Off
Ethernet56   Off
Ethernet64   Off
Ethernet72   Off
Ethernet80   Off
Ethernet88   Off
Ethernet96   Off
Ethernet104  Off
Ethernet112  Off
Ethernet120  Off
Ethernet128  Off
Ethernet136  Off
Ethernet144  Off
Ethernet152  Off
Ethernet160  Off
Ethernet168  Off
Ethernet176  Off
Ethernet184  Off
Ethernet192  Off
Ethernet200  Off
Ethernet208  Off
Ethernet216  Off
Ethernet224  Off
Ethernet232  Off
Ethernet240  Off
Ethernet248  Off
root@sonic:/home/admin#
```

#### Additional Information (Optional)

