### PR TITLE
Fix the temperature parsing in virtium nvme disks

### DIFF
--- a/sonic_platform_base/sonic_storage/ssd.py
+++ b/sonic_platform_base/sonic_storage/ssd.py
@@ -240,7 +240,9 @@ class SsdUtil(StorageCommon):
 
     def parse_virtium_info(self):
         if self.vendor_ssd_info:
-            self.temperature = self._parse_re('Temperature_Celsius\s*\d*\s*(\d+?)\s+', self.vendor_ssd_info)
+            vendor_temp = self._parse_re('Temperature_Celsius\s*\d*\s*(\d+?)\s+', self.vendor_ssd_info)
+            if vendor_temp != NOT_AVAILABLE:
+                self.temperature = vendor_temp
             nand_endurance = self._parse_re('NAND_Endurance\s*\d*\s*(\d+?)\s+', self.vendor_ssd_info)
             avg_erase_count = self._parse_re('Average_Erase_Count\s*\d*\s*(\d+?)\s+', self.vendor_ssd_info)
             if nand_endurance != NOT_AVAILABLE and avg_erase_count != NOT_AVAILABLE:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

Fix https://github.com/sonic-net/sonic-buildimage/issues/19020

If the vendor utility couldn't infer the temperature, display the temperature inferred from smartctl utility

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

Temperature can be read from smartctl utility

```
root@sonic:/home/admin# smartctl /dev/nvme0n1 -a 
smartctl 7.4 2023-08-01 r5530 [x86_64-linux-6.1.0-11-2-amd64] (local build)
Copyright (C) 2002-23, Bruce Allen, Christian Franke, www.smartmontools.org

=== START OF INFORMATION SECTION ===
Model Number:                       Virtium VTPM24CEXI080-BM110006
SMART/Health Information (NVMe Log 0x02)
Temperature:                        39 Celsius
```

```
Before this change
root@sonic:/home/admin# show platform ssdhealth
Device Model : Virtium VTPM24CEXI080-BM110006
Health       : 100.0%
Temperature  : N/A

After this change
root@sonic:/home/admin# show platform ssdhealth
Device Model : Virtium VTPM24CEXI080-BM110006
Health       : 100.0%
Temperature  : 39.0C

```

#### Additional Information (Optional)

