### PR TITLE
Add is_copper definition to cmis api

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -372,7 +372,7 @@ class CmisApi(XcvrApi):
         Returns True if the module is copper, False otherwise
         '''
         media_intf = self.get_module_media_type()
-        return media_intf == "passive_copper_media_interface" or media_intf == "active_cable_media_interface"
+        return media_intf == "passive_copper_media_interface"
 
     def is_flat_memory(self):
         return self.xcvr_eeprom.read(consts.FLAT_MEM_FIELD) is not False

--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -367,6 +367,13 @@ class CmisApi(XcvrApi):
             return None
         return float("{:.3f}".format(voltage))
 
+    def is_copper(self):
+        '''
+        Returns True if the module is copper, False otherwise
+        '''
+        media_intf = self.get_module_media_type()
+        return media_intf == "passive_copper_media_interface" or media_intf == "active_cable_media_interface"
+
     def is_flat_memory(self):
         return self.xcvr_eeprom.read(consts.FLAT_MEM_FIELD) is not False
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
For CMIS it's pretty easy to tell if a module is copper because the media interface will always be passive_copper_media_interface. This PR adds a check for that.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
Similar to other SFF xcvr api's it would be helpful to know if a CMIS module is copper or optical. We can use this information for tunings and in other areas where appropriate.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Manually tested a lot of copper and optical modules ensuring they return the correct type.
