### PR TITLE
Fix the temperature parsing issue on swissbit SSD

### DIFF
--- a/sonic_platform_base/sonic_ssd/ssd_generic.py
+++ b/sonic_platform_base/sonic_ssd/ssd_generic.py
@@ -183,7 +183,7 @@ class SsdUtil(SsdBase):
             if temp_raw == NOT_AVAILABLE:
                 self.temperature = NOT_AVAILABLE
             else:
-                self.temperature = temp_raw.split()[-3]
+                self.temperature = temp_raw.split()[8]
 
     def parse_transcend_info(self):
         if self.vendor_ssd_info:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
Fix the temperature parsing issue on Swissbit SSD

#### Motivation and Context
current implementation parsing the temperature from the end of the line(attributes 194), it assumes the output should always have "(Min/Max -1/44)"

```
193 Unknown_SSD_Attribute   0x0012   100   100   000    Old_age   Always       -       0
194 Temperature_Celsius     0x0023   100   100   000    Pre-fail  Always       -       25 (Min/Max -1/44)
195 Hardware_ECC_Recovered  0x0012   100   100   000    Old_age   Always       -       0
```

But in some cases, there could be no Min and Max value in the output, like the following, so paring from the beginning will be more robust.
```
193 Unknown_SSD_Attribute   0x0012   100   100   000    Old_age   Always       -       0
194 Temperature_Celsius     0x0023   100   100   000    Pre-fail  Always       -       25 
195 Hardware_ECC_Recovered  0x0012   100   100   000    Old_age   Always       -       0
```

#### How Has This Been Tested?
run a test with Swissbit SSD to make sure SSD temperature can be parsed correctly.

#### Additional Information (Optional)

