### PR TITLE
Added a procfs check for pcie peripherals to verify device ID.

### DIFF
--- a/sonic_platform_base/sonic_pcie/pcie_common.py
+++ b/sonic_platform_base/sonic_pcie/pcie_common.py
@@ -96,10 +96,10 @@ class PcieUtil(PcieBase):
                 hexstring = binascii.hexlify(data).decode('ascii')
                 procfs_id = str(hexstring[-2:] + hexstring[:2])
                 if id == procfs_id: return True
-                else: log.log_info("PCIe device ID mismatch for {}:{}.{} - expected {}, got {}".format(bs, device, fn, id, procfs_id))
+                else: log.log_info("PCIe device ID mismatch for {}:{}.{} - expected {}, got {}".format(bus, device, fn, id, procfs_id))
                 return False
         except OSError as osex:
-            log.log_info("Ecountered {} while trying to open {}".format(str(osex), current_file))
+            log.log_warning("Ecountered {} while trying to open {}".format(str(osex), current_file))
             return False
 
 

--- a/sonic_platform_base/sonic_pcie/pcie_common.py
+++ b/sonic_platform_base/sonic_pcie/pcie_common.py
@@ -10,9 +10,14 @@ import sys
 from copy import deepcopy
 try:
     from .pcie_base import PcieBase
+    import binascii
+    from sonic_py_common import logger
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
+# Enable logging by classes and helper functions
+SYSLOG_IDENTIFIER = "PcieUtil"
+log = logger.Logger(SYSLOG_IDENTIFIER)
 
 class PcieUtil(PcieBase):
     """Platform-specific PCIEutil class"""
@@ -20,6 +25,7 @@ class PcieUtil(PcieBase):
     def __init__(self, path):
         self.config_path = path
         self._conf_rev = None
+        self.procfs_path = "/proc/bus/pci/"
 
     # load the config file
     def load_config_file(self):
@@ -29,8 +35,8 @@ class PcieUtil(PcieBase):
             with open(config_file) as conf_file:
                 self.confInfo = yaml.safe_load(conf_file)
         except IOError as e:
-            print("Error: {}".format(str(e)))
-            print("Not found config file, please add a config file manually, or generate it by running [pcieutil pcie_generate]")
+            log.log_error("Error: {}".format(str(e)))
+            log.log_error("Not found config file, please add a config file manually, or generate it by running [pcieutil pcie_generate]")
             sys.exit()
 
     # load current PCIe device
@@ -77,8 +83,25 @@ class PcieUtil(PcieBase):
                     pciList.append(pciDict)
                     pciDict = deepcopy(pciDict)
                 else:
-                    print("CAN NOT MATCH PCIe DEVICE")
+                    log.log_warning("CAN NOT MATCH PCIe DEVICE")
         return pciList
+
+    # Check device ID from procfs file check for each PCI device
+    def check_pcie_deviceid(self, bus="", device="", fn="", id=""):
+        current_file = os.path.join(self.procfs_path, bus, "{}.{}".format(device, fn))
+        try:
+            with open(current_file, 'rb') as f:
+                f.seek(2)
+                data = f.read(2)
+                hexstring = binascii.hexlify(data).decode('ascii')
+                procfs_id = str(hexstring[-2:] + hexstring[:2])
+                if id == procfs_id: return True
+                else: log.log_info("PCIe device ID mismatch for {}:{}.{} - expected {}, got {}".format(bs, device, fn, id, procfs_id))
+                return False
+        except OSError as osex:
+            log.log_info("Ecountered {} while trying to open {}".format(str(osex), current_file))
+            return False
+
 
     # check the sysfs tree for each PCIe device
     def check_pcie_sysfs(self, domain=0, bus=0, device=0, func=0):
@@ -93,8 +116,13 @@ class PcieUtil(PcieBase):
         for item_conf in self.confInfo:
             bus_conf = item_conf["bus"]
             dev_conf = item_conf["dev"]
-            fn_conf = item_conf["fn"]
-            if self.check_pcie_sysfs(bus=int(bus_conf, base=16), device=int(dev_conf, base=16), func=int(fn_conf, base=16)):
+            fn_conf  = item_conf["fn"]
+            id_conf  = item_conf["id"]
+
+            sysfs_check = self.check_pcie_sysfs(bus=int(bus_conf, base=16), device=int(dev_conf, base=16), func=int(fn_conf, base=16))
+            deviceid_check = self.check_pcie_deviceid(bus_conf, dev_conf, fn_conf, id_conf)
+
+            if sysfs_check and deviceid_check:
                 item_conf["result"] = "Passed"
             else:
                 item_conf["result"] = "Failed"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

This PR adds a procfs check for PCI peripherals. It provides a device ID check to ensure that the PCI peripherals match the pcie.yaml manifest, including undercutting PCI device hijack by other drivers that might change the device ID.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

The proc filesystem is an overlay filesystem that automatically takes care of PCI peripheral hotplug and disappearance at any given time. The motivation for this PR is to get ahead the 'ASIC missing' issue and provide a mechanism to auto-mitigate said issues. 

Fixes #191 


#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

Ran following tests:

1. Happy path
2. Mismatched vendor ID on existing device (modified pcie.yaml) and verified that it was picked up by pcied
3. Spoofed a PCI device (added to pcie.yaml) and verified that it was picked up by pcied

on the following HardwareSKUs:

1. Arista-7050CX3-32S-D48C8
2. Arista-7060CX-32S-D48C8
3. Arista-7260CX3-C64
4. Celestica-DX010-C32
5. Celestica-E1031-T48S4
6. Cisco-8101-O8C48
7. Cisco-8102-C64
8. Cisco-8111-O32
9. Force10-S6100
10. Mellanox-SN2700
11. Mellanox-SN3800-D112C8
12. Nexus-3164
13. Nokia-7215

#### Additional Information (Optional)

