### PR TITLE
Enhanced NVMe disk support, added limited eUSB disk support

### DIFF
--- a/sonic_platform_base/sonic_storage/ssd.py
+++ b/sonic_platform_base/sonic_storage/ssd.py
@@ -148,38 +148,41 @@ class SsdUtil(StorageCommon):
     def fetch_generic_ssd_info(self, diskdev):
         self.ssd_info = self._execute_shell(self.vendor_ssd_utility["Generic"]["utility"].format(diskdev))
 
+    def parse_nvme_ssd_info(self):
+        self.model = self._parse_re('Model Number:\s*(.+?)\n', self.ssd_info)
+
+        health_raw = self._parse_re('Percentage Used\s*(.+?)\n', self.ssd_info)
+        if health_raw == NOT_AVAILABLE:
+            self.health = NOT_AVAILABLE
+        else:
+            health_raw = health_raw.split()[-1]
+            self.health = 100 - float(health_raw.strip('%'))
+
+        temp_raw = self._parse_re('Temperature\s*(.+?)\n', self.ssd_info)
+        if temp_raw == NOT_AVAILABLE:
+            self.temperature = NOT_AVAILABLE
+        else:
+            temp_raw = temp_raw.split()[-2]
+            self.temperature = float(temp_raw)
+
+        spare_blocks_raw = self._parse_re('Available Spare\s*(.+?)\n', self.ssd_info)
+        if spare_blocks_raw != NOT_AVAILABLE:
+            spare_blocks_raw = spare_blocks_raw.split()[-1]
+            self.reserved_blocks = float(spare_blocks_raw.strip('%'))
+
+        disk_io_reads_raw = self._parse_re('Data Units Read\s*(.+?)\n', self.ssd_info)
+        if disk_io_reads_raw != NOT_AVAILABLE:
+            self.disk_io_reads = disk_io_reads_raw.split(':')[-1].strip()
+
+        disk_io_writes_raw = self._parse_re('Data Units Written\s*(.+?)\n', self.ssd_info)
+        if disk_io_writes_raw != NOT_AVAILABLE:
+            self.disk_io_writes = disk_io_writes_raw.split(':')[-1].strip()
+
     # Health and temperature values may be overwritten with vendor specific data
     def parse_generic_ssd_info(self):
+
         if "nvme" in self.dev:
-            self.model = self._parse_re('Model Number:\s*(.+?)\n', self.ssd_info)
-
-            health_raw = self._parse_re('Percentage Used\s*(.+?)\n', self.ssd_info)
-            if health_raw == NOT_AVAILABLE:
-                self.health = NOT_AVAILABLE
-            else:
-                health_raw = health_raw.split()[-1]
-                self.health = 100 - float(health_raw.strip('%'))
-
-            temp_raw = self._parse_re('Temperature\s*(.+?)\n', self.ssd_info)
-            if temp_raw == NOT_AVAILABLE:
-                self.temperature = NOT_AVAILABLE
-            else:
-                temp_raw = temp_raw.split()[-2]
-                self.temperature = float(temp_raw)
-
-            spare_blocks_raw = self._parse_re('Available Spare\s*(.+?)\n', self.ssd_info)
-            if spare_blocks_raw != NOT_AVAILABLE:
-                spare_blocks_raw = spare_blocks_raw.split()[-1]
-                self.reserved_blocks = float(spare_blocks_raw.strip('%'))
-
-            disk_io_reads_raw = self._parse_re('Data Units Read\s*(.+?)\n', self.ssd_info)
-            if disk_io_reads_raw != NOT_AVAILABLE:
-                self.disk_io_reads = disk_io_reads_raw.split(':')[-1].strip()
-
-            disk_io_writes_raw = self._parse_re('Data Units Written\s*(.+?)\n', self.ssd_info)
-            if disk_io_writes_raw != NOT_AVAILABLE:
-                self.disk_io_writes = disk_io_writes_raw.split(':')[-1].strip()
-
+            self.parse_nvme_ssd_info()
         else:
             self.model = self._parse_re('Device Model:\s*(.+?)\n', self.ssd_info)
 

--- a/sonic_platform_base/sonic_storage/storage_devices.py
+++ b/sonic_platform_base/sonic_storage/storage_devices.py
@@ -23,6 +23,8 @@ except ImportError as e:
 
 BASE_PATH = "/sys/block"
 BLKDEV_BASE_PATH = "/dev"
+ssdutil_compatible_keys = ('sd', 'nvme')
+ssdutil_compatible_paths_strings = ('ata', 'nvme')
 
 class StorageDevices:
     def __init__(self):
@@ -65,9 +67,9 @@ class StorageDevices:
         blkdev = os.path.join(BLKDEV_BASE_PATH, key)
         diskdev = os.path.join(BASE_PATH, key)
 
-        if key.startswith('sd'):
+        if key.startswith(ssdutil_compatible_keys):
             path = os.path.join(diskdev, "device")
-            if "ata" in os.path.realpath(path):
+            if any(substring in os.path.realpath(path) for substring in ssdutil_compatible_paths_strings):
                 try:
                     return SsdUtil(blkdev)
                 except Exception as e:

--- a/sonic_platform_base/sonic_storage/storage_devices.py
+++ b/sonic_platform_base/sonic_storage/storage_devices.py
@@ -12,6 +12,8 @@ try:
     from sonic_py_common import syslogger
     from sonic_platform_base.sonic_storage.ssd import SsdUtil
     from sonic_platform_base.sonic_storage.emmc import EmmcUtil
+    from sonic_platform_base.sonic_storage.usb import UsbUtil
+
 except ImportError as e:
     raise ImportError (str(e) + "- required module not found")
 

--- a/sonic_platform_base/sonic_storage/usb.py
+++ b/sonic_platform_base/sonic_storage/usb.py
@@ -8,7 +8,6 @@
 try:
     import os
     from .storage_common import StorageCommon
-    from sonic_py_common import syslogger
     from blkinfo import BlkDiskInfo
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
@@ -35,9 +34,6 @@ class UsbUtil(StorageCommon):
         self.diskdev = diskdev
         self.path = os.path.join('/sys/block', os.path.basename(diskdev))
         StorageCommon.__init__(self, diskdev)
-
-        self.log_identifier = "UsbUtil"
-        self.log = syslogger.SysLogger(self.log_identifier)
 
         self.fetch_parse_info()
 

--- a/sonic_platform_base/sonic_storage/usb.py
+++ b/sonic_platform_base/sonic_storage/usb.py
@@ -1,0 +1,140 @@
+#
+# usb.py
+#
+# Implementation of SSD Utility API for eUSB.
+# It reads eUSB health, model, firmware, and serial from /sys/block/*.
+#
+
+try:
+    import os
+    from .storage_common import StorageCommon
+    from sonic_py_common import syslogger
+    from blkinfo import BlkDiskInfo
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+
+NOT_AVAILABLE = "N/A"
+
+class UsbUtil(StorageCommon):
+
+    model = NOT_AVAILABLE
+    serial = NOT_AVAILABLE
+    firmware = NOT_AVAILABLE
+    temperature = NOT_AVAILABLE
+    health = NOT_AVAILABLE
+    vendor = NOT_AVAILABLE
+    disk_io_reads = NOT_AVAILABLE
+    disk_io_writes = NOT_AVAILABLE
+    reserved_blocks = NOT_AVAILABLE
+    blkd = {}
+
+
+    def __init__(self, diskdev):
+
+        self.diskdev = diskdev
+        self.path = os.path.join('/sys/block', os.path.basename(diskdev))
+        StorageCommon.__init__(self, diskdev)
+
+        self.log_identifier = "UsbUtil"
+        self.log = syslogger.SysLogger(self.log_identifier)
+
+        self.fetch_parse_info()
+
+    def fetch_parse_info(self, diskdev=None):
+        self.fetch_blkinfo()
+        self.parse_blkinfo()
+
+    def fetch_blkinfo(self):
+        filters = {}
+        filters['name'] = '{}'.format(os.path.basename(self.diskdev))
+        self.blkd = BlkDiskInfo().get_disks(filters)[0]
+
+    def parse_blkinfo(self):
+        if 'dict' in str(type(self.blkd)) and self.blkd:
+            self.model = self.blkd["model"]
+            self.serial = self.blkd["serial"]
+            self.vendor = self.blkd["vendor"]
+
+    def get_health(self):
+        """
+        Retrieves current disk health in percentages
+
+        Returns:
+            A float number of current ssd health
+            e.g. 83.5
+        """
+        return self.health
+
+    def get_temperature(self):
+        """
+        Retrieves current disk temperature in Celsius
+
+        Returns:
+            A float number of current temperature in Celsius
+            e.g. 40.1
+        """
+        return self.temperature
+
+    def get_model(self):
+        """
+        Retrieves model for the given disk device
+
+        Returns:
+            A string holding disk model as provided by the manufacturer
+        """
+        return self.model
+
+    def get_firmware(self):
+        """
+        Retrieves firmware version for the given disk device
+
+        Returns:
+            A string holding disk firmware version as provided by the manufacturer
+        """
+        return self.firmware
+
+    def get_serial(self):
+        """
+        Retrieves serial number for the given disk device
+
+        Returns:
+            A string holding disk serial number as provided by the manufacturer
+        """
+        return self.serial
+
+    def get_disk_io_reads(self):
+        """
+        Retrieves the total number of Input/Output (I/O) reads done on an SSD
+
+        Returns:
+            An integer value of the total number of I/O reads
+        """
+        return self.disk_io_reads
+
+    def get_disk_io_writes(self):
+        """
+        Retrieves the total number of Input/Output (I/O) writes done on an SSD
+
+        Returns:
+            An integer value of the total number of I/O writes
+        """
+        return self.disk_io_writes
+
+    def get_reserved_blocks(self):
+        """
+        Retrieves the total number of reserved blocks in an SSD
+
+        Returns:
+            An integer value of the total number of reserved blocks
+        """
+        return self.reserved_blocks
+
+    def get_vendor_output(self):
+        """
+        Retrieves vendor specific data for the given disk device
+
+        Returns:
+            A string holding some vendor specific disk information
+        """
+        return self.vendor

--- a/tests/mocked_libs/blkinfo.py
+++ b/tests/mocked_libs/blkinfo.py
@@ -1,0 +1,90 @@
+mock_json_op = \
+    [
+        {
+            "name": "sdx",
+            "kname": "sdx",
+            "fstype": "",
+            "label": "",
+            "mountpoint": "",
+            "size": "3965714432",
+            "maj:min": "8:0",
+            "rm": "0",
+            "model": "SMART EUSB",
+            "vendor": "SMART EUSB",
+            "serial": "SPG200807J1",
+            "hctl": "2:0:0:0",
+            "tran": "usb",
+            "rota": "1",
+            "type": "disk",
+            "ro": "0",
+            "owner": "",
+            "group": "",
+            "mode": "brw-rw----",
+            "children": [
+                {
+                    "name": "sdx1",
+                    "kname": "sdx1",
+                    "fstype": "ext4",
+                    "label": "",
+                    "mountpoint": "/host",
+                    "size": "3964665856",
+                    "maj:min": "8:1",
+                    "rm": "0",
+                    "model": " ",
+                    "vendor": " ",
+                    "serial": "",
+                    "hctl": "",
+                    "tran": "",
+                    "rota": "1",
+                    "type": "part",
+                    "ro": "0",
+                    "owner": "",
+                    "group": "",
+                    "mode": "brw-rw----",
+                    "children": [],
+                    "parents": ["sdx"],
+                    "statistics": {
+                        "major": "8",
+                        "minor": "1",
+                        "kname": "sdx1",
+                        "reads_completed": "22104",
+                        "reads_merged": "5299",
+                        "sectors_read": "1091502",
+                        "time_spent_reading_ms": "51711",
+                        "writes_completed": "11283",
+                        "writes_merged": "13401",
+                        "sectors_written": "443784",
+                        "time_spent_ writing": "133398",
+                        "ios_in_progress": "0",
+                        "time_spent_doing_ios_ms": "112040",
+                        "weighted_time_ios_ms": "112040",
+                    },
+                }
+            ],
+            "parents": [],
+            "statistics": {
+                "major": "8",
+                "minor": "0",
+                "kname": "sdx",
+                "reads_completed": "22151",
+                "reads_merged": "5299",
+                "sectors_read": "1093606",
+                "time_spent_reading_ms": "52005",
+                "writes_completed": "11283",
+                "writes_merged": "13401",
+                "sectors_written": "443784",
+                "time_spent_ writing": "133398",
+                "ios_in_progress": "0",
+                "time_spent_doing_ios_ms": "112220",
+                "weighted_time_ios_ms": "112220",
+            },
+        }
+    ]
+
+
+class BlkDiskInfo:
+    def __init__(self):
+        return
+
+    def get_disks(self, filters={}):
+        return mock_json_op

--- a/tests/mocked_libs/psutil.py
+++ b/tests/mocked_libs/psutil.py
@@ -1,0 +1,6 @@
+from collections import namedtuple
+
+
+def disk_partitions():
+    sdiskio = namedtuple('sdiskio', ['read_count', 'write_count'])
+    return sdiskio(read_count=42444, write_count=210141)

--- a/tests/test_ssd.py
+++ b/tests/test_ssd.py
@@ -1198,6 +1198,9 @@ class TestSsd:
         assert(nvme_ssd.get_firmware() == "COT6OQ")
         assert(nvme_ssd.get_temperature() == 37)
         assert(nvme_ssd.get_serial() == "A0221030722410000027")
+        assert(nvme_ssd.get_disk_io_reads() == "1,546,369 [791 GB]")
+        assert(nvme_ssd.get_disk_io_writes() == "7,118,163 [3.64 TB]")
+        assert(nvme_ssd.get_reserved_blocks() == 100.0)
 
     @mock.patch('sonic_platform_base.sonic_storage.ssd.SsdUtil._execute_shell', mock.MagicMock(return_value=output_lack_info_ssd))
     def test_nvme_ssd_with_na_path(self):

--- a/tests/test_storage_devices.py
+++ b/tests/test_storage_devices.py
@@ -1,12 +1,21 @@
+import os
 import sys
 from mock import patch, MagicMock
 import pytest
 
-from sonic_platform_base.sonic_storage.storage_devices import StorageDevices
-
 mocked_basepath = ['loop1', 'mmcblk0', 'loop6', 'mmcblk0boot0', 'loop4', 'loop2', 'loop0', 'loop7', 'mmcblk0boot1', 'sda', 'loop5', 'loop3']
 mocked_devices = { 'mmcblk0' : None, 'sda' : None}
 mock_realpath = "/sys/devices/pci0000:00/0000:00:18.0/ata5/host4/target4:0:0/4:0:0:0"
+
+tests_path = os.path.dirname(os.path.abspath(__file__))
+# Add mocked_libs path so that the file under test
+# can load mocked modules from there
+mocked_libs_path = os.path.join(tests_path, "mocked_libs")  # noqa: E402,F401
+sys.path.insert(0, mocked_libs_path)
+
+from .mocked_libs.blkinfo import BlkDiskInfo  # noqa: E402,F401
+
+from sonic_platform_base.sonic_storage.storage_devices import StorageDevices
 
 
 class TestStorageDevices:
@@ -26,12 +35,13 @@ class TestStorageDevices:
 
     @patch('os.listdir', MagicMock(return_value=['sdj']))
     @patch('os.path.realpath', MagicMock(return_value="usb"))
+    @patch('sonic_platform_base.sonic_storage.usb.UsbUtil', MagicMock())
     def test_get_storage_devices_usb_obj(self):
 
         storage = StorageDevices()
 
         assert (list(storage.devices.keys()) == ['sdj'])
-        assert (storage.devices['sdj'] == None)
+        assert ("UsbUtil" in str(type(storage.devices['sdj'])))
 
 
     @patch('os.listdir', MagicMock(return_value=['mmcblk0']))

--- a/tests/test_usb.py
+++ b/tests/test_usb.py
@@ -1,0 +1,29 @@
+import os
+import sys
+from mock import patch, MagicMock
+
+tests_path = os.path.dirname(os.path.abspath(__file__))
+# Add mocked_libs path so that the file under test
+# can load mocked modules from there
+mocked_libs_path = os.path.join(tests_path, "mocked_libs")  # noqa: E402,F401
+sys.path.insert(0, mocked_libs_path)
+
+from .mocked_libs.blkinfo import BlkDiskInfo  # noqa: E402,F401
+from sonic_platform_base.sonic_storage import usb
+
+class TestUsb:
+
+    def test_eusb_disk(self):
+
+        usb_disk = usb.UsbUtil("sdx")
+
+        assert usb_disk.get_model() == "SMART EUSB"
+        assert usb_disk.get_serial() == "SPG200807J1"
+        assert usb_disk.get_vendor_output() == "SMART EUSB"
+        assert usb_disk.get_firmware() == "N/A"
+        assert usb_disk.get_temperature() == "N/A"
+        assert usb_disk.get_health() == "N/A"
+        assert usb_disk.get_disk_io_reads() == "N/A"
+        assert usb_disk.get_disk_io_writes() == "N/A"
+        assert usb_disk.get_reserved_blocks() == "N/A"
+


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

1. Modified storage_devices.py to support class object instantiation for devices with NVMe and eUSB storage disks.
2. Full support for NVMe devices, limited support for eUSB per [promised Future Work on the Storage Monitoring Daemon](https://github.com/sonic-net/SONiC/blob/master/doc/storagemond/storagemond-hld.md#future-work)
3. Fixed bug within parse_generic_ssd_info() function in Ssdutil class that would overwrite disk_io_reads, disk_io_writes and reserved_blocks information for NVMe disks with `N/A` after successfully parsing said values. This is due to an indentation bug and has been fixed as part of this commit.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

This PR is in line with [promised future work on the Storage Monitoring Daemon](https://github.com/sonic-net/SONiC/blob/master/doc/storagemond/storagemond-hld.md#future-work). It adds support for devices with NVMe storage disks.

Needs to be merged only after https://github.com/sonic-net/sonic-buildimage/pull/20053 is merged to master+202405 branches.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

 **NVMe**

Ran image containing these changes on a device with an NVMe disk and verified that storage disk attributes were getting successfully parsed and updated to `STATE_DB`.

```
[root@str3-7060x6-64pe-2:~# lsblk
NAME        MAJ:MIN RM   SIZE RO TYPE MOUNTPOINTS
loop0         7:0    0 386.4M  0 loop
loop1         7:1    0     4G  0 loop /var/log
nvme0n1     259:0    0 223.6G  0 disk
├─nvme0n1p1 259:1    0 223.5G  0 part /boot
│                                     /var/lib/docker
│                                     /host
├─nvme0n1p2 259:2    0    64M  0 part
└─nvme0n1p3 259:3    0     1M  0 part
```

Syslogs:

```
2024 Aug 24 07:55:50.392206 str3-7060x6-64pe-2 INFO pmon#stormond[906]: Starting Storage Monitoring Daemon
2024 Aug 24 07:55:50.437050 str3-7060x6-64pe-2 INFO pmon#stormond[906]: Storage Device: nvme0n1, Device Model: ATP AF240GSTJA-AW1, Serial: 23090240-000257
2024 Aug 24 07:55:50.437789 str3-7060x6-64pe-2 INFO pmon#stormond[906]: Polling Interval set to 60 seconds
2024 Aug 24 07:55:50.437789 str3-7060x6-64pe-2 INFO pmon#stormond[906]: FSIO JSON file Interval set to 360 seconds
2024 Aug 24 07:55:50.481670 str3-7060x6-64pe-2 INFO pmon#stormond[906]: Storage Device: nvme0n1, Firmware: 42A4SB6G, health: 100.0%, Temp: 27.0C, FS IO Reads: 95432, FS IO Writes: 18860
2024 Aug 24 07:55:50.481837 str3-7060x6-64pe-2 INFO pmon#stormond[906]: Latest FSIO Reads: 95432, Latest FSIO Writes: 18860
2024 Aug 24 07:55:50.481837 str3-7060x6-64pe-2 INFO pmon#stormond[906]: Disk IO Reads: 3,657,918 [1.87 TB], Disk IO Writes: 1,155,355 [591 GB], Reserved Blocks: 100.0
2024 Aug 24 07:56:00.045910 str3-7060x6-64pe-2 INFO pmon#supervisord 2024-08-24 07:56:00,044 INFO success: stormond entered RUNNING state, process has stayed up for > than 10 seconds (startsecs)
```

STATE_DB:

```
root@sonic-device:/usr/local/bin# redis-cli -n 6 HGETALL "STORAGE_INFO|nvme0n1"
 1) "device_model"
 2) "ATP AF240GSTJA-AW1"
 3) "serial"
 4) "23090240-000257"
 5) "firmware"
 6) "42A4SB6G"
 7) "health"
 8) "100.0"
 9) "temperature"
10) "27.0"
11) "latest_fsio_reads"
12) "95432"
13) "latest_fsio_writes"
14) "18971"
15) "disk_io_reads"
16) "3,657,918 [1.87 TB]"
17) "disk_io_writes"
18) "1,155,357 [591 GB]"
19) "reserved_blocks"
20) "100.0"
21) "total_fsio_reads"
22) "95432"
23) "total_fsio_writes"
24) "18971"
```

**eUSB**

```
root@str2-7050qx-32s-acs-03:~# realpath /sys/block/sda/device
/sys/devices/pci0000:00/0000:00:12.2/usb1/1-2/1-2:1.0/host2/target2:0:0/2:0:0:0
root@str2-7050qx-32s-acs-03:~#
```

Syslogs:

```
2024 Aug 28 06:37:32.875451 str2-7050qx-32s-acs-03 INFO pmon#stormond[466]: Starting Storage Monitoring Daemon
2024 Aug 28 06:37:32.875451 str2-7050qx-32s-acs-03 INFO pmon#stormond[466]: Storage Device: sda, Device Model: SMART EUSB, Serial:
2024 Aug 28 06:37:32.877125 str2-7050qx-32s-acs-03 INFO pmon#stormond[466]: Polling Interval set to 60 seconds
2024 Aug 28 06:37:32.877125 str2-7050qx-32s-acs-03 INFO pmon#stormond[466]: FSIO JSON file Interval set to 360 seconds
2024 Aug 28 06:37:32.906668 str2-7050qx-32s-acs-03 INFO pmon#stormond[466]: Storage Device: sda, Firmware: N/A, health: N/A%, Temp: N/AC, FS IO Reads: 32835, FS IO Writes: 7658
2024 Aug 28 06:37:32.906803 str2-7050qx-32s-acs-03 INFO pmon#stormond[466]: Latest FSIO Reads: 32835, Latest FSIO Writes: 7658
2024 Aug 28 06:37:32.906865 str2-7050qx-32s-acs-03 INFO pmon#stormond[466]: Disk IO Reads: N/A, Disk IO Writes: N/A, Reserved Blocks: N/A

```

STATE_DB:

```
root@str2-7050qx-32s-acs-03:~# redis-cli -n 6 HGETALL "STORAGE_INFO|sda"
 1) "device_model"
 2) "SMART EUSB"
 3) "serial"
 4) ""
 5) "firmware"
 6) "N/A"
 7) "health"
 8) "N/A"
 9) "temperature"
10) "N/A"
11) "latest_fsio_reads"
12) "32854"
13) "latest_fsio_writes"
14) "7723"
15) "disk_io_reads"
16) "N/A"
17) "disk_io_writes"
18) "N/A"
19) "reserved_blocks"
20) "N/A"
21) "total_fsio_reads"
22) "32854"
23) "total_fsio_writes"
24) "7723"
```

#### Additional Information (Optional)

