### PR TITLE
Parse all VDM advertised fields during DOM monitoring

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -21,6 +21,29 @@ from collections import defaultdict
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
+CMIS_VDM_KEY_TO_DB_PREFIX_KEY_MAP = {
+    "eSNR Media Input [dB]" : "esnr_media_input",
+    "PAM4 Level Transition Parameter Media Input [dB]" : "pam4_level_transition_media_input",
+    "Pre-FEC BER Minimum Media Input" : "prefec_ber_min_media_input",
+    "Pre-FEC BER Maximum Media Input" : "prefec_ber_max_media_input",
+    "Pre-FEC BER Average Media Input" : "prefec_ber_avg_media_input",
+    "Pre-FEC BER Current Value Media Input" : "prefec_ber_curr_media_input",
+    "Errored Frames Minimum Media Input" : "errored_frames_min_media_input",
+    "Errored Frames Maximum Media Input" : "errored_frames_max_media_input",
+    "Errored Frames Average Media Input" : "errored_frames_avg_media_input",
+    "Errored Frames Current Value Media Input" : "errored_frames_curr_media_input",
+    "eSNR Host Input [dB]" : "esnr_host_input",
+    "PAM4 Level Transition Parameter Host Input [dB]" : "pam4_level_transition_host_input",
+    "Pre-FEC BER Minimum Host Input" : "prefec_ber_min_host_input",
+    "Pre-FEC BER Maximum Host Input" : "prefec_ber_max_host_input",
+    "Pre-FEC BER Average Host Input" : "prefec_ber_avg_host_input",
+    "Pre-FEC BER Current Value Host Input" : "prefec_ber_curr_host_input",
+    "Errored Frames Minimum Host Input" : "errored_frames_min_host_input",
+    "Errored Frames Maximum Host Input" : "errored_frames_max_host_input",
+    "Errored Frames Average Host Input" : "errored_frames_avg_host_input",
+    "Errored Frames Current Value Host Input" : "errored_frames_curr_host_input"
+}
+
 class CmisApi(XcvrApi):
     NUM_CHANNELS = 8
     LowPwrRequestSW = 4
@@ -233,13 +256,17 @@ class CmisApi(XcvrApi):
         self.vdm_dict = self.get_vdm(self.vdm.VDM_REAL_VALUE)
         try:
             bulk_status['laser_temperature'] = laser_temp_dict['monitor value']
-            bulk_status['prefec_ber'] = self.vdm_dict['Pre-FEC BER Average Media Input'][1][0]
-            bulk_status['postfec_ber_min'] = self.vdm_dict['Errored Frames Minimum Media Input'][1][0]
-            bulk_status['postfec_ber_max'] = self.vdm_dict['Errored Frames Maximum Media Input'][1][0]
-            bulk_status['postfec_ber_avg'] = self.vdm_dict['Errored Frames Average Media Input'][1][0]
-            bulk_status['postfec_curr_val'] = self.vdm_dict['Errored Frames Current Value Media Input'][1][0]
         except (KeyError, TypeError):
             pass
+
+        for vdm_key, db_key in CMIS_VDM_KEY_TO_DB_PREFIX_KEY_MAP.items():
+            for lane in range(1, self.NUM_CHANNELS + 1):
+                try:
+                    bulk_status_key = "%s%d" % (db_key, lane)
+                    bulk_status[bulk_status_key] = self.vdm_dict[vdm_key][lane][0]
+                except (KeyError, TypeError):
+                    pass
+
         return bulk_status
 
     def get_transceiver_threshold_info(self):

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -1375,6 +1375,7 @@ class TestCmis(object):
                     'Errored Frames Maximum Media Input':{1:[0, 1, 0, 1, 0, False, False, False, False]},
                     'Errored Frames Average Media Input':{1:[0, 1, 0, 1, 0, False, False, False, False]},
                     'Errored Frames Current Value Media Input':{1:[0, 1, 0, 1, 0, False, False, False, False]},
+                    'Pre-FEC BER Current Value Host Input':{1: [2.66e-09, 1e-05, 0.0, 1e-06, 0.0, False, False, False, False], 2: [1.0, 1e-05, 0.0, 1e-06, 0.0, False, False, False, False], 3: [1.0, 1e-05, 0.0, 1e-06, 0.0, False, False, False, False], 4: [1.0, 1e-05, 0.0, 1e-06, 0.0, False, False, False, False]},
                 }
             ],
             {
@@ -1387,11 +1388,15 @@ class TestCmis(object):
                 'tx1bias': 70, 'tx2bias': 70, 'tx3bias': 70, 'tx4bias': 70,
                 'tx5bias': 70, 'tx6bias': 70, 'tx7bias': 70, 'tx8bias': 70,
                 'laser_temperature': 40,
-                'prefec_ber': 0.001,
-                'postfec_ber_min': 0,
-                'postfec_ber_max': 0,
-                'postfec_ber_avg': 0,
-                'postfec_curr_val': 0,
+                'prefec_ber_avg_media_input1': 0.001,
+                'errored_frames_min_media_input1': 0,
+                'errored_frames_max_media_input1': 0,
+                'errored_frames_avg_media_input1': 0,
+                'errored_frames_curr_media_input1': 0,
+                'prefec_ber_curr_host_input1': 2.66e-09,
+                'prefec_ber_curr_host_input2': 1.0,
+                'prefec_ber_curr_host_input3': 1.0,
+                'prefec_ber_curr_host_input4': 1.0
             }
         ),
         (


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
There are multiple VDM observable types which are not being updated in redis-db (`TRANSCEIVER_DOM_SENSOR` table) during DOM monitoring. Hence, these fields need to be monitored periodically.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
Added the missing VDM fields to be monitored as part of periodic DOM polling. Also, reading the fields based on lane id.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
1. Ensured that the output of `show interface transceiver eeprom -d EthernetXX` does not change with the current changeset
2. Ensured that the advertised VDM fields by the module are pushed to the `TRANSCEIVER_DOM_SENSOR` table.

redis-db dump
```
root@sonic:/home/admin# redis-cli -n 6 hgetall "TRANSCEIVER_DOM_SENSOR|Ethernet144"
  1) "temperature"
  2) "56.102"
  3) "voltage"
  4) "3.344"
  5) "tx1bias"
  6) "201.896"
  7) "rx1power"
  8) "-11.163"
  9) "tx1power"
 10) "-10.32"
 11) "tx2bias"
 12) "0.0"
 13) "rx2power"
 14) "-inf"
 15) "tx2power"
 16) "-inf"
 17) "tx3bias"
 18) "0.0"
 19) "rx3power"
 20) "-inf"
 21) "tx3power"
 22) "-inf"
 23) "tx4bias"
 24) "0.0"
 25) "rx4power"
 26) "-inf"
 27) "tx4power"
 28) "-inf"
 29) "tx5bias"
 30) "0.0"
 31) "rx5power"
 32) "-inf"
 33) "tx5power"
 34) "-inf"
 35) "tx6bias"
 36) "0.0"
 37) "rx6power"
 38) "-inf"
 39) "tx6power"
 40) "-inf"
 41) "tx7bias"
 42) "0.0"
 43) "rx7power"
 44) "-inf"
 45) "tx7power"
 46) "-inf"
 47) "tx8bias"
 48) "0.0"
 49) "rx8power"
 50) "-inf"
 51) "tx8power"
 52) "-inf"
 53) "laser_temperature"
 54) "50.3203125"
 55) "prefec_ber_min_media_input1"
 56) "6.0299999999999995e-05"
 57) "prefec_ber_max_media_input1"
 58) "1.0"
 59) "prefec_ber_avg_media_input1"
 60) "0.000134"
 61) "prefec_ber_curr_media_input1"
 62) "0.000138"
 63) "errored_frames_min_media_input1"
 64) "0.0"
 65) "errored_frames_max_media_input1"
 66) "10000000000"
 67) "errored_frames_avg_media_input1"
 68) "0.0"
 69) "errored_frames_curr_media_input1"
 70) "0.0"
 71) "prefec_ber_min_host_input1"
 72) "0.0"
 73) "prefec_ber_min_host_input2"
 74) "1.0"
 75) "prefec_ber_min_host_input3"
 76) "1.0"
 77) "prefec_ber_min_host_input4"
 78) "1.0"
 79) "prefec_ber_max_host_input1"
 80) "1.0"
 81) "prefec_ber_max_host_input2"
 82) "1.0"
 83) "prefec_ber_max_host_input3"
 84) "1.0"
 85) "prefec_ber_max_host_input4"
 86) "1.0"
 87) "prefec_ber_avg_host_input1"
 88) "7.91e-09"
 89) "prefec_ber_avg_host_input2"
 90) "1.0"
 91) "prefec_ber_avg_host_input3"
 92) "1.0"
 93) "prefec_ber_avg_host_input4"
 94) "1.0"
 95) "prefec_ber_curr_host_input1"
 96) "8.01e-09"
 97) "prefec_ber_curr_host_input2"
 98) "1.0"
 99) "prefec_ber_curr_host_input3"
100) "1.0"
101) "prefec_ber_curr_host_input4"
102) "1.0"
103) "errored_frames_min_host_input1"
104) "0.0"
105) "errored_frames_min_host_input2"
106) "0.0"
107) "errored_frames_min_host_input3"
108) "0.0"
109) "errored_frames_min_host_input4"
110) "0.0"
111) "errored_frames_max_host_input1"
112) "10000000000"
113) "errored_frames_max_host_input2"
114) "0.0"
115) "errored_frames_max_host_input3"
116) "0.0"
117) "errored_frames_max_host_input4"
118) "0.0"
119) "errored_frames_avg_host_input1"
120) "0.0"
121) "errored_frames_avg_host_input2"
122) "0.0"
123) "errored_frames_avg_host_input3"
124) "0.0"
125) "errored_frames_avg_host_input4"
126) "0.0"
127) "errored_frames_curr_host_input1"
128) "0.0"
129) "errored_frames_curr_host_input2"
130) "0.0"
131) "errored_frames_curr_host_input3"
132) "0.0"
133) "errored_frames_curr_host_input4"
134) "0.0"
135) "biasxi"
136) "70.11062790875106"
137) "biasxq"
138) "32.05920500495918"
139) "biasxp"
140) "63.0411230640116"
141) "biasyi"
142) "60.34790569924468"
143) "biasyq"
144) "77.43343251697566"
145) "biasyp"
146) "37.4517433432517"
147) "cdshort"
148) "93"
149) "cdlong"
150) "80"
151) "dgd"
152) "4.93"
153) "sopmd"
154) "N/A"
155) "soproc"
156) "1"
157) "pdl"
158) "0.4"
159) "osnr"
160) "34.9"
161) "esnr"
162) "31.900000000000002"
163) "cfo"
164) "62"
165) "txcurrpower"
166) "-10.32"
167) "rxtotpower"
168) "-11.17"
169) "rxsigpower"
170) "N/A"
171) "laser_config_freq"
172) "193100"
173) "laser_curr_freq"
174) "193100.0"
175) "tx_config_power"
176) "-10.29"
root@sonic:/home/admin# 
```

EEPROM DOM CLI output
```
root@sonic:/home/admin# show int transceiver eeprom -d Ethernet144
Ethernet144: SFP EEPROM detected
        Active Firmware: 2.2.2
        Active application selected code assigned to host lane 1: 1
        Active application selected code assigned to host lane 2: 1
        Active application selected code assigned to host lane 3: 1
        Active application selected code assigned to host lane 4: 1
        Active application selected code assigned to host lane 5: 1
        Active application selected code assigned to host lane 6: 1
        Active application selected code assigned to host lane 7: 1
        Active application selected code assigned to host lane 8: 1
        Application Advertisement: 400GAUI-8 C2M (Annex 120E) - Host Assign (0x1) - 400ZR, DWDM, amplified - Media Assign (0x1)
                                   100GAUI-2 C2M (Annex 135G) - Host Assign (0x55) - 400ZR, DWDM, amplified - Media Assign (0x1)
        CMIS Rev: 5.0
        Connector: LC
        Encoding: N/A
        Extended Identifier: Power Class 8 (18.0W Max)
        Extended RateSelect Compliance: N/A
        Host Lane Count: 8
        Identifier: QSFP-DD Double Density 8X Pluggable Transceiver
        Inactive Firmware: 1.1.1
        Length Cable Assembly(m): 0.0
        Media Interface Technology: C-band tunable laser
        Media Lane Count: 1
        Module Hardware Rev: 0.0
        Nominal Bit Rate(100Mbs): 0
        Specification compliance: sm_media_interface
        Supported Max Laser Frequency: 196100
        Supported Max TX Power: -10.3
        Supported Min Laser Frequency: 191300
        Supported Min TX Power: -14.0
        Vendor Date Code(YYYY-MM-DD Lot): 0000-00-00
        Vendor Name: XXXXX
        Vendor OUI: 00-00--00
        Vendor PN: VENDOR_ABC
        Vendor Rev: 01
        Vendor SN: A12345678
        ChannelMonitorValues:
                RX1Power: -11.163dBm
                RX2Power: -infdBm
                RX3Power: -infdBm
                RX4Power: -infdBm
                RX5Power: -infdBm
                RX6Power: -infdBm
                RX7Power: -infdBm
                RX8Power: -infdBm
                TX1Bias: 201.896mA
                TX1Power: -10.32dBm
                TX2Bias: 0.0mA
                TX2Power: -infdBm
                TX3Bias: 0.0mA
                TX3Power: -infdBm
                TX4Bias: 0.0mA
                TX4Power: -infdBm
                TX5Bias: 0.0mA
                TX5Power: -infdBm
                TX6Bias: 0.0mA
                TX6Power: -infdBm
                TX7Bias: 0.0mA
                TX7Power: -infdBm
                TX8Bias: 0.0mA
                TX8Power: -infdBm
        ChannelThresholdValues:
                RxPowerHighAlarm  : 2.0dBm
                RxPowerHighWarning: 0.0dBm
                RxPowerLowAlarm   : -21.024dBm
                RxPowerLowWarning : -18.013dBm
                TxBiasHighAlarm   : 450.0mA
                TxBiasHighWarning : 420.0mA
                TxBiasLowAlarm    : 100.0mA
                TxBiasLowWarning  : 110.0mA
                TxPowerHighAlarm  : -5.0dBm
                TxPowerHighWarning: -6.0dBm
                TxPowerLowAlarm   : -16.99dBm
                TxPowerLowWarning : -16.003dBm
        ModuleMonitorValues:
                Temperature: 56.102C
                Vcc: 3.344Volts
        ModuleThresholdValues:
                TempHighAlarm  : 80.0C
                TempHighWarning: 75.0C
                TempLowAlarm   : -5.0C
                TempLowWarning : 0.0C
                VccHighAlarm   : 3.465Volts
                VccHighWarning : 3.4Volts
                VccLowAlarm    : 3.1Volts
                VccLowWarning  : 3.15Volts
root@sonic:/home/admin# 
```

#### Additional Information (Optional)
MSFT ADO - 28751849
