### PR TITLE
Make is_flat_memory more robust

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -368,7 +368,7 @@ class CmisApi(XcvrApi):
         return float("{:.3f}".format(voltage))
 
     def is_flat_memory(self):
-        return self.xcvr_eeprom.read(consts.FLAT_MEM_FIELD)
+        return self.xcvr_eeprom.read(consts.FLAT_MEM_FIELD) is not False
 
     def get_temperature_support(self):
         return not self.is_flat_memory()

--- a/sonic_platform_base/sonic_xcvr/api/public/sff8436.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/sff8436.py
@@ -273,7 +273,7 @@ class Sff8436Api(XcvrApi):
         return ret
 
     def is_flat_memory(self):
-        return self.xcvr_eeprom.read(consts.FLAT_MEM_FIELD)
+        return self.xcvr_eeprom.read(consts.FLAT_MEM_FIELD) is not False
 
     def get_tx_power_support(self):
         return False

--- a/sonic_platform_base/sonic_xcvr/api/public/sff8472.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/sff8472.py
@@ -261,7 +261,7 @@ class Sff8472Api(XcvrApi):
         return self.tx_disable(disable) if channel != 0 else True
 
     def is_flat_memory(self):
-        return not self.xcvr_eeprom.read(consts.PAGING_SUPPORT_FIELD)
+        return not self.xcvr_eeprom.read(consts.PAGING_SUPPORT_FIELD) is not False
 
     def get_temperature_support(self):
         return self.xcvr_eeprom.read(consts.DDM_SUPPORT_FIELD)

--- a/sonic_platform_base/sonic_xcvr/api/public/sff8636.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/sff8636.py
@@ -299,7 +299,7 @@ class Sff8636Api(XcvrApi):
         return ret
 
     def is_flat_memory(self):
-        return self.xcvr_eeprom.read(consts.FLAT_MEM_FIELD)
+        return self.xcvr_eeprom.read(consts.FLAT_MEM_FIELD) is not False
 
     def get_tx_power_support(self):
         if self.is_copper():

--- a/sonic_platform_base/sonic_xcvr/api/xcvr_api.py
+++ b/sonic_platform_base/sonic_xcvr/api/xcvr_api.py
@@ -493,7 +493,7 @@ class XcvrApi(object):
         Returns:
             A Boolean, True if flat memory, False if paging is implemented
 
-            If there is an issue with reading the xcvr, None should be returned.
+            If there is an issue with reading the xcvr, True should be returned.
         """
         raise NotImplementedError
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
Currently, `is_flat_memory` could return 3 different values:

- True when the module is flat memory
- False when the module is not flat memory
- None when the EEPROM read returns None or empty bytearray

When it returns None, we should not assume that the module is NOT a flat memory. Instead, it would be safer to treat it as a flat memory.

 

#### Motivation and Context
This PR is to make `is_flat_memory` only returns two state, True or False. And if EEPROM reading returns None or empty bytearray, we should treat the module as a flat memory.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Manual test

#### Additional Information (Optional)

