### PR TITLE
Handle page select and remote access check after changing SFP target

### DIFF
--- a/sonic_platform_base/sonic_xcvr/fields/consts.py
+++ b/sonic_platform_base/sonic_xcvr/fields/consts.py
@@ -482,6 +482,7 @@ CDB_CMD = "CdbCommand"
 CDB_WRITE_MSG = "CdbWriteMessage"
 
 #CMISTargetFWUpgrade
+PAGE_SELECT_BYTE = "PageSelectByte"
 CMIS_TARGET_SERVER_INFO = "CmisTargetServerInfo"
 SERVER_FW_MAGIC_BYTE = "ServerFirmwareMagicByte"
 SERVER_FW_CHECKSUM = "ServerFirmwareChecksum"

--- a/sonic_platform_base/sonic_xcvr/mem_maps/public/cmisTargetFWUpgrade.py
+++ b/sonic_platform_base/sonic_xcvr/mem_maps/public/cmisTargetFWUpgrade.py
@@ -19,6 +19,7 @@ class CmisTargetFWUpgradeMemMap(CmisMemMap):
         super().__init__(codes)
 
         self.CMIS_TARGET_SERVER_INFO = RegGroupField(consts.CMIS_TARGET_SERVER_INFO,
+            NumberRegField(consts.PAGE_SELECT_BYTE, self.getaddr(0, 127), format="B", size=1, ro=False),
             NumberRegField(consts.SERVER_FW_MAGIC_BYTE, self.getaddr(0x3, 128), format="B", size=1),
             NumberRegField(consts.SERVER_FW_CHECKSUM, self.getaddr(0x3, 129), format="B", size=1),
             ServerFWVersionRegField(consts.SERVER_FW_VERSION, self.getaddr(0x3, 130), size=16))

--- a/tests/sonic_xcvr/test_cmisTargetFWUpgrade.py
+++ b/tests/sonic_xcvr/test_cmisTargetFWUpgrade.py
@@ -22,12 +22,11 @@ class TestCmis(object):
         (1, [True, True, True, True], True, None, True),    # All operations successful
         (0, [True, True, True, True], True, None, True),    # Target is E0, all operations successful
     ])
-    @patch('sonic_platform_base.sonic_xcvr.api.public.cmisTargetFWUpgrade.CmisTargetFWUpgradeAPI._handle_error_and_restore_target_to_E0', MagicMock(return_value=False))
     def test_set_firmware_download_target_end(self, target, write_results, accessible, exception, expected_result):
         self.api.xcvr_eeprom.write = MagicMock()
         self.api.xcvr_eeprom.write.side_effect = write_results
         with patch('sonic_platform_base.sonic_xcvr.api.public.cmisTargetFWUpgrade.CmisTargetFWUpgradeAPI._is_remote_target_accessible', return_value=accessible):
-            with patch('sonic_platform_base.sonic_xcvr.api.public.cmisTargetFWUpgrade.CmisTargetFWUpgradeAPI._handle_error_and_restore_target_to_E0', return_value=False):
+            with patch('sonic_platform_base.sonic_xcvr.api.public.cmisTargetFWUpgrade.CmisTargetFWUpgradeAPI._restore_target_to_E0', return_value=False):
                 if exception is not None:
                     self.api.xcvr_eeprom.write.side_effect = exception
 
@@ -37,7 +36,7 @@ class TestCmis(object):
                     expected_call_count = 0
                 else:
                     expected_call_count = 1
-                assert self.api._handle_error_and_restore_target_to_E0.call_count == expected_call_count
+                assert self.api._restore_target_to_E0.call_count == expected_call_count
 
     @pytest.mark.parametrize("set_firmware_result, exception_raised", [
         (False, False),
@@ -98,13 +97,9 @@ class TestCmis(object):
         result = self.api._is_remote_target_accessible()
         assert result == expected_result
 
-    @patch('logging.error')
-    def test_handle_error_and_restore_target_to_E0(self, mock_error):
+    def test_restore_target_to_E0(self):
         self.api.xcvr_eeprom.write = MagicMock()
-        error_message = "Test error message"
-        assert self.api._handle_error_and_restore_target_to_E0(error_message) == False
-        mock_error.assert_called_once_with(error_message)
-        # Check that the target mode was restored to E0
+        assert self.api._restore_target_to_E0() == False
         self.api.xcvr_eeprom.write.assert_called_once()
 
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
After changing the target to remote, many sfputil commands which access transceiver EEPROM fail with the below traceback if either of the below scenario is true.
1. If the remote target had page select register set to non-zero
2. If the remote target was powered down or is removed from the device

Traceback details
```
Running command: sudo sfputil show fwversion Ethernet232
['Traceback (most recent call last):', '  File "/usr/local/bin/sfputil", line 8, in <module>', '    sys.exit(cli())', '  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 764, in __call__', '    return self.main(*args, **kwargs)', '  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 717, in main', '    rv = self.invoke(ctx)', '  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 1137, in invoke', '    return _process_result(sub_ctx.command.invoke(sub_ctx))', '  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 1137, in invoke', '    return _process_result(sub_ctx.command.invoke(sub_ctx))', '  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 956, in invoke', '    return ctx.invoke(self.callback, **ctx.params)', '  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 555, in invoke', '    return callback(*args, **kwargs)', '  File "/usr/local/lib/python3.9/dist-packages/sfputil/main.py", line 1056, in fwversion', '    show_firmware_version(physical_port)', '  File "/usr/local/lib/python3.9/dist-packages/sfputil/main.py", line 1026, in show_firmware_version', '    api = sfp.get_xcvr_api()', '  File "/usr/local/lib/python3.9/dist-packages/sonic_platform_base/sfp_base.py", line 468, in get_xcvr_api', '    self.refresh_xcvr_api()', '  File "/usr/local/lib/python3.9/dist-packages/sonic_platform_base/sfp_base.py", line 458, in refresh_xcvr_api', '    self._xcvr_api = self._xcvr_api_factory.create_xcvr_api()', '  File "/usr/local/lib/python3.9/dist-packages/sonic_platform_base/sonic_xcvr/xcvr_api_factory.py", line 76, in create_xcvr_api', '    vendor_pn = self._get_vendor_part_num()', '  File "/usr/local/lib/python3.9/dist-packages/sonic_platform_base/sonic_xcvr/xcvr_api_factory.py", line 67, in _get_vendor_part_num', '    vendor_pn = part_num.decode()', "UnicodeDecodeError: 'utf-8' codec can't decode byte 0x9d in position 2: invalid start byte"]
```

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
The set_firmware_download_target_end API needs to be enhanced since it currently
1. Does not set the page select byte to 0 after changing the target (assumes it to be zero). In addition, the optoe kernel driver changes page select byte only if a non-zero page is being accessed
https://github.com/opencomputeproject/OpenNetworkLinux/blob/e85f118fb6400caf869f4a83b92c0bc3123962da/packages/base/any/kernels/modules/optoe.c#L522
2. Does not ensure if the remote target is accessible after changing the target.

If either of the above scenario is true, when sfputil or xcvrd attempts reading the Vendor name and Vendor part number (residing an Upper page 0h) to create the relevant transceiver specific instances (https://github.com/sonic-net/sonic-platform-common/blob/de16e50d87f63fb3ab3cfa9f52c8d2557de67ebb/sonic_platform_base/sonic_xcvr/xcvr_api_factory.py#L72), an unexpected data is read since
1. If the current scenario is `#1`, the data of upper page will be actually read from the corresponding non-zero page selected
2. If the current scenarios is `#2`, all registers of EEPROM except TARGET_MODE register will have a value of 0xff populated

In addition to the above changes, the `get_current_target_end` API has been added for future use.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Following test cases were executed

1. Change target to E1 and dump page 1
2. Modify page select to 0x10 on E1 and change target to E1
3. Modify page select to 0x11 on E2 and change target to E2
4. Remove E1, change target to E1 and ensure target is changed back to 0
5. Ensure firmware info is not populated when remote target is not accessible
6. Ensure get_firmware_download_target_end returns valid output 

#### Additional Information (Optional)
MSFT ADO - 27920899
