### PR TITLE
[CMIS] Return the CDB status value for the caller to check the status…

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -1281,7 +1281,7 @@ class CmisApi(XcvrApi):
         else:
             txt += 'Status or reply payload check code error\n'
             logger.info(txt)
-            logger.info('Fail to get fw mgnt feature, cdb status: 0x{}\n'.format(status))
+            logger.info('Fail to get fw mgmt feature, cdb status: {:#x}, cdb_chkcode: {:#x}, rpl_chkcode: {:#x}\n'.format(status, self.cdb.cdb_chkcode(rpl), rpl_chkcode))
             return {'status': False, 'info': txt, 'feature': None}
         elapsedtime = time.time()-starttime
         logger.info('Get module FW upgrade features time: %.2f s\n' %elapsedtime)

--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -1280,8 +1280,8 @@ class CmisApi(XcvrApi):
 
         else:
             txt += 'Status or reply payload check code error\n'
-            logger.info(txt)
-            logger.info('Fail to get fw mgmt feature, cdb status: {:#x}, cdb_chkcode: {:#x}, rpl_chkcode: {:#x}\n'.format(status, self.cdb.cdb_chkcode(rpl), rpl_chkcode))
+            logger.error(txt)
+            logger.error('Fail to get fw mgmt feature, cdb status: {:#x}, cdb_chkcode: {:#x}, rpl_chkcode: {:#x}\n'.format(status, self.cdb.cdb_chkcode(rpl), rpl_chkcode))
             return {'status': False, 'info': txt, 'feature': None}
         elapsedtime = time.time()-starttime
         logger.info('Get module FW upgrade features time: %.2f s\n' %elapsedtime)

--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -1240,7 +1240,7 @@ class CmisApi(XcvrApi):
         """
         txt = ''
         if self.cdb is None:
-            return {'status': False, 'info': "CDB Not supported", 'result': None}
+            return {'status': False, 'info': "CDB Not supported", 'feature': None}
 
         # get fw upgrade features (CMD 0041h)
         starttime = time.time()
@@ -1252,8 +1252,11 @@ class CmisApi(XcvrApi):
         writelength = (writelength_raw + 1) * 8
         txt += 'Auto page support: %s\n' %autopaging_flag
         txt += 'Max write length: %d\n' %writelength
-        rpllen, rpl_chkcode, rpl = self.cdb.get_fw_management_features()
-        if self.cdb.cdb_chkcode(rpl) == rpl_chkcode:
+        result = self.cdb.get_fw_management_features()
+        status = result['status']
+        _, rpl_chkcode, rpl = result['rpl']
+
+        if status == 1 and self.cdb.cdb_chkcode(rpl) == rpl_chkcode:
             startLPLsize = rpl[2]
             txt += 'Start payload size %d\n' % startLPLsize
             maxblocksize = (rpl[4] + 1) * 8
@@ -1277,7 +1280,7 @@ class CmisApi(XcvrApi):
 
         else:
             txt += 'Reply payload check code error\n'
-            return {'status': False, 'info': txt, 'result': None}
+            return {'status': False, 'info': txt, 'feature': None}
         elapsedtime = time.time()-starttime
         logger.info('Get module FW upgrade features time: %.2f s\n' %elapsedtime)
         logger.info(txt)
@@ -1297,20 +1300,25 @@ class CmisApi(XcvrApi):
             return {'status': False, 'info': "CDB Not supported", 'result': None}
 
         # get fw info (CMD 0100h)
-        rpllen, rpl_chkcode, rpl = self.cdb.get_fw_info()
+        result = self.cdb.get_fw_info()
+        status = result['status']
+        rpllen, rpl_chkcode, rpl = result['rpl']
+
         # Interface NACK or timeout
         if (rpllen is None) or (rpl_chkcode is None):
             return {'status': False, 'info': "Interface fail", 'result': 0} # Return result 0 for distinguishing CDB is maybe in busy or failure.
 
         # password issue
-        if self.cdb.cdb_chkcode(rpl) != rpl_chkcode:
+        if status == 0x46:
             string = 'Get module FW info: Need to enter password\n'
             logger.info(string)
             # Reset password for module using CMIS 4.0
             self.cdb.module_enter_password(0)
-            rpllen, rpl_chkcode, rpl = self.cdb.get_fw_info()
+            result = self.cdb.get_fw_info()
+            status = result['status']
+            rpllen, rpl_chkcode, rpl = result['rpl']
 
-        if self.cdb.cdb_chkcode(rpl) == rpl_chkcode:
+        if status == 1 and self.cdb.cdb_chkcode(rpl) == rpl_chkcode:
             # Regiter 9Fh:136
             fwStatus = rpl[0]
             ImageARunning = (fwStatus & 0x01) # bit 0 - image A is running
@@ -1603,7 +1611,7 @@ class CmisApi(XcvrApi):
             return result['status'], result['info']
         result = self.get_module_fw_mgmt_feature()
         try:
-            startLPLsize, maxblocksize, lplonly_flag, autopaging_flag, writelength = result['result']
+            startLPLsize, maxblocksize, lplonly_flag, autopaging_flag, writelength = result['feature']
         except (ValueError, TypeError):
             return result['status'], result['info']
         download_status, txt = self.module_fw_download(startLPLsize, maxblocksize, lplonly_flag, autopaging_flag, writelength, imagepath)

--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -1279,7 +1279,9 @@ class CmisApi(XcvrApi):
                 txt += 'Read to LPL/EPL {:#x}\n'.format(rpl[6])
 
         else:
-            txt += 'Reply payload check code error\n'
+            txt += 'Status or reply payload check code error\n'
+            logger.info(txt)
+            logger.info('Fail to get fw mgnt feature, cdb status: 0x{}\n'.format(status))
             return {'status': False, 'info': txt, 'feature': None}
         elapsedtime = time.time()-starttime
         logger.info('Get module FW upgrade features time: %.2f s\n' %elapsedtime)

--- a/sonic_platform_base/sonic_xcvr/api/public/cmisCDB.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmisCDB.py
@@ -155,13 +155,13 @@ class CmisCdbApi(XcvrApi):
         '''
         This QUERY Status command may be used to retrieve the password acceptance
         status and to perform a test of the CDB interface.
-        It returns the reply message of this CDB command 0000h.
+        It returns the status and reply message of this CDB command 0000h.
         '''
         cmd = bytearray(b'\x00\x00\x00\x00\x02\x00\x00\x00\x00\x10')
         cmd[133-INIT_OFFSET] = self.cdb_chkcode(cmd)
         self.write_cdb(cmd)
         status = self.cdb1_chkstatus()
-        if (status != 0x1):
+        if status != 0x1:
             if status > 127:
                 txt = 'Query CDB status: Busy'
             else:
@@ -170,7 +170,8 @@ class CmisCdbApi(XcvrApi):
         else:
             txt = 'Query CDB status: Success'
         logger.info(txt)
-        return self.read_cdb()
+        rpl = self.read_cdb()
+        return {'status': status, 'rpl': rpl}
 
     # Enter password
     def module_enter_password(self, psw = 0x00001011):
@@ -199,7 +200,7 @@ class CmisCdbApi(XcvrApi):
     def get_module_feature(self):
         '''
         This command is used to query which CDB commands are supported.
-        It returns the reply message of this CDB command 0040h.
+        It returns the status and reply message of this CDB command 0040h.
         '''
         cmd = bytearray(b'\x00\x40\x00\x00\x00\x00\x00\x00')
         cmd[133-INIT_OFFSET] = self.cdb_chkcode(cmd)
@@ -214,13 +215,15 @@ class CmisCdbApi(XcvrApi):
         else:
             txt = 'Get module feature status: Success'
         logger.info(txt)
-        return self.read_cdb()
+
+        rpl = self.read_cdb()
+        return {'status': status, 'rpl': rpl}
 
     # Firmware Update Features Supported
     def get_fw_management_features(self):
         '''
         This command is used to query supported firmware update features
-        It returns the reply message of this CDB command 0041h.
+        It returns the status and reply message of this CDB command 0041h.
         '''
         cmd = bytearray(b'\x00\x41\x00\x00\x00\x00\x00\x00')
         cmd[133-INIT_OFFSET] = self.cdb_chkcode(cmd)
@@ -235,14 +238,16 @@ class CmisCdbApi(XcvrApi):
         else:
             txt = 'Get firmware management feature status: Success'
         logger.info(txt)
-        return self.read_cdb()
+
+        rpl = self.read_cdb()
+        return {'status': status, 'rpl': rpl}
 
     # Get FW info
     def get_fw_info(self):
         '''
         This command returns the firmware versions and firmware default running
         images that reside in the module
-        It returns the reply message of this CDB command 0100h.
+        It returns the status and reply message of this CDB command 0100h.
         '''
         cmd = bytearray(b'\x01\x00\x00\x00\x00\x00\x00\x00')
         cmd[133-INIT_OFFSET] = self.cdb_chkcode(cmd)
@@ -257,7 +262,9 @@ class CmisCdbApi(XcvrApi):
         else:
             txt = 'Get firmware info status: Success'
         logger.info(txt)
-        return self.read_cdb()
+
+        rpl = self.read_cdb()
+        return {'status': status, 'rpl': rpl}
 
     # Start FW download
     def start_fw_download(self, startLPLsize, header, imagesize):

--- a/tests/sonic_xcvr/test_cmisCDB.py
+++ b/tests/sonic_xcvr/test_cmisCDB.py
@@ -78,7 +78,7 @@ class TestCDB(object):
         self.api.cdb1_chkstatus.return_value = mock_response[0]
         self.api.read_cdb = MagicMock()
         self.api.read_cdb.return_value = mock_response[1]
-        result = self.api.query_cdb_status()
+        result = self.api.query_cdb_status()['rpl']
         assert result == expected
 
     @pytest.mark.parametrize("mock_response, expected", [
@@ -102,7 +102,7 @@ class TestCDB(object):
         self.api.cdb1_chkstatus.return_value = mock_response[0]
         self.api.read_cdb = MagicMock()
         self.api.read_cdb.return_value = mock_response[1]
-        result = self.api.get_module_feature()
+        result = self.api.get_module_feature()['rpl']
         assert result == expected
 
     @pytest.mark.parametrize("mock_response, expected", [
@@ -115,7 +115,7 @@ class TestCDB(object):
         self.api.cdb1_chkstatus.return_value = mock_response[0]
         self.api.read_cdb = MagicMock()
         self.api.read_cdb.return_value = mock_response[1]
-        result = self.api.get_fw_management_features()
+        result = self.api.get_fw_management_features()['rpl']
         assert result == expected
 
     @pytest.mark.parametrize("mock_response, expected", [
@@ -128,7 +128,7 @@ class TestCDB(object):
         self.api.cdb1_chkstatus.return_value = mock_response[0]
         self.api.read_cdb = MagicMock()
         self.api.read_cdb.return_value = mock_response[1]
-        result = self.api.get_fw_info()
+        result = self.api.get_fw_info()['rpl']
         assert result == expected
 
     @pytest.mark.parametrize("input_param, mock_response, expected", [


### PR DESCRIPTION
#### Description

This PR unifies all CDB API calls to return CDB status, allowing the caller to check the command status returned from the module and perform corresponding actions.

#### Motivation and Context
Modified the following CDB APIs to return a dictionary with CDB status as the first element and RPL result as the second element.

- query_cdb_status()
- get_module_feature()
- get_fw_management_features()
- get_fw_info()

The caller can first check the CDB status to ensure the command was processed successfully, then retrieve the data from the reply payload (RPL).

#### How Has This Been Tested?
Tested with Cisco8111 and Credo C1 cable
![image](https://github.com/user-attachments/assets/7da2bb4e-4365-4a12-b1bf-b8e6e01e1211)

