### PR TITLE
[CMIS] Add lane_mask parameter to set_loopback_mode() to enable setti…

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -1115,15 +1115,18 @@ class CmisApi(XcvrApi):
         loopback_capability['media_side_output_loopback_supported'] = bool((allowed_loopback_result >> 0) & 0x1)
         return loopback_capability
 
-    def set_loopback_mode(self, loopback_mode):
+    def set_loopback_mode(self, loopback_mode, lane_mask = 0xff):
         '''
         This function sets the module loopback mode.
-        Loopback mode has to be one of the five:
+        loopback_mode: Loopback mode has to be one of the five:
         1. "none" (default)
         2. "host-side-input"
         3. "host-side-output"
         4. "media-side-input"
         5. "media-side-output"
+        lane_mask: A bitmask representing which lanes to apply the loopback mode to.
+        The default value of 0xFF indicates that the mode should be applied to all lanes.
+
         The function will look at 13h:128 to check advertized loopback capabilities.
         Return True if the provision succeeds, False if it fails
         '''
@@ -1138,22 +1141,22 @@ class CmisApi(XcvrApi):
             return all([status_host_input, status_host_output, status_media_input, status_media_output])
         elif loopback_mode == 'host-side-input':
             if loopback_capability['host_side_input_loopback_supported']:
-                return self.xcvr_eeprom.write(consts.HOST_INPUT_LOOPBACK, 0xff)
+                return self.xcvr_eeprom.write(consts.HOST_INPUT_LOOPBACK, lane_mask)
             else:
                 return False
         elif loopback_mode == 'host-side-output':
             if loopback_capability['host_side_output_loopback_supported']:
-                return self.xcvr_eeprom.write(consts.HOST_OUTPUT_LOOPBACK, 0xff)
+                return self.xcvr_eeprom.write(consts.HOST_OUTPUT_LOOPBACK, lane_mask)
             else:
                 return False
         elif loopback_mode == 'media-side-input':
             if loopback_capability['media_side_input_loopback_supported']:
-                return self.xcvr_eeprom.write(consts.MEDIA_INPUT_LOOPBACK, 0xff)
+                return self.xcvr_eeprom.write(consts.MEDIA_INPUT_LOOPBACK, lane_mask)
             else:
                 return False
         elif loopback_mode == 'media-side-output':
             if loopback_capability['media_side_output_loopback_supported']:
-                return self.xcvr_eeprom.write(consts.MEDIA_OUTPUT_LOOPBACK, 0xff)
+                return self.xcvr_eeprom.write(consts.MEDIA_OUTPUT_LOOPBACK, lane_mask)
             else:
                 return False
         else:

--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -1279,35 +1279,28 @@ class CmisApi(XcvrApi):
         else:
             return self.xcvr_eeprom.write(consts.MEDIA_OUTPUT_LOOPBACK, media_output_val & ~lane_mask)
 
-    def set_loopback_mode(self, loopback_mode, lane_mask = 0xff):
+    def set_loopback_mode(self, loopback_mode, lane_mask = 0xff, enable = False):
         '''
         This function sets the module loopback mode.
 
         Args:
         - loopback_mode (str): Specifies the loopback mode. It must be one of the following:
             1. "none"
-            2. "host-side-input-none"
-            3. "host-side-output-none"
-            4. "media-side-input-none"
-            5. "media-side-output-none"
-            6. "host-side-input"
-            7. "host-side-output"
-            8. "media-side-input"
-            9. "media-side-output"
+            2. "host-side-input"
+            3. "host-side-output"
+            4. "media-side-input"
+            5. "media-side-output"
         - lane_mask (int): A bitmask representing the lanes to which the loopback mode should
                            be applied. Default 0xFF applies to all lanes.
+        - enable (bool): Whether to enable or disable the loopback mode. Default False.
         Returns:
         - bool: True if the operation succeeds, False otherwise.
         '''
         loopback_functions = {
-            'host-side-input-none': (self.set_host_input_loopback, False),
-            'host-side-output-none': (self.set_host_output_loopback, False),
-            'media-side-input-none': (self.set_media_input_loopback, False),
-            'media-side-output-none': (self.set_media_output_loopback, False),
-            'host-side-input': (self.set_host_input_loopback, True),
-            'host-side-output': (self.set_host_output_loopback, True),
-            'media-side-input': (self.set_media_input_loopback, True),
-            'media-side-output': (self.set_media_output_loopback, True)
+            'host-side-input': self.set_host_input_loopback,
+            'host-side-output': self.set_host_output_loopback,
+            'media-side-input': self.set_media_input_loopback,
+            'media-side-output': self.set_media_output_loopback,
         }
 
         if loopback_mode == 'none':
@@ -1318,8 +1311,8 @@ class CmisApi(XcvrApi):
                 self.set_media_output_loopback(0xff, False)
             ])
 
-        if loopback_mode in loopback_functions:
-            func, enable = loopback_functions[loopback_mode]
+        func = loopback_functions.get(loopback_mode)
+        if func:
             return func(lane_mask, enable)
 
         logger.error('Invalid loopback mode:%s, lane_mask:%#x', loopback_mode, lane_mask)

--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -1147,6 +1147,11 @@ class CmisApi(XcvrApi):
         media_input_support = loopback_capability['media_side_input_loopback_supported']
         media_output_support = loopback_capability['media_side_output_loopback_supported']
 
+        if lane_mask != 0xff:
+            if any([loopback_capability['per_lane_host_loopback_supported'] is False and 'host' in loopback_mode,
+                    loopback_capability['per_lane_media_loopback_supported'] is False and 'media' in loopback_mode]):
+                return False
+
         if 'none' in loopback_mode:
             if loopback_mode == 'none':
                 status_host_input = self.xcvr_eeprom.write(consts.HOST_INPUT_LOOPBACK, 0)
@@ -1167,6 +1172,11 @@ class CmisApi(XcvrApi):
             if loopback_mode == 'media-side-output-none':
                 return self.xcvr_eeprom.write(consts.MEDIA_OUTPUT_LOOPBACK, media_output_val & ~lane_mask)
         else:
+            if loopback_capability['simultaneous_host_media_loopback_supported'] is False:
+                if any(['host' in loopback_mode and (media_input_val or media_output_val),
+                        'media' in loopback_mode and (host_input_val or host_output_val)]):
+                    return False
+
             if loopback_mode == 'host-side-input' and host_input_support:
                 return self.xcvr_eeprom.write(consts.HOST_INPUT_LOOPBACK, host_input_val | lane_mask)
 

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -1052,45 +1052,79 @@ class TestCmis(object):
         result = self.api.get_loopback_capability()
         assert result == expected
 
-    @pytest.mark.parametrize("input_param, mock_response",[
-        ('none', {
+    @pytest.mark.parametrize("input_param, mock_response, expected",[
+        (['none',0x0f], {
             'host_side_input_loopback_supported': True,
             'host_side_output_loopback_supported': True,
             'media_side_input_loopback_supported': True,
-            'media_side_output_loopback_supported': True
-        }),
-        ('host-side-input', {
+            'media_side_output_loopback_supported': True,
+            'simultaneous_host_media_loopback_supported': True,
+            'per_lane_host_loopback_supported': True,
+            'per_lane_media_loopback_supported': True
+        }, True),
+        (['host-side-input', 0x0f], {
             'host_side_input_loopback_supported': True,
             'host_side_output_loopback_supported': True,
             'media_side_input_loopback_supported': True,
-            'media_side_output_loopback_supported': True
-        }),
-        ('host-side-output', {
+            'media_side_output_loopback_supported': True,
+            'simultaneous_host_media_loopback_supported': True,
+            'per_lane_host_loopback_supported': True,
+            'per_lane_media_loopback_supported': True
+        }, True),
+        (['host-side-output', 0x0f], {
             'host_side_input_loopback_supported': True,
             'host_side_output_loopback_supported': True,
             'media_side_input_loopback_supported': True,
-            'media_side_output_loopback_supported': True
-        }),
-        ('media-side-input', {
+            'media_side_output_loopback_supported': True,
+            'simultaneous_host_media_loopback_supported': False,
+            'per_lane_host_loopback_supported': True,
+            'per_lane_media_loopback_supported': True
+        }, False),
+        (['host-side-output', 0x0f], {
             'host_side_input_loopback_supported': True,
             'host_side_output_loopback_supported': True,
             'media_side_input_loopback_supported': True,
-            'media_side_output_loopback_supported': True
-        }),
-        ('media-side-output', {
+            'media_side_output_loopback_supported': True,
+            'simultaneous_host_media_loopback_supported': True,
+            'per_lane_host_loopback_supported': False,
+            'per_lane_media_loopback_supported': True
+        }, False),
+        (['media-side-input', 0x0f], {
             'host_side_input_loopback_supported': True,
             'host_side_output_loopback_supported': True,
             'media_side_input_loopback_supported': True,
-            'media_side_output_loopback_supported': True
-        }),
-        (
-            'none', None
-        )
+            'media_side_output_loopback_supported': True,
+            'simultaneous_host_media_loopback_supported': True,
+            'per_lane_host_loopback_supported': True,
+            'per_lane_media_loopback_supported': True
+        }, True),
+        (['media-side-output', 0x0f], {
+            'host_side_input_loopback_supported': True,
+            'host_side_output_loopback_supported': True,
+            'media_side_input_loopback_supported': True,
+            'media_side_output_loopback_supported': True,
+            'simultaneous_host_media_loopback_supported': False,
+            'per_lane_host_loopback_supported': False,
+            'per_lane_media_loopback_supported': False
+        }, False),
+        (['media-side-output', 0x0f], {
+            'host_side_input_loopback_supported': False,
+            'host_side_output_loopback_supported': False,
+            'media_side_input_loopback_supported': False,
+            'media_side_output_loopback_supported': False,
+            'simultaneous_host_media_loopback_supported': True,
+            'per_lane_host_loopback_supported': True,
+            'per_lane_media_loopback_supported': True
+        }, False),
+        (['none', 0x0F], None, False)
     ])
-    def test_set_loopback_mode(self, input_param, mock_response):
+    def test_set_loopback_mode(self, input_param, mock_response, expected):
         self.api.get_loopback_capability = MagicMock()
         self.api.get_loopback_capability.return_value = mock_response
-        self.api.set_loopback_mode(input_param)
+        self.api.xcvr_eeprom.read = MagicMock()
+        self.api.xcvr_eeprom.read.side_effect = [0xf0,0,0xf0,0]
+        result = self.api.set_loopback_mode(input_param[0], input_param[1])
+        assert result == expected
 
     @pytest.mark.parametrize("mock_response, expected",[
         (

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -1206,15 +1206,15 @@ class TestCmis(object):
 
     @pytest.mark.parametrize("input_param, mock_response, expected",[
         (['none', 0], True, True),
-        (['host-side-input', 0x0F], True, True),
-        (['host-side-output', 0x0F], True, True),
-        (['media-side-input', 0x0F], True, True),
-        (['media-side-output', 0x0F], True, True),
-        (['host-side-input-none', 0xF0], True, True),
-        (['host-side-output-none', 0xF0], True, True),
-        (['media-side-input-none', 0xF0], True, True),
-        (['media-side-output-none', 0xF0], True, True),
-        (['', 0xF0], True, False),
+        (['host-side-input', 0x0F, True], True, True),
+        (['host-side-output', 0x0F, True], True, True),
+        (['media-side-input', 0x0F, True], True, True),
+        (['media-side-output', 0x0F, True], True, True),
+        (['host-side-input', 0xF0, False], True, True),
+        (['host-side-output', 0xF0, False], True, True),
+        (['media-side-input', 0xF0, False], True, True),
+        (['media-side-output', 0xF0, False], True, True),
+        (['', 0xF0, False], True, False),
 
     ])
     def test_set_loopback_mode(self, input_param, mock_response, expected):

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -1053,76 +1053,179 @@ class TestCmis(object):
         assert result == expected
 
     @pytest.mark.parametrize("input_param, mock_response, expected",[
-        (['none',0x0f], {
-            'host_side_input_loopback_supported': True,
-            'host_side_output_loopback_supported': True,
-            'media_side_input_loopback_supported': True,
-            'media_side_output_loopback_supported': True,
-            'simultaneous_host_media_loopback_supported': True,
-            'per_lane_host_loopback_supported': True,
-            'per_lane_media_loopback_supported': True
-        }, True),
-        (['host-side-input', 0x0f], {
-            'host_side_input_loopback_supported': True,
-            'host_side_output_loopback_supported': True,
-            'media_side_input_loopback_supported': True,
-            'media_side_output_loopback_supported': True,
-            'simultaneous_host_media_loopback_supported': True,
-            'per_lane_host_loopback_supported': True,
-            'per_lane_media_loopback_supported': True
-        }, True),
-        (['host-side-output', 0x0f], {
-            'host_side_input_loopback_supported': True,
-            'host_side_output_loopback_supported': True,
-            'media_side_input_loopback_supported': True,
-            'media_side_output_loopback_supported': True,
-            'simultaneous_host_media_loopback_supported': False,
-            'per_lane_host_loopback_supported': True,
-            'per_lane_media_loopback_supported': True
-        }, False),
-        (['host-side-output', 0x0f], {
-            'host_side_input_loopback_supported': True,
-            'host_side_output_loopback_supported': True,
-            'media_side_input_loopback_supported': True,
-            'media_side_output_loopback_supported': True,
-            'simultaneous_host_media_loopback_supported': True,
-            'per_lane_host_loopback_supported': False,
-            'per_lane_media_loopback_supported': True
-        }, False),
-        (['media-side-input', 0x0f], {
-            'host_side_input_loopback_supported': True,
-            'host_side_output_loopback_supported': True,
-            'media_side_input_loopback_supported': True,
-            'media_side_output_loopback_supported': True,
-            'simultaneous_host_media_loopback_supported': True,
-            'per_lane_host_loopback_supported': True,
-            'per_lane_media_loopback_supported': True
-        }, True),
-        (['media-side-output', 0x0f], {
-            'host_side_input_loopback_supported': True,
-            'host_side_output_loopback_supported': True,
-            'media_side_input_loopback_supported': True,
-            'media_side_output_loopback_supported': True,
-            'simultaneous_host_media_loopback_supported': False,
-            'per_lane_host_loopback_supported': False,
-            'per_lane_media_loopback_supported': False
-        }, False),
-        (['media-side-output', 0x0f], {
+        ([0xf, True], None, False),
+        ([0xf, True], {
             'host_side_input_loopback_supported': False,
-            'host_side_output_loopback_supported': False,
-            'media_side_input_loopback_supported': False,
-            'media_side_output_loopback_supported': False,
             'simultaneous_host_media_loopback_supported': True,
             'per_lane_host_loopback_supported': True,
-            'per_lane_media_loopback_supported': True
         }, False),
-        (['none', 0x0F], None, False)
+        ([0xf, True], {
+            'host_side_input_loopback_supported': True,
+            'simultaneous_host_media_loopback_supported': True,
+            'per_lane_host_loopback_supported': False,
+        }, False),
+        ([0xf, True], {
+            'host_side_input_loopback_supported': True,
+            'simultaneous_host_media_loopback_supported': False,
+            'per_lane_host_loopback_supported': True,
+        }, False),
+        ([0xf, True], {
+            'host_side_input_loopback_supported': True,
+            'simultaneous_host_media_loopback_supported': True,
+            'per_lane_host_loopback_supported': True,
+        }, True),
+        ([0xf, False], {
+            'host_side_input_loopback_supported': True,
+            'simultaneous_host_media_loopback_supported': True,
+            'per_lane_host_loopback_supported': True,
+        }, True),
     ])
-    def test_set_loopback_mode(self, input_param, mock_response, expected):
+    def test_set_host_input_loopback(self, input_param, mock_response, expected):
         self.api.get_loopback_capability = MagicMock()
         self.api.get_loopback_capability.return_value = mock_response
         self.api.xcvr_eeprom.read = MagicMock()
-        self.api.xcvr_eeprom.read.side_effect = [0xf0,0,0xf0,0]
+        self.api.xcvr_eeprom.read.side_effect = [0x0f,0x0f]
+        self.api.xcvr_eeprom.write = MagicMock()
+        self.api.xcvr_eeprom.write.return_value = True
+        result = self.api.set_host_input_loopback(input_param[0], input_param[1])
+        assert result == expected
+
+    @pytest.mark.parametrize("input_param, mock_response, expected",[
+        ([0xf, True], None, False),
+        ([0xf, True], {
+            'host_side_output_loopback_supported': False,
+            'simultaneous_host_media_loopback_supported': True,
+            'per_lane_host_loopback_supported': True,
+        }, False),
+        ([0xf, True], {
+            'host_side_output_loopback_supported': True,
+            'simultaneous_host_media_loopback_supported': True,
+            'per_lane_host_loopback_supported': False,
+        }, False),
+        ([0xf, True], {
+            'host_side_output_loopback_supported': True,
+            'simultaneous_host_media_loopback_supported': False,
+            'per_lane_host_loopback_supported': True,
+        }, False),
+        ([0xf, True], {
+            'host_side_output_loopback_supported': True,
+            'simultaneous_host_media_loopback_supported': True,
+            'per_lane_host_loopback_supported': True,
+        }, True),
+        ([0xf, False], {
+            'host_side_output_loopback_supported': True,
+            'simultaneous_host_media_loopback_supported': True,
+            'per_lane_host_loopback_supported': True,
+        }, True),
+    ])
+    def test_set_host_output_loopback(self, input_param, mock_response, expected):
+        self.api.get_loopback_capability = MagicMock()
+        self.api.get_loopback_capability.return_value = mock_response
+        self.api.xcvr_eeprom.read = MagicMock()
+        self.api.xcvr_eeprom.read.side_effect = [0x0f,0x0f]
+        self.api.xcvr_eeprom.write = MagicMock()
+        self.api.xcvr_eeprom.write.return_value = True
+        result = self.api.set_host_output_loopback(input_param[0], input_param[1])
+        assert result == expected
+
+    @pytest.mark.parametrize("input_param, mock_response, expected",[
+        ([0xf, True], None, False),
+        ([0xf, True], {
+            'media_side_input_loopback_supported': False,
+            'simultaneous_host_media_loopback_supported': True,
+            'per_lane_media_loopback_supported': True,
+        }, False),
+        ([0xf, True], {
+            'media_side_input_loopback_supported': True,
+            'simultaneous_host_media_loopback_supported': True,
+            'per_lane_media_loopback_supported': False,
+        }, False),
+        ([0xf, True], {
+            'media_side_input_loopback_supported': True,
+            'simultaneous_host_media_loopback_supported': False,
+            'per_lane_media_loopback_supported': True,
+        }, False),
+        ([0xf, True], {
+            'media_side_input_loopback_supported': True,
+            'simultaneous_host_media_loopback_supported': True,
+            'per_lane_media_loopback_supported': True,
+        }, True),
+        ([0xf, False], {
+            'media_side_input_loopback_supported': True,
+            'simultaneous_host_media_loopback_supported': True,
+            'per_lane_media_loopback_supported': True,
+        }, True),
+    ])
+    def test_set_media_input_loopback(self, input_param, mock_response, expected):
+        self.api.get_loopback_capability = MagicMock()
+        self.api.get_loopback_capability.return_value = mock_response
+        self.api.xcvr_eeprom.read = MagicMock()
+        self.api.xcvr_eeprom.read.side_effect = [0x0f,0x0f]
+        self.api.xcvr_eeprom.write = MagicMock()
+        self.api.xcvr_eeprom.write.return_value = True
+        result = self.api.set_media_input_loopback(input_param[0], input_param[1])
+        assert result == expected
+
+    @pytest.mark.parametrize("input_param, mock_response, expected",[
+        ([0xf, True], None, False),
+        ([0xf, True], {
+            'media_side_output_loopback_supported': False,
+            'simultaneous_host_media_loopback_supported': True,
+            'per_lane_media_loopback_supported': True,
+        }, False),
+        ([0xf, True], {
+            'media_side_output_loopback_supported': True,
+            'simultaneous_host_media_loopback_supported': True,
+            'per_lane_media_loopback_supported': False,
+        }, False),
+        ([0xf, True], {
+            'media_side_output_loopback_supported': True,
+            'simultaneous_host_media_loopback_supported': False,
+            'per_lane_media_loopback_supported': True,
+        }, False),
+        ([0xf, True], {
+            'media_side_output_loopback_supported': True,
+            'simultaneous_host_media_loopback_supported': True,
+            'per_lane_media_loopback_supported': True,
+        }, True),
+        ([0xf, False], {
+            'media_side_output_loopback_supported': True,
+            'simultaneous_host_media_loopback_supported': True,
+            'per_lane_media_loopback_supported': True,
+        }, True),
+    ])
+    def test_set_media_output_loopback(self, input_param, mock_response, expected):
+        self.api.get_loopback_capability = MagicMock()
+        self.api.get_loopback_capability.return_value = mock_response
+        self.api.xcvr_eeprom.read = MagicMock()
+        self.api.xcvr_eeprom.read.side_effect = [0x0f,0x0f]
+        self.api.xcvr_eeprom.write = MagicMock()
+        self.api.xcvr_eeprom.write.return_value = True
+        result = self.api.set_media_output_loopback(input_param[0], input_param[1])
+        assert result == expected
+
+    @pytest.mark.parametrize("input_param, mock_response, expected",[
+        (['none', 0], True, True),
+        (['host-side-input', 0x0F], True, True),
+        (['host-side-output', 0x0F], True, True),
+        (['media-side-input', 0x0F], True, True),
+        (['media-side-output', 0x0F], True, True),
+        (['host-side-input-none', 0xF0], True, True),
+        (['host-side-output-none', 0xF0], True, True),
+        (['media-side-input-none', 0xF0], True, True),
+        (['media-side-output-none', 0xF0], True, True),
+        (['', 0xF0], True, False),
+
+    ])
+    def test_set_loopback_mode(self, input_param, mock_response, expected):
+        self.api.set_host_input_loopback = MagicMock()
+        self.api.set_host_input_loopback.return_value = mock_response
+        self.api.set_host_output_loopback = MagicMock()
+        self.api.set_host_output_loopback.return_value = mock_response
+        self.api.set_media_input_loopback = MagicMock()
+        self.api.set_media_input_loopback.return_value = mock_response
+        self.api.set_media_output_loopback = MagicMock()
+        self.api.set_media_output_loopback.return_value = mock_response
         result = self.api.set_loopback_mode(input_param[0], input_param[1])
         assert result == expected
 


### PR DESCRIPTION
#### Description
This commit introduces two additional input parameters, lane_mask and enable, to the set_loopback_mode() function. By specifying lane_mask, users can enable or disable the loopback mode on individual lanes rather than applying it to the entire physical port

#### Motivation and Context
Previously, the set_loopback_mode() function affected all lanes of a physical port simultaneously, limiting flexibility. By adding the lane_mask parameter, this update allows callers to target specific lanes, thereby enabling more precise testing, debugging, and configuration of network equipment. 

#### How Has This Been Tested?
Only the corresponding lanes of the logical port will be manipulated with the newly updated **sfputil debug loopback** command.
![image](https://github.com/user-attachments/assets/76e2c712-4cfc-49b6-92bc-831b93448e2d)

Test log for the following reject cases:[loopback_error_case_test_log.txt](https://github.com/user-attachments/files/16860076/loopback_error_case_test_log.txt)
- Simultaneous host media loopback is not supported
- Host/media output loopback is not supported
- Per-lane/host host loopback is not supported

