### PR TITLE
DPinit timeout seen for Innolight transceiver during CMIS init + transceiver OIR causing CMIS init failure

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/innolight/fr8_800g.py
+++ b/sonic_platform_base/sonic_xcvr/api/innolight/fr8_800g.py
@@ -9,7 +9,11 @@ from ..public.cmis import CmisApi
 
 class CmisFr8800gApi(CmisApi):
     def get_transceiver_info_firmware_versions(self):
-        InactiveFirmware = self.get_module_inactive_firmware() + ".0"
-        ActiveFirmware = self.get_module_active_firmware() + ".0"
+        return_dict = {"active_firmware" : "N/A", "inactive_firmware" : "N/A"}
+        
+        InactiveFirmware = self.get_module_inactive_firmware()
+        ActiveFirmware = self.get_module_active_firmware()
 
-        return [ActiveFirmware, InactiveFirmware]
+        return_dict["active_firmware"] = ActiveFirmware + ".0"
+        return_dict["inactive_firmware"] = InactiveFirmware + ".0"
+        return return_dict

--- a/sonic_platform_base/sonic_xcvr/api/innolight/fr8_800g.py
+++ b/sonic_platform_base/sonic_xcvr/api/innolight/fr8_800g.py
@@ -1,0 +1,15 @@
+"""
+    fr8_800g.py
+
+    Implementation of Innolight FR8 module specific in addition to the CMIS specification.
+"""
+
+from ...fields import consts
+from ..public.cmis import CmisApi
+
+class CmisFr8800gApi(CmisApi):
+    def get_transceiver_info_firmware_versions(self):
+        InactiveFirmware = self.get_module_inactive_firmware() + ".0"
+        ActiveFirmware = self.get_module_active_firmware() + ".0"
+
+        return [ActiveFirmware, InactiveFirmware]

--- a/sonic_platform_base/sonic_xcvr/api/innolight/fr_800g.py
+++ b/sonic_platform_base/sonic_xcvr/api/innolight/fr_800g.py
@@ -1,13 +1,13 @@
 """
-    fr8_800g.py
+    fr_800g.py
 
-    Implementation of Innolight FR8 module specific in addition to the CMIS specification.
+    Implementation of Innolight FR module specific in addition to the CMIS specification.
 """
 
 from ...fields import consts
 from ..public.cmis import CmisApi
 
-class CmisFr8800gApi(CmisApi):
+class CmisFr800gApi(CmisApi):
     def get_transceiver_info_firmware_versions(self):
         return_dict = {"active_firmware" : "N/A", "inactive_firmware" : "N/A"}
         

--- a/sonic_platform_base/sonic_xcvr/xcvr_api_factory.py
+++ b/sonic_platform_base/sonic_xcvr/xcvr_api_factory.py
@@ -17,6 +17,8 @@ from .codes.credo.aec_800g import CmisAec800gCodes
 from .api.credo.aec_800g import CmisAec800gApi
 from .mem_maps.credo.aec_800g import CmisAec800gMemMap
 
+from .api.innolight.fr8_800g import CmisFr8800gApi
+
 from .codes.public.sff8436 import Sff8436Codes
 from .api.public.sff8436 import Sff8436Api
 from .mem_maps.public.sff8436 import Sff8436MemMap
@@ -79,6 +81,11 @@ class XcvrApiFactory(object):
                 mem_map = CmisAec800gMemMap(CmisAec800gCodes)
                 xcvr_eeprom = XcvrEeprom(self.reader, self.writer, mem_map)
                 api = CmisAec800gApi(xcvr_eeprom)
+            elif vendor_name == 'CISCO-INNOLIGHT' and vendor_pn == 'T-DH8CNT-NCI':
+                codes = CmisCodes
+                mem_map = CmisMemMap(codes)
+                xcvr_eeprom = XcvrEeprom(self.reader, self.writer, mem_map)
+                api = CmisFr8800gApi(xcvr_eeprom)
             else:
                 codes = CmisCodes
                 mem_map = CmisMemMap(codes)

--- a/sonic_platform_base/sonic_xcvr/xcvr_api_factory.py
+++ b/sonic_platform_base/sonic_xcvr/xcvr_api_factory.py
@@ -17,7 +17,7 @@ from .codes.credo.aec_800g import CmisAec800gCodes
 from .api.credo.aec_800g import CmisAec800gApi
 from .mem_maps.credo.aec_800g import CmisAec800gMemMap
 
-from .api.innolight.fr8_800g import CmisFr8800gApi
+from .api.innolight.fr_800g import CmisFr800gApi
 
 from .codes.public.sff8436 import Sff8436Codes
 from .api.public.sff8436 import Sff8436Api
@@ -85,7 +85,7 @@ class XcvrApiFactory(object):
                 codes = CmisCodes
                 mem_map = CmisMemMap(codes)
                 xcvr_eeprom = XcvrEeprom(self.reader, self.writer, mem_map)
-                api = CmisFr8800gApi(xcvr_eeprom)
+                api = CmisFr800gApi(xcvr_eeprom)
             else:
                 codes = CmisCodes
                 mem_map = CmisMemMap(codes)

--- a/tests/sonic_xcvr/test_fr_800g.py
+++ b/tests/sonic_xcvr/test_fr_800g.py
@@ -1,0 +1,27 @@
+from unittest.mock import patch
+from mock import MagicMock
+import pytest
+
+from sonic_platform_base.sonic_xcvr.api.public.cmis import CmisApi
+from sonic_platform_base.sonic_xcvr.mem_maps.public.cmis import CmisMemMap
+from sonic_platform_base.sonic_xcvr.xcvr_eeprom import XcvrEeprom
+from sonic_platform_base.sonic_xcvr.codes.public.cmis import CmisCodes
+from sonic_platform_base.sonic_xcvr.fields import consts
+from sonic_platform_base.sonic_xcvr.api.innolight.fr_800g import CmisFr800gApi
+
+class TestCmisFr800gApi(object):
+    codes = CmisCodes
+    mem_map = CmisMemMap(codes)
+    reader = MagicMock(return_value=None)
+    writer = MagicMock()
+    eeprom = XcvrEeprom(reader, writer, mem_map)
+    api = CmisFr800gApi(eeprom)
+
+    def test_get_transceiver_info_firmware_versions(self):
+        self.api.get_module_inactive_firmware = MagicMock()
+        self.api.get_module_inactive_firmware.return_value = "1.0"
+        self.api.get_module_active_firmware = MagicMock()
+        self.api.get_module_active_firmware.return_value = "1.1"
+        expected_result = {"active_firmware" : "1.1.0", "inactive_firmware" : "1.0.0"}
+        result = self.api.get_transceiver_info_firmware_versions()
+        assert result == expected_result

--- a/tests/sonic_xcvr/test_xcvr_api_factory.py
+++ b/tests/sonic_xcvr/test_xcvr_api_factory.py
@@ -6,6 +6,7 @@ from sonic_platform_base.sonic_xcvr.api.credo.aec_800g import CmisAec800gApi
 from sonic_platform_base.sonic_xcvr.mem_maps.credo.aec_800g import CmisAec800gMemMap
 from sonic_platform_base.sonic_xcvr.xcvr_eeprom import XcvrEeprom
 from sonic_platform_base.sonic_xcvr.codes.credo.aec_800g import CmisAec800gCodes
+from sonic_platform_base.sonic_xcvr.api.innolight.fr_800g import CmisFr800gApi
 from sonic_platform_base.sonic_xcvr.fields import consts
 from sonic_platform_base.sonic_xcvr.xcvr_api_factory import XcvrApiFactory
 from sonic_platform_base.sonic_xcvr.api.public.sff8636 import Sff8636Api
@@ -51,6 +52,16 @@ class TestXcvrApiFactory(object):
         CmisAec800gMemMap = MagicMock()
         XcvrEeprom = MagicMock()
         CmisAec800gApi = MagicMock()
+        self.api.create_xcvr_api()
+
+    @patch('sonic_platform_base.sonic_xcvr.xcvr_api_factory.XcvrApiFactory._get_vendor_name', MagicMock(return_value='CISCO-INNOLIGHT'))
+    @patch('sonic_platform_base.sonic_xcvr.xcvr_api_factory.XcvrApiFactory._get_vendor_part_num', MagicMock(return_value='T-DH8CNT-NCI'))
+    def test_create_xcvr_api(self):
+        self.api.reader = self.mock_reader
+        CmisCodes = MagicMock()
+        CmisMemMap = MagicMock()
+        XcvrEeprom = MagicMock()
+        CmisFr800gApi = MagicMock()
         self.api.create_xcvr_api()
 
     @pytest.mark.parametrize("reader, expected_api", [


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
DPinit timeout seen for Innolight transceiver during CMIS init + transceiver OIR causing CMIS init failure

This is caused in Cisco-Innolight because of continuous calls to CDB infra from SFPUpdate Thread while updating FW info.
In Cisco-Innolight CDB runs at foreground getting continuous NACKS to CDB calls and this is causing it to miss some CMIS calls also. 

Fix is to read FW info from eeprom page data rather than reading from CDB for Cisco_innolight only

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
Will update soon

#### Additional Information (Optional)

