### PR TITLE
Fix xcvrd crash when CMIS cable is flat memory

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -14,7 +14,7 @@ from ...codes.public.sff8024 import Sff8024
 from ...fields import consts
 from ..xcvr_api import XcvrApi
 from .cmisCDB import CmisCdbApi
-from .cmisVDM import CmisVdmApi
+from .cmisVDM import CmisVdmApi, VDM_REAL_VALUE, VDM_THRESHOLD, VDM_FLAG, ALL_FIELD
 import time
 from collections import defaultdict
 
@@ -230,7 +230,7 @@ class CmisApi(XcvrApi):
             bulk_status["tx%dpower" % i] = float("{:.3f}".format(self.mw_to_dbm(tx_power[i - 1]))) if tx_power[i - 1] != 'N/A' else 'N/A'
 
         laser_temp_dict = self.get_laser_temperature()
-        self.vdm_dict = self.get_vdm(self.vdm.VDM_REAL_VALUE)
+        self.vdm_dict = self.get_vdm(VDM_REAL_VALUE)
         try:
             bulk_status['laser_temperature'] = laser_temp_dict['monitor value']
             bulk_status['prefec_ber'] = self.vdm_dict['Pre-FEC BER Average Media Input'][1][0]
@@ -303,7 +303,7 @@ class CmisApi(XcvrApi):
             threshold_info_dict['lasertemplowwarning'] = laser_temp_dict['low warn']
         except (KeyError, TypeError):
             pass
-        self.vdm_dict = self.get_vdm(self.vdm.VDM_THRESHOLD)
+        self.vdm_dict = self.get_vdm(VDM_THRESHOLD)
         try:
             threshold_info_dict['prefecberhighalarm'] = self.vdm_dict['Pre-FEC BER Average Media Input'][1][1]
             threshold_info_dict['prefecberlowalarm'] = self.vdm_dict['Pre-FEC BER Average Media Input'][1][2]
@@ -1137,7 +1137,7 @@ class CmisApi(XcvrApi):
         This function returns all the VDM items, including real time monitor value, threholds and flags
         '''
         if field_option is None:
-            field_option = self.vdm.ALL_FIELD
+            field_option = ALL_FIELD
         vdm = self.vdm.get_vdm_allpage(field_option) if self.vdm is not None else {}
         return vdm
 
@@ -1862,7 +1862,7 @@ class CmisApi(XcvrApi):
                     trans_status['txbiaslowalarm_flag%d' % lane] = tx_bias_flag_dict['tx_bias_low_alarm']['TxBiasLowAlarmFlag%d' % lane]
                     trans_status['txbiashighwarning_flag%d' % lane] = tx_bias_flag_dict['tx_bias_high_warn']['TxBiasHighWarnFlag%d' % lane]
                     trans_status['txbiaslowwarning_flag%d' % lane] = tx_bias_flag_dict['tx_bias_low_warn']['TxBiasLowWarnFlag%d' % lane]
-            self.vdm_dict = self.get_vdm(self.vdm.VDM_FLAG)
+            self.vdm_dict = self.get_vdm(VDM_FLAG)
             try:
                 trans_status['prefecberhighalarm_flag'] = self.vdm_dict['Pre-FEC BER Average Media Input'][1][5]
                 trans_status['prefecberlowalarm_flag'] = self.vdm_dict['Pre-FEC BER Average Media Input'][1][6]

--- a/sonic_platform_base/sonic_xcvr/api/public/cmisVDM.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmisVDM.py
@@ -17,12 +17,12 @@ VDM_FLAG_PAGE = 0x2c
 VDM_FREEZE = 128
 VDM_UNFREEZE = 0
 
-class CmisVdmApi(XcvrApi):
+VDM_REAL_VALUE = 0x1
+VDM_THRESHOLD = 0x2
+VDM_FLAG = 0x4
+ALL_FIELD = 0xff
 
-    VDM_REAL_VALUE = 0x1
-    VDM_THRESHOLD = 0x2
-    VDM_FLAG = 0x4
-    ALL_FIELD = 0xff
+class CmisVdmApi(XcvrApi):
 
     def __init__(self, xcvr_eeprom):
         super(CmisVdmApi, self).__init__(xcvr_eeprom)
@@ -86,7 +86,7 @@ class CmisVdmApi(XcvrApi):
             vdm_high_warn_offset = vdm_high_alarm_offset + 4
             vdm_low_warn_offset = vdm_high_alarm_offset + 6
 
-            if field_option & self.VDM_REAL_VALUE:
+            if field_option & VDM_REAL_VALUE:
                 vdm_value_raw = self.xcvr_eeprom.read_raw(vdm_value_offset, VDM_SIZE, True)
                 if not vdm_value_raw:
                     continue
@@ -102,7 +102,7 @@ class CmisVdmApi(XcvrApi):
             else:
                 vdm_value = None
 
-            if field_option & self.VDM_THRESHOLD:
+            if field_option & VDM_THRESHOLD:
                 vdm_thrsh_raw = self.xcvr_eeprom.read_raw(vdm_high_alarm_offset, VDM_SIZE*4, True)
                 if not vdm_thrsh_raw:
                     continue
@@ -201,7 +201,7 @@ class CmisVdmApi(XcvrApi):
         VDM_START_PAGE = 0x20
         vdm = dict()
 
-        if field_option & self.VDM_FLAG:
+        if field_option & VDM_FLAG:
             vdm_flag_page = self.xcvr_eeprom.read_raw(VDM_FLAG_PAGE * PAGE_SIZE + PAGE_OFFSET, PAGE_SIZE)
         else:
             vdm_flag_page = None

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -1095,22 +1095,24 @@ class TestCmis(object):
     @pytest.mark.parametrize("mock_response, expected",[
         (
             [
-                True,
+                False,
                 {'Pre-FEC BER Average Media Input': {1: [0.001, 0.0125, 0, 0.01, 0, False, False, False, False]}},
             ],
             {'Pre-FEC BER Average Media Input': {1: [0.001, 0.0125, 0, 0.01, 0, False, False, False, False]}}
         ),
         (
-            [False, {}], {}
+            [True, {}], {}
         )
     ])
     def test_get_vdm(self, mock_response, expected):
-        self.api.get_vdm_support = MagicMock()
-        self.api.get_vdm_support.return_value = mock_response[0]
-        self.api.vdm = MagicMock()
-        self.api.vdm.get_vdm_allpage = MagicMock()
-        self.api.vdm.get_vdm_allpage.return_value = mock_response[1]
-        result = self.api.get_vdm()
+        eeprom = MagicMock()
+        eeprom.read = MagicMock()
+        eeprom.read.return_value = mock_response[0]
+        api = CmisApi(eeprom)
+        if api.vdm:
+            api.vdm.get_vdm_allpage = MagicMock()
+            api.vdm.get_vdm_allpage.return_value = mock_response[1]
+        result = api.get_vdm()
         assert result == expected
 
     @pytest.mark.parametrize("mock_response, expected", [


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
Fix https://github.com/sonic-net/sonic-buildimage/issues/18468
xcvrd crashes due to PR https://github.com/sonic-net/sonic-platform-common/pull/397.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Insert CMIS cable with flat memory

#### Additional Information (Optional)

