### PR TITLE
Add XcvrApi for configuring application 0

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -2483,7 +2483,7 @@ class CmisApi(XcvrApi):
         This function applies App0 configuration - in case some lanes are de-activated
         '''
         for lane in range(self.NUM_CHANNELS):
-            addr = "{}_{}_{}".format(consts.STAGED_CTRL_APSEL_FIELD, 0, lane + 1)
+            addr = f"{consts.STAGED_CTRL_APSEL_FIELD}_0_{lane+1}"
             data = 0
             return self.xcvr_eeprom.write(addr, data)
 

--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -200,7 +200,7 @@ class CmisApi(XcvrApi):
             ( _, _, _, _, _, _, _, _, ActiveFirmware, InactiveFirmware) = result['result']
         except (ValueError, TypeError):
             return return_dict
-        
+
         return_dict["active_firmware"] = ActiveFirmware
         return_dict["inactive_firmware"] = InactiveFirmware
         return return_dict
@@ -776,10 +776,10 @@ class CmisApi(XcvrApi):
         '''
         if self.is_flat_memory():
             return 0
-        
+
         if (appl <= 0):
             return 0
-        
+
         appl_advt = self.get_application_advertisement()
         return appl_advt[appl]['media_lane_count'] if len(appl_advt) >= appl else 0
 
@@ -808,10 +808,10 @@ class CmisApi(XcvrApi):
         '''
         if self.is_flat_memory():
             return 'N/A'
-        
+
         if (appl <= 0):
             return 0
-        
+
         appl_advt = self.get_application_advertisement()
         return appl_advt[appl]['media_lane_assignment_options'] if len(appl_advt) >= appl else 0
 
@@ -2141,7 +2141,7 @@ class CmisApi(XcvrApi):
             name = "DP{}State".format(lane + 1)
             if dp_state[name] != 'DataPathDeactivated':
                 return False
-            
+
             name = "ConfigStatusLane{}".format(lane + 1)
             if config_state[name] != 'ConfigSuccess':
                 return False
@@ -2477,5 +2477,14 @@ class CmisApi(XcvrApi):
             return state
 
         return None
+
+    def apply_app0_configuration(self):
+        '''
+        This function applies App0 configuration - in case some lanes are de-activated
+        '''
+        for lane in range(self.NUM_CHANNELS):
+            addr = "{}_{}_{}".format(consts.STAGED_CTRL_APSEL_FIELD, 0, lane + 1)
+            data = 0
+            return self.xcvr_eeprom.write(addr, data)
 
     # TODO: other XcvrApi methods


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
When NOS configures the CMIS modules, we need to be aware to a case where some of the lanes are disabled.
According to CMIS spec, in that case, an application 0 is needed to make sure all disabled lanes are zeroed.
This function sets "0" in all lanes before configuring the module, so de-activated lanes will remain with 0. 

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
This was done according to CMIS specification document.


#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
This addition to CMIS thread was tested with a CMIS active cable, with only 4 active lanes (and 4 de-active).
We made sure the link is up, right places are zeroed, and have traffic.


#### Additional Information (Optional)

