### PR TITLE
[202305] Implementing set_optoe_write_timeout API

### DIFF
--- a/sonic_platform_base/sonic_xcvr/sfp_optoe_base.py
+++ b/sonic_platform_base/sonic_xcvr/sfp_optoe_base.py
@@ -175,6 +175,15 @@ class SfpOptoeBase(SfpBase):
         except (OSError, IOError):
             pass
 
+    def set_optoe_write_timeout(self, write_timeout):
+        sys_path = self.get_eeprom_path()
+        sys_path = sys_path.replace("eeprom", "write_timeout")
+        try:
+            with open(sys_path, mode='w') as f:
+                f.write(str(write_timeout))
+        except (OSError, IOError):
+            pass
+
     def read_eeprom(self, offset, num_bytes):
         try:
             with open(self.get_eeprom_path(), mode='rb', buffering=0) as f:

--- a/tests/sonic_xcvr/test_sfp_optoe_base.py
+++ b/tests/sonic_xcvr/test_sfp_optoe_base.py
@@ -1,0 +1,41 @@
+from unittest.mock import mock_open
+from mock import patch 
+from sonic_platform_base.sonic_xcvr.sfp_optoe_base import SfpOptoeBase 
+
+class TestSfpOptoeBase(object): 
+ 
+    sfp_optoe_api = SfpOptoeBase() 
+ 
+    @patch("builtins.open", new_callable=mock_open)
+    @patch.object(SfpOptoeBase, 'get_eeprom_path')
+    def test_set_optoe_write_timeout_success(self, mock_get_eeprom_path, mock_open):
+        mock_get_eeprom_path.return_value = "/sys/bus/i2c/devices/1-0050/eeprom"
+        expected_path = "/sys/bus/i2c/devices/1-0050/write_timeout"
+        expected_timeout = 1
+
+        self.sfp_optoe_api.set_optoe_write_timeout(expected_timeout)
+
+        mock_open.assert_called_once_with(expected_path, mode='w')
+        mock_open().write.assert_called_once_with(str(expected_timeout))
+
+    @patch("builtins.open", new_callable=mock_open)
+    @patch.object(SfpOptoeBase, 'get_eeprom_path')
+    def test_set_optoe_write_timeout_ioerror(self, mock_get_eeprom_path, mock_open):
+        mock_get_eeprom_path.return_value = "/sys/bus/i2c/devices/1-0050/eeprom"
+        expected_timeout = 1
+        mock_open.side_effect = IOError
+
+        self.sfp_optoe_api.set_optoe_write_timeout(expected_timeout)
+
+        mock_open.assert_called()
+
+    @patch("builtins.open", new_callable=mock_open)
+    @patch.object(SfpOptoeBase, 'get_eeprom_path')
+    def test_set_optoe_write_timeout_oserror(self, mock_get_eeprom_path, mock_open):
+        mock_get_eeprom_path.return_value = "/sys/bus/i2c/devices/1-0050/eeprom"
+        expected_timeout = 1
+        mock_open.side_effect = OSError
+
+        self.sfp_optoe_api.set_optoe_write_timeout(expected_timeout)
+
+        mock_open.assert_called()


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
Cherry-pick for https://github.com/sonic-net/sonic-platform-common/pull/422

#### Description
<!--
     Describe your changes in detail
-->
We currently need to implement set_optoe_write_timeout API to dynamically change the write timeout value in optoe kernel driver.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
The API is planned to provide an interface to dynamically change the write_timeout value in optoe kernel driver through sysfs.
The sysfs creation is handled through https://github.com/sonic-net/sonic-linux-kernel/pull/370

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
```
Before changing value of write_timeout
root@sonic:/sys/bus/i2c/devices/31-0050# cat write_timeout 
25

After changing the write_timeout value through API
>>> platform_chassis.get_sfp(port_num).set_optoe_write_timeout(80)
>>> 

root@sonic:/sys/bus/i2c/devices/31-0050# cat write_timeout 
80
```

#### Additional Information (Optional)
ADO - 26145674
