### PR TITLE
Generate media key in platform sepcific way and fix cable issues

### DIFF
--- a/sonic_platform_base/sfp_base.py
+++ b/sonic_platform_base/sfp_base.py
@@ -467,3 +467,22 @@ class SfpBase(device_base.DeviceBase):
         if self._xcvr_api is None:
             self.refresh_xcvr_api()
         return self._xcvr_api
+
+    def get_platform_media_key(self, transceiver_dict, port_speed, lane_count):
+        """
+        Retrieves the media key constructed in a platform specific way,
+        to be used for parsing the media settings
+
+        Args:
+             transceiver_dict :
+                     SFP transceived EEPROM dictionary
+             port_speed:
+                     Configured port speed
+             lane_count:
+                     Number of lanes assigned for that port
+
+        Returns:
+            a dictionary with string values defined for keys,
+            {'vendor_key':'', 'media_key':'', 'lane_speed_key':'')
+        """
+        raise NotImplementedError

--- a/sonic_platform_base/sonic_xcvr/api/public/sff8436.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/sff8436.py
@@ -45,6 +45,7 @@ class Sff8436Api(XcvrApi):
             if len > 0:
                 cable_len = len
                 cable_type = type
+                break
 
         xcvr_info = {
             "type": serial_id[consts.ID_FIELD],

--- a/sonic_platform_base/sonic_xcvr/api/public/sff8636.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/sff8636.py
@@ -52,6 +52,7 @@ class Sff8636Api(XcvrApi):
             if len > 0:
                 cable_len = len
                 cable_type = type
+                break
 
         xcvr_info = {
             "type": serial_id[consts.ID_FIELD],

--- a/sonic_platform_base/sonic_xcvr/xcvr_api_factory.py
+++ b/sonic_platform_base/sonic_xcvr/xcvr_api_factory.py
@@ -61,14 +61,14 @@ class XcvrApiFactory(object):
        name_data = self.reader(VENDOR_NAME_OFFSET, VENDOR_NAME_LENGTH)
        if name_data is None:
            return None
-       vendor_name = name_data.decode()
+       vendor_name = name_data.decode("ascii", errors="ignore")
        return vendor_name.strip()
 
     def _get_vendor_part_num(self):
        part_num = self.reader(VENDOR_PART_NUM_OFFSET, VENDOR_PART_NUM_LENGTH)
        if part_num is None:
            return None
-       vendor_pn = part_num.decode()
+       vendor_pn = part_num.decode("ascii", errors="ignore")
        return vendor_pn.strip()
         
     def create_xcvr_api(self):


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
- Add API to support the generation of the preemphasis key in a platform
  vendor dictated way instead of generic one
- Add break to return the cable length immediately and avoid reading the
  junk values
- Ignore ASCII errors as some cables might have some junk values causing
  the daemon to exit

#### How Has This Been Tested?
Verified in Celestica platform DS2000 and DS3000 with Amphenol and Molex DAC