### PR TITLE
Tx/Rx power values should be rounded up to 3 decimal places

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/xcvr_api.py
+++ b/sonic_platform_base/sonic_xcvr/api/xcvr_api.py
@@ -15,7 +15,7 @@ class XcvrApi(object):
             return float("-inf")
         elif mW < 0:
             return float("NaN")
-        return 10. * log10(mW)
+        return round(10. * log10(mW), 3)
 
     def get_model(self):
         """


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
It seems that currently, Tx/Rx power values are not rounded to a specific decimal value. We need to round the value up to 3 decimal places.
MSFT ADO - 26621895

Following is the snippet for the same
```
root@sonic:/host/Inphi# sfputil show eeprom -d -p Ethernet260
Ethernet260: SFP EEPROM detected
        Application Advertisement: N/A
        Connector: LC
        Encoding: 64B/66B
        Extended Identifier: GBIC/SFP defined by two-wire interface ID
        Extended RateSelect Compliance: Unknown
        Identifier: SFP/SFP+/SFP28
        Length OM3(10m): 30.0
        Nominal Bit Rate(100Mbs): 103
        Specification compliance:
                10G Ethernet Compliance: 10GBASE-SR
                ESCON Compliance: Unknown
                Ethernet Compliance: Unknown
                Fibre Channel Link Length: Unknown
                Fibre Channel Speed: Unknown
                Fibre Channel Transmission Media: Unknown
                Fibre Channel Transmitter Technology: Unknown
                Infiniband Compliance: Unknown
                SFP+CableTechnology: Unknown
                SONET Compliance Codes: Unknown
        Vendor Date Code(YYYY-MM-DD Lot): 2014-02-08  
        Vendor Name: FINISAR CORP.  
        Vendor OUI: 00-90-65
        Vendor PN: FTLX8571D3BCL  
        Vendor Rev: A  
        Vendor SN: AR62NDY        
        MonitorData:
                RXPower: -2.1824462534753115dBm
                TXBias: 7.46mA
                TXPower: -2.069083998234198dBm
                Temperature: 24.898C
                Vcc: 3.381Volts
        ThresholdData:
                TempHighAlarm  : 78.0C
                TempHighWarning: 73.0C
                TempLowAlarm   : -13.0C
                TempLowWarning : -8.0C
                VccHighAlarm   : 3.7Volts
                VccHighWarning : 3.6Volts
                VccLowAlarm    : 2.9Volts
                VccLowWarning  : 3.0Volts
                RxPowerHighAlarm  : 0.0dBm
                RxPowerHighWarning: -1.0dBm
                RxPowerLowAlarm   : -20.0dBm
                RxPowerLowWarning : -18.013dBm
                TxBiasHighAlarm   : 13.2mA
                TxBiasHighWarning : 12.6mA
                TxBiasLowAlarm    : 4.0mA
                TxBiasLowWarning  : 5.0mA
                TxPowerHighAlarm  : 0.0dBm
                TxPowerHighWarning: -1.0dBm
                TxPowerLowAlarm   : -6.0dBm
                TxPowerLowWarning : -5.0dBm


root@sonic:/host/Inphi#
```

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
This issue was introduced with https://github.com/sonic-net/sonic-platform-common/pull/377 wherein the function `mw_to_dbm` was called for different types of SFPs.
However, the function `mw_to_dbm` doesn't perform rounding of the values and hence, the TX and RX power show with more precision.

Hence, I have now modified the function `mw_to_dbm` to round values up to 3 decimal places.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
The commands `sfputil show eeprom -d -p PORT_NAME` and `show interfaces transceiver eeprom -d PORT_NAME` were tested on the following types of transceivers and Tx/Rx power values were ensured to be within 3 digits.
1. CMIS
2. QSFP28 
3. QSFP+ (40G)
4. SFP+ (10G)

Following is the snippet of SFP+ testing
```
root@sonic:/home/admin# sfputil show eeprom -d -p $port_name
Ethernet256: SFP EEPROM detected
        Application Advertisement: N/A
        Connector: LC
        Encoding: 64B/66B
        Extended Identifier: GBIC/SFP defined by two-wire interface ID
        Extended RateSelect Compliance: Unknown
        Identifier: SFP/SFP+/SFP28
        Length OM3(10m): 30.0
        Nominal Bit Rate(100Mbs): 103
        Specification compliance:
                10G Ethernet Compliance: 10GBASE-SR
                ESCON Compliance: Unknown
                Ethernet Compliance: Unknown
                Fibre Channel Link Length: Unknown
                Fibre Channel Speed: Unknown
                Fibre Channel Transmission Media: Unknown
                Fibre Channel Transmitter Technology: Unknown
                Infiniband Compliance: Unknown
                SFP+CableTechnology: Unknown
                SONET Compliance Codes: Unknown
        Vendor Date Code(YYYY-MM-DD Lot): 2009-06-27   
        Vendor Name: FINISAR CORP.   
        Vendor OUI: 00-90-65
        Vendor PN: FTLX8571D3BCL   
        Vendor Rev: A   
        Vendor SN: UFS073Z         
        MonitorData:
                RXPower: -1.752dBm
                TXBias: 7.486mA
                TXPower: -2.749dBm
                Temperature: 28.457C
                Vcc: 3.38Volts
        ThresholdData:
                TempHighAlarm  : 78.0C
                TempHighWarning: 73.0C
                TempLowAlarm   : -13.0C
                TempLowWarning : -8.0C
                VccHighAlarm   : 3.7Volts
                VccHighWarning : 3.6Volts
                VccLowAlarm    : 2.9Volts
                VccLowWarning  : 3.0Volts
                RxPowerHighAlarm  : 0.0dBm
                RxPowerHighWarning: -1.0dBm
                RxPowerLowAlarm   : -20.0dBm
                RxPowerLowWarning : -18.013dBm
                TxBiasHighAlarm   : 11.8mA
                TxBiasHighWarning : 10.8mA
                TxBiasLowAlarm    : 4.0mA
                TxBiasLowWarning  : 5.0mA
                TxPowerHighAlarm  : -0.8dBm
                TxPowerHighWarning: -1.8dBm
                TxPowerLowAlarm   : -6.0dBm
                TxPowerLowWarning : -5.0dBm

root@sonic:/home/admin# show interfaces transceiver eeprom -d $port_name
Ethernet256: SFP EEPROM detected
        Application Advertisement: N/A
        Connector: LC
        Encoding: 64B/66B
        Extended Identifier: GBIC/SFP defined by two-wire interface ID
        Extended RateSelect Compliance: Unknown
        Identifier: SFP/SFP+/SFP28
        Length OM3(10m): 30.0
        Nominal Bit Rate(100Mbs): 103
        Specification compliance:
                10G Ethernet Compliance: 10GBASE-SR
                ESCON Compliance: Unknown
                Ethernet Compliance: Unknown
                Fibre Channel Link Length: Unknown
                Fibre Channel Speed: Unknown
                Fibre Channel Transmission Media: Unknown
                Fibre Channel Transmitter Technology: Unknown
                Infiniband Compliance: Unknown
                SFP+CableTechnology: Unknown
                SONET Compliance Codes: Unknown
        Vendor Date Code(YYYY-MM-DD Lot): 2009-06-27   
        Vendor Name: FINISAR CORP.   
        Vendor OUI: 00-90-65
        Vendor PN: FTLX8571D3BCL   
        Vendor Rev: A   
        Vendor SN: UFS073Z         
        MonitorData:
                RXPower: -1.713dBm
                TXBias: 7.472mA
                TXPower: -2.774dBm
                Temperature: 29.371C
                Vcc: 3.38Volts
        ThresholdData:
                TempHighAlarm  : 78.0C
                TempHighWarning: 73.0C
                TempLowAlarm   : -13.0C
                TempLowWarning : -8.0C
                VccHighAlarm   : 3.7Volts
                VccHighWarning : 3.6Volts
                VccLowAlarm    : 2.9Volts
                VccLowWarning  : 3.0Volts
                RxPowerHighAlarm  : 0.0dBm
                RxPowerHighWarning: -1.0dBm
                RxPowerLowAlarm   : -20.0dBm
                RxPowerLowWarning : -18.013dBm
                TxBiasHighAlarm   : 11.8mA
                TxBiasHighWarning : 10.8mA
                TxBiasLowAlarm    : 4.0mA
                TxBiasLowWarning  : 5.0mA
                TxPowerHighAlarm  : -0.8dBm
                TxPowerHighWarning: -1.8dBm
                TxPowerLowAlarm   : -6.0dBm
                TxPowerLowWarning : -5.0dBm
root@sonic:/home/admin#
```
#### Additional Information (Optional)

