### PR TITLE
Wait for specified duration during LPmode on/off

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -1077,13 +1077,13 @@ class CmisApi(XcvrApi):
         if self.is_flat_memory() or not self.get_lpmode_support():
             return False
 
+        DELAY_RETRY = 0.1
         lpmode_val = self.xcvr_eeprom.read(consts.MODULE_LEVEL_CONTROL)
         if lpmode_val is not None:
             if lpmode is True:
                 # Force module transition to LowPwr under SW control
                 lpmode_val = lpmode_val | (1 << CmisApi.LowPwrRequestSW)
                 self.xcvr_eeprom.write(consts.MODULE_LEVEL_CONTROL, lpmode_val)
-                time.sleep(0.1)
                 start_time = time.time()
                 pwroff_duration = self.get_module_pwr_down_duration()/1000
                 # Loop until the power-off duration has elapsed
@@ -1091,7 +1091,7 @@ class CmisApi(XcvrApi):
                     if self.get_lpmode():
                         return self.get_lpmode()
                     # Sleep for a short interval before the next check
-                    time.sleep(0.1)
+                    time.sleep(DELAY_RETRY)
                 return self.get_lpmode()
             else:
                 # Force transition from LowPwr to HighPower state under SW control.
@@ -1099,7 +1099,6 @@ class CmisApi(XcvrApi):
                 lpmode_val = lpmode_val & ~(1 << CmisApi.LowPwrRequestSW)
                 lpmode_val = lpmode_val & ~(1 << CmisApi.LowPwrAllowRequestHW)
                 self.xcvr_eeprom.write(consts.MODULE_LEVEL_CONTROL, lpmode_val)
-                time.sleep(1)
                 start_time = time.time()
                 # Loop until the power-on duration has elapsed
                 pwron_duration = self.get_module_pwr_up_duration()/1000
@@ -1108,7 +1107,7 @@ class CmisApi(XcvrApi):
                     if mstate == 'ModuleReady':
                         return True
                     # Sleep for a short interval before the next check
-                    time.sleep(0.1)
+                    time.sleep(DELAY_RETRY)
         return False
 
     def get_loopback_capability(self):

--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -1066,7 +1066,7 @@ class CmisApi(XcvrApi):
                 return True
         return False
 
-     def wait_time_condition(self, condition_func, expected_state, duration_ms, delay_retry):
+    def wait_time_condition(self, condition_func, expected_state, duration_ms, delay_retry):
         '''
         This function will wait and retry based on
         condition function state and delay provided

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -1012,7 +1012,7 @@ class TestCmis(object):
         assert kall[0] == (consts.MODULE_LEVEL_CONTROL, 0x8)
 
     @pytest.mark.parametrize("lpmode", [
-        ([True], [False])
+        True, False
     ])
     def test_set_low_power(self, lpmode):
         self.api.xcvr_eeprom.read = MagicMock()
@@ -1024,6 +1024,8 @@ class TestCmis(object):
         self.api.get_lpmode_support = MagicMock()
         self.api.get_lpmode_support.return_value = True
         self.api.get_module_state = MagicMock()
+        self.api.get_lpmode = MagicMock()
+        self.api.get_lpmode.return_value = True
         self.api.get_module_state.return_value = "ModuleReady"
         self.api.set_lpmode(lpmode)
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
Wait for power on/off duration advertised in EEPROM during LP mode on/off

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
```
Ethernet496  2072,2073,2074,2075     400G   9100    N/A   etp62a  routed      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         N/A
Ethernet500  2076,2077,2078,2079     400G   9100    N/A   etp62b  routed      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         N/A
Ethernet504  2064,2065,2066,2067     400G   9100    N/A   etp63a  routed      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         N/A
Ethernet508  2068,2069,2070,2071     400G   9100    N/A   etp63b  routed      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         N/A

root@sonic:/home/admin# sfputil lpmode on  Ethernet496
Enabling low-power mode for port Ethernet496 ... ERROR:sonic_platform_base.sonic_xcvr.api.public.cmis: --- start_time 1727658036.2857926
ERROR:sonic_platform_base.sonic_xcvr.api.public.cmis:--- module adv time 1.0
ERROR:sonic_platform_base.sonic_xcvr.api.public.cmis:-- delta 0.010367155075073242
ERROR:sonic_platform_base.sonic_xcvr.api.public.cmis:--- retry 1727658036.3228872
ERROR:sonic_platform_base.sonic_xcvr.api.public.cmis:-- delta 0.13735604286193848

Ethernet496  2072,2073,2074,2075     400G   9100    N/A   etp62a  routed    down       up  QSFP-DD Double Density 8X Pluggable Transceiver         N/A
Ethernet500  2076,2077,2078,2079     400G   9100    N/A   etp62b  routed    down       up  QSFP-DD Double Density 8X Pluggable Transceiver         N/A
Ethernet504  2064,2065,2066,2067     400G   9100    N/A   etp63a  routed    down       up  QSFP-DD Double Density 8X Pluggable Transceiver         N/A
Ethernet508  2068,2069,2070,2071     400G   9100    N/A   etp63b  routed    down       up  QSFP-DD Double Density 8X Pluggable Transceiver         N/A

root@sonic:/home/admin# sfputil lpmode off  Ethernet496
Disabling low-power mode for port Ethernet496 ... ERROR:sonic_platform_base.sonic_xcvr.api.public.cmis:--- start_time 1727658051.8098736
ERROR:sonic_platform_base.sonic_xcvr.api.public.cmis:--- module advt time 10.0
ERROR:sonic_platform_base.sonic_xcvr.api.public.cmis:--- delta 0.003449678421020508
ERROR:sonic_platform_base.sonic_xcvr.api.public.cmis:--- retry 1727658051.8133779
ERROR:sonic_platform_base.sonic_xcvr.api.public.cmis:--- delta 0.10421037673950195
ERROR:sonic_platform_base.sonic_xcvr.api.public.cmis:--- retry 1727658051.9141643
ERROR:sonic_platform_base.sonic_xcvr.api.public.cmis:--- delta 0.20499515533447266
ERROR:sonic_platform_base.sonic_xcvr.api.public.cmis:--- retry 1727658052.014951
ERROR:sonic_platform_base.sonic_xcvr.api.public.cmis:--- delta 0.3057982921600342
ERROR:sonic_platform_base.sonic_xcvr.api.public.cmis:--- retry 1727658052.1157365
ERROR:sonic_platform_base.sonic_xcvr.api.public.cmis:--- delta 0.4065535068511963
ERROR:sonic_platform_base.sonic_xcvr.api.public.cmis:--- retry 1727658052.2164953
ERROR:sonic_platform_base.sonic_xcvr.api.public.cmis:--- delta 0.5073249340057373
ERROR:sonic_platform_base.sonic_xcvr.api.public.cmis:--- retry 1727658052.3172574
ERROR:sonic_platform_base.sonic_xcvr.api.public.cmis:--- delta 0.6081044673919678
ERROR:sonic_platform_base.sonic_xcvr.api.public.cmis:--- retry 1727658052.4180627
ERROR:sonic_platform_base.sonic_xcvr.api.public.cmis:--- delta 0.7088265419006348
ERROR:sonic_platform_base.sonic_xcvr.api.public.cmis:--- retry 1727658052.5188124
ERROR:sonic_platform_base.sonic_xcvr.api.public.cmis:--- delta 0.8098671436309814
ERROR:sonic_platform_base.sonic_xcvr.api.public.cmis:--- retry 1727658052.6199818
ERROR:sonic_platform_base.sonic_xcvr.api.public.cmis:--- delta 0.9108560085296631
ERROR:sonic_platform_base.sonic_xcvr.api.public.cmis:--- retry 1727658052.7208529
ERROR:sonic_platform_base.sonic_xcvr.api.public.cmis:--- delta 1.0118434429168701
ERROR:sonic_platform_base.sonic_xcvr.api.public.cmis:--- retry 1727658052.8219044
ERROR:sonic_platform_base.sonic_xcvr.api.public.cmis:--- delta 1.1129236221313477
ERROR:sonic_platform_base.sonic_xcvr.api.public.cmis:--- retry 1727658052.922967
ERROR:sonic_platform_base.sonic_xcvr.api.public.cmis:--- delta 1.2139770984649658
ERROR:sonic_platform_base.sonic_xcvr.api.public.cmis:--- retry 1727658053.0240204
ERROR:sonic_platform_base.sonic_xcvr.api.public.cmis:--- delta 1.314863920211792
ERROR:sonic_platform_base.sonic_xcvr.api.public.cmis:--- retry 1727658053.1248899
ERROR:sonic_platform_base.sonic_xcvr.api.public.cmis:--- delta 1.4159109592437744
ERROR:sonic_platform_base.sonic_xcvr.api.public.cmis:--- retry 1727658053.2259784
ERROR:sonic_platform_base.sonic_xcvr.api.public.cmis:--- delta 1.517002820968628
ERROR:sonic_platform_base.sonic_xcvr.api.public.cmis:--- retry 1727658053.3270552
ERROR:sonic_platform_base.sonic_xcvr.api.public.cmis:--- delta 1.6179804801940918
ERROR:sonic_platform_base.sonic_xcvr.api.public.cmis:--- retry 1727658053.427951
ERROR:sonic_platform_base.sonic_xcvr.api.public.cmis:--- delta 1.7188282012939453
ERROR:sonic_platform_base.sonic_xcvr.api.public.cmis:--- retry 1727658053.5288022
ERROR:sonic_platform_base.sonic_xcvr.api.public.cmis:--- delta 1.8196513652801514
OK

```
#### Additional Information (Optional)

