### PR TITLE
Adding supported vendor PNs for remote CDB FW upgrade

### DIFF
--- a/sonic_platform_base/sonic_xcvr/xcvr_api_factory.py
+++ b/sonic_platform_base/sonic_xcvr/xcvr_api_factory.py
@@ -34,6 +34,8 @@ VENDOR_PART_NUM_OFFSET = 148
 VENDOR_NAME_LENGTH = 16
 VENDOR_PART_NUM_LENGTH = 16
 
+CREDO_800G_AEC_VENDOR_PN_LIST = ["CAC81X321M2MC1MS", "CAC815321M2MC1MS", "CAC82X321M2MC1MS"]
+
 class XcvrApiFactory(object):
     def __init__(self, reader, writer):
         self.reader = reader
@@ -72,7 +74,7 @@ class XcvrApiFactory(object):
         if id == 0x18 or id == 0x19 or id == 0x1e:
             vendor_name = self._get_vendor_name()
             vendor_pn = self._get_vendor_part_num()
-            if vendor_name == 'Credo' and vendor_pn == 'CAC81X321M2MC1MS':
+            if vendor_name == 'Credo' and vendor_pn in CREDO_800G_AEC_VENDOR_PN_LIST:
                 codes = CmisAec800gCodes
                 mem_map = CmisAec800gMemMap(CmisAec800gCodes)
                 xcvr_eeprom = XcvrEeprom(self.reader, self.writer, mem_map)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
Currently, we just have the Vendor PN "CAC81X321M2MC1MS" for selecting target for CDB remote FW upgrade support.
We need to add vendor PNs "CAC815321M2MC1MS" and "CAC82X321M2MC1MS" for supporting remote FW upgrade for these transceivers.
Following error is seen while upgrading FW for remote sides
```
root@sonic:/home/admin# sfputil firmware target Ethernet224 1
Ethernet224: This functionality is not applicable for this module
root@sonic:/home/admin#
```

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
This will enable CDB remote FW upgrade support for the listed Vendor PNs

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
CDB FW upgrade was verified for all 3 sides of the cable (1 local and 2 remote sides).
```
Following output is captured after FW updgrade
root@sonic:/home/admin# sfputil firmware target Ethernet224 0
Target Mode set to 0
root@sonic:/home/admin# sfputil show fwversion Ethernet224
Image A Version: 0.3.5
Image B Version: 0.3.6
Factory Image Version: 0.0.0
Running Image: B
Committed Image: B
Active Firmware: 0.3.6
Inactive Firmware: 0.3.5

root@sonic:/home/admin# sfputil firmware target Ethernet224 1
Target Mode set to 1
root@sonic:/home/admin# sfputil show fwversion Ethernet224
Image A Version: 0.3.5
Image B Version: 0.3.6
Factory Image Version: 0.0.0
Running Image: B
Committed Image: B
Active Firmware: 0.3.6
Inactive Firmware: 0.3.5

root@sonic:/home/admin# sfputil firmware target Ethernet224 2
Target Mode set to 2
root@sonic:/home/admin# sfputil show fwversion Ethernet224
Image A Version: 0.3.5
Image B Version: 0.3.6
Factory Image Version: 0.0.0
Running Image: B
Committed Image: B
Active Firmware: 0.3.6
Inactive Firmware: 0.3.5

root@sonic:/home/admin#
```

#### Additional Information (Optional)
MSFT ADO - 26097760
