### PR TITLE
fix: using PAGE_LENGTH instead of INIT_OFFSET

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/cmisCDB.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmisCDB.py
@@ -363,7 +363,7 @@ class CmisCdbApi(XcvrApi):
                     datachunk = data[PAGE_LENGTH*pageoffset : PAGE_LENGTH*(pageoffset + 1)]
                     self.xcvr_eeprom.write_raw(next_page*PAGE_LENGTH+INIT_OFFSET, PAGE_LENGTH, datachunk)
                 else:
-                    datachunk = data[INIT_OFFSET*pageoffset : ]
+                    datachunk = data[PAGE_LENGTH*pageoffset : ]
                     self.xcvr_eeprom.write_raw(next_page*PAGE_LENGTH+INIT_OFFSET, len(datachunk), datachunk)
         else:
             sections = epl_len // writelength


### PR DESCRIPTION
#### Description
https://github.com/sonic-net/sonic-platform-common/blob/2606cd5fb0a58fc956577602235a9f8f84a887c6/sonic_platform_base/sonic_xcvr/api/public/cmisCDB.py#L360-L367
here, on line 363 uses `PAGE_LENGTH`, but on line 366 uses `INIT_OFFSET`. This must be an oversight。
Although the two values are equal, they are semantically different.

#### Motivation and Context
None

#### Additional Information (Optional)