### PR TITLE
Change get_transceiver_info_firmware_versions return type to dict

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -181,8 +181,6 @@ class CmisApi(XcvrApi):
         xcvr_info['cmis_rev'] = self.get_cmis_rev()
         xcvr_info['specification_compliance'] = self.get_module_media_type()
 
-        xcvr_info['active_firmware'], xcvr_info['inactive_firmware'] = self.get_transceiver_info_firmware_versions()
-
         # In normal case will get a valid value for each of the fields. If get a 'None' value
         # means there was a failure while reading the EEPROM, either because the EEPROM was
         # not ready yet or experincing some other issues. It shouldn't return a dict with a
@@ -194,15 +192,18 @@ class CmisApi(XcvrApi):
             return xcvr_info
 
     def get_transceiver_info_firmware_versions(self):
+        return_dict = {"active_firmware" : "N/A", "inactive_firmware" : "N/A"}
         result = self.get_module_fw_info()
         if result is None:
-            return ["N/A", "N/A"]
+            return return_dict
         try:
             ( _, _, _, _, _, _, _, _, ActiveFirmware, InactiveFirmware) = result['result']
         except (ValueError, TypeError):
-            return ["N/A", "N/A"]
-
-        return [ActiveFirmware, InactiveFirmware]
+            return return_dict
+        
+        return_dict["active_firmware"] = ActiveFirmware
+        return_dict["inactive_firmware"] = InactiveFirmware
+        return return_dict
 
     def get_transceiver_bulk_status(self):
         temp = self.get_module_temperature()

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -1294,9 +1294,7 @@ class TestCmis(object):
                 'nominal_bit_rate': 0,
                 'specification_compliance': 'sm_media_interface',
                 'application_advertisement': 'N/A',
-                'active_firmware': '0.3.0',
                 'media_lane_count': 1,
-                'inactive_firmware': '0.2.0',
                 'vendor_rev': '0.0',
                 'host_electrical_interface': '400GAUI-8 C2M (Annex 120E)',
                 'vendor_oui': 'xx-xx-xx',
@@ -2374,13 +2372,19 @@ class TestCmis(object):
                 assert 0, traceback.format_exc()
             run_num -= 1
 
-    def test_get_transceiver_info_firmware_versions_negative_tests(self):
+    def test_get_transceiver_info_firmware_versions(self):
         self.api.get_module_fw_info = MagicMock()
         self.api.get_module_fw_info.return_value = None
+        expected_result = {"active_firmware" : "N/A", "inactive_firmware" : "N/A"}
         result = self.api.get_transceiver_info_firmware_versions()
-        assert result == ["N/A", "N/A"]
+        assert result == expected_result
 
         self.api.get_module_fw_info = MagicMock()
         self.api.get_module_fw_info.side_effect = {'result': TypeError}
         result = self.api.get_transceiver_info_firmware_versions()
-        assert result == ["N/A", "N/A"]
+        assert result == expected_result
+
+        expected_result = {"active_firmware" : "2.0.0", "inactive_firmware" : "1.0.0"}
+        self.api.get_module_fw_info.side_effect = [{'result': ( '', '', '', '', '', '', '', '','2.0.0', '1.0.0')}]
+        result = self.api.get_transceiver_info_firmware_versions()
+        assert result == expected_result


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
Modify the return type of `get_transceiver_info_firmware_versions` API to dictionary.
Also, remove the `active_firmware` and `inactive_firmware` fields from `get_transceiver_info` since xcvrd is now using TRANSCEIVER_FIRMWARE_INFO table to store these values.
MSFT ADO - 26788561

This PR should be merged along with https://github.com/sonic-net/sonic-platform-daemons/pull/435 and https://github.com/sonic-net/sonic-mgmt/pull/11708.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
This changeset is required to store  `active_firmware` and `inactive_firmware` fields to TRANSCEVIER_FIRMWARE_INFO table in xcvrd.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Please refer to the test result details added in https://github.com/sonic-net/sonic-platform-daemons/pull/435

#### Additional Information (Optional)

