### PR TITLE
[202311][SSD] Bug fix: the logic to match the vendor specific attribute is not accurate

### DIFF
--- a/sonic_platform_base/sonic_ssd/ssd_generic.py
+++ b/sonic_platform_base/sonic_ssd/ssd_generic.py
@@ -242,4 +242,4 @@ class SsdUtil(SsdBase):
         return self.vendor_ssd_info
 
     def parse_id_number(self, id):
-        return self._parse_re('{}\s*(.+?)\n'.format(id), self.ssd_info)
+        return self._parse_re('\n{}\s*(.+?)\n'.format(id), self.ssd_info)

--- a/tests/ssd_generic_test.py
+++ b/tests/ssd_generic_test.py
@@ -748,7 +748,7 @@ ID# ATTRIBUTE_NAME          FLAG     VALUE WORST THRESH TYPE      UPDATED  WHEN_
 199 UDMA_CRC_Error_Count    0x000b   100   100   000    Pre-fail  Always       -       0
 215 Unknown_Attribute       0x0012   100   100   000    Old_age   Always       -       4275
 231 Unknown_SSD_Attribute   0x1913   100   100   025    Pre-fail  Always       -       100
-235 Unknown_Attribute       0x0012   100   100   000    Old_age   Always       -       1302467136
+235 Unknown_Attribute       0x0012   100   100   000    Old_age   Always       -       1302467248
 237 Unknown_Attribute       0x0012   100   100   000    Old_age   Always       -       0
 241 Total_LBAs_Written      0x0012   100   100   000    Old_age   Always       -       1186450104
 242 Total_LBAs_Read         0x0012   100   100   000    Old_age   Always       -       2257141451


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

The logic to match the vendor-specific attribute in SSD API is not accurate. The vendor-specific attribute should start with a new line (`\n`) otherwise it can hit a false match scenario.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

Unit test and manual test

#### Additional Information (Optional)

Eg. if the raw value of an attribute happens to contain the ID, the next line can be matched but it is wrong.
For example the vendor-specific attribute ID is 248, but the output is like the following:

```
215 Unknown_Attribute       0x0012   100   100   000    Old_age   Always       -       4275
231 Unknown_SSD_Attribute   0x1913   100   100   025    Pre-fail  Always       -       100
235 Unknown_Attribute       0x0012   100   100   000    Old_age   Always       -       1302467136
235 Unknown_Attribute       0x0012   100   100   000    Old_age   Always       -       1302467248
237 Unknown_Attribute       0x0012   100   100   000    Old_age   Always       -       0
241 Total_LBAs_Written      0x0012   100   100   000    Old_age   Always       -       1186450104
242 Total_LBAs_Read         0x0012   100   100   000    Old_age   Always       -       2257141451
243 Unknown_Attribute       0x0012   100   100   000    Old_age   Always       -       0
244 Unknown_Attribute       0x0012   100   100   000    Old_age   Always       -       0
248 Unknown_Attribute       0x0112   100   100   001    Old_age   Always       -       100
```

The raw value of attribute 235 contains `248`, the next line, which is of attribute 237, will be matched, which is wrong.


