### PR TITLE
Implement is_copper for QSFP-DD

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -703,6 +703,18 @@ class CmisApi(XcvrApi):
         else:
             return 'Unknown media interface'
 
+    def is_copper(self):
+        '''
+        Returns True if xcvr is copper, False if xcvr is optical
+        '''
+        media_type = self.get_module_media_type()
+        if media_type == 'passive_copper_media_interface' or media_type == 'base_t_media_interface' or media_type == 'active_cable_media_interface':
+            return True
+        elif  media_type == 'nm_850_media_interface' or media_type == 'sm_media_interface' :
+            return False
+        else:
+            return None
+
     def is_coherent_module(self):
         '''
         Returns True if the module follow C-CMIS spec, False otherwise

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -638,6 +638,20 @@ class TestCmis(object):
         assert result == expected
 
     @pytest.mark.parametrize("mock_response, expected", [
+            ("sm_media_interface", False),
+            ("nm_850_media_interface", False),
+            ("passive_copper_media_interface", True),
+            ("active_cable_media_interface", True),
+            ("base_t_media_interface", True),
+            ("ABCD", None)
+    ])
+    def test_is_copper(self, mock_response, expected):
+        self.api.get_module_media_type = MagicMock()
+        self.api.get_module_media_type.return_value = mock_response
+        result = self.api.is_copper()
+        assert result == expected
+
+    @pytest.mark.parametrize("mock_response, expected", [
         ('Copper cable', False),
         ('400ZR', True),
     ])


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
Add is_copper() api for QSFP-DD.
#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
While I tested with as9726-32d and as9736-64d with QSFP-DD transceiver via adding is_copper() in my modified sfputil tools, it shows that is_copper() not implemented for QSFP-DD. 
In this PR is to add the is_copper() in sonic_platform_base/sonic_xcvr/api/public/cmis.py and its pytest feature for this api.
#### How Has This Been Tested?

<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
A. Git clone the fixed code:
- 1. git clone https://github.com/jcsteven/sonic-platform-common.git -b master-qsfp_dd_is_copper
- 2. cd sonic-platform-common 

B. Install pip dependencie in virtual environment
- 1. Create virtual environment: python3.10 -m venv venv-3.10
- 2. Active virtual environment: source venv-3.10/bin/activate
- 3. pip install -U pytest
- 4. pip install pytest-cov
- 5. pip install mock
- 5. pip install sonic_py_common-1.0-py3-none-any.whl

C. Run the pytest:
- 1. pytest -v tests/sonic_xcvr/test_cmis.py
#### Additional Information (Optional)
Test log as: [test_cmis.py-test-log.txt](https://github.com/user-attachments/files/16104484/test_cmis.py-test-log.txt)
Test summary:

![test-screen-shot](https://github.com/sonic-net/sonic-platform-common/assets/15793708/050688f3-a4ec-4a51-a89a-54825d5867a3)

