### PR TITLE
Add negative case for pci_detach() and pci_reattach()

### DIFF
--- a/sonic_platform_base/module_base.py
+++ b/sonic_platform_base/module_base.py
@@ -266,7 +266,7 @@ class ModuleBase(device_base.DeviceBase):
         """
         raise NotImplementedError
 
-    def get_bus_info(self):
+    def get_pci_bus_info(self):
         """
         Retrieves the bus information.
 
@@ -284,7 +284,7 @@ class ModuleBase(device_base.DeviceBase):
         """
         raise NotImplementedError
 
-    def pci_reattach(self):
+    def pci_rescan(self):
         """
         Rescans and reconnects the PCI device.
 

--- a/sonic_platform_base/module_base.py
+++ b/sonic_platform_base/module_base.py
@@ -52,6 +52,8 @@ class ModuleBase(device_base.DeviceBase):
     MODULE_REBOOT_FPGA_COMPLEX = "FPGA"
     # Module reboot type to reboot DPU
     MODULE_REBOOT_DPU = "DPU"
+    # Module reboot type to reboot SMART SWITCH
+    MODULE_REBOOT_SMARTSWITCH = "SMARTSWITCH"
 
     def __init__(self):
         # List of ComponentBase-derived objects representing all components
@@ -168,9 +170,11 @@ class ModuleBase(device_base.DeviceBase):
         Args:
             reboot_type: A string, the type of reboot requested from one of the
             predefined reboot types: MODULE_REBOOT_DEFAULT, MODULE_REBOOT_CPU_COMPLEX,
-            MODULE_REBOOT_FPGA_COMPLEX or MODULE_REBOOT_DPU
+            MODULE_REBOOT_FPGA_COMPLEX, MODULE_REBOOT_DPU or MODULE_REBOOT_SMARTSWITCH
 
             MODULE_REBOOT_DPU is only applicable for smartswitch chassis.
+
+            MODULE_REBOOT_SMARTSWITCH is only applicable for smartswitch chassis.
 
         Returns:
             bool: True if the request has been issued successfully, False if not
@@ -277,6 +281,15 @@ class ModuleBase(device_base.DeviceBase):
 
         Returns: True once the PCI is successfully detached.
         Returns False, if PCI detachment fails or specified device is not found.
+        """
+        raise NotImplementedError
+
+    def pci_reattach(self):
+        """
+        Rescans and reconnects the PCI device.
+
+        Returns: True once the PCI is successfully reconnected.
+        Returns False, if PCI rescan fails or specified device is not found.
         """
         raise NotImplementedError
 

--- a/sonic_platform_base/module_base.py
+++ b/sonic_platform_base/module_base.py
@@ -284,7 +284,7 @@ class ModuleBase(device_base.DeviceBase):
         """
         raise NotImplementedError
 
-    def pci_rescan(self):
+    def pci_reattach(self):
         """
         Rescans and reconnects the PCI device.
 

--- a/sonic_platform_base/module_base.py
+++ b/sonic_platform_base/module_base.py
@@ -262,28 +262,22 @@ class ModuleBase(device_base.DeviceBase):
         """
         raise NotImplementedError
 
-    def get_bus_info(self, module_name):
+    def get_bus_info(self):
         """
-        Retrieves the bus information for the specified by "module_name" on a SmartSwitch.
+        Retrieves the bus information. Returns None for non-smartswitch chassis.
 
         Returns:
             Returns the PCI bus information in BDF format like "[DDDD:]BB:SS:F"
         """
         raise NotImplementedError
 
-    def pci_detach(self, module_name):
+    def pci_detach(self):
         """
         Detaches the DPU PCI device specified by "module_name" on a SmartSwitch.
+        Returns False for non-smartswitch chassis.
 
         Returns: True once the PCI is successfully detached.
-        """
-        raise NotImplementedError
-
-    def pci_reattach(self, module_name):
-        """
-        Rescans and reconnects the DPU PCI device specified by "module_name" on a SmartSwitch.
-
-        Returns: True once the PCI is successfully reconnected.
+        Returns False if PCI detachment fails or specified 'module_name' is not found.
         """
         raise NotImplementedError
 

--- a/sonic_platform_base/module_base.py
+++ b/sonic_platform_base/module_base.py
@@ -264,7 +264,7 @@ class ModuleBase(device_base.DeviceBase):
 
     def get_bus_info(self):
         """
-        Retrieves the bus information. Returns None for non-smartswitch chassis.
+        Retrieves the bus information.
 
         Returns:
             Returns the PCI bus information in BDF format like "[DDDD:]BB:SS:F"
@@ -273,11 +273,10 @@ class ModuleBase(device_base.DeviceBase):
 
     def pci_detach(self):
         """
-        Detaches the DPU PCI device specified by "module_name" on a SmartSwitch.
-        Returns False for non-smartswitch chassis.
+        Detaches the PCI device.
 
         Returns: True once the PCI is successfully detached.
-        Returns False if PCI detachment fails or specified 'module_name' is not found.
+        Returns False, if PCI detachment fails or specified device is not found.
         """
         raise NotImplementedError
 

--- a/tests/module_base_test.py
+++ b/tests/module_base_test.py
@@ -8,9 +8,9 @@ class TestModuleBase:
                 [module.get_dpu_id],
                 [module.get_reboot_cause],
                 [module.get_state_info],
-                [module.get_bus_info],
+                [module.get_pci_bus_info],
                 [module.pci_detach],
-                [module.pci_reattach],
+                [module.pci_rescan],
             ]
 
         for method in not_implemented_methods:

--- a/tests/module_base_test.py
+++ b/tests/module_base_test.py
@@ -10,7 +10,7 @@ class TestModuleBase:
                 [module.get_state_info],
                 [module.get_pci_bus_info],
                 [module.pci_detach],
-                [module.pci_rescan],
+                [module.pci_reattach],
             ]
 
         for method in not_implemented_methods:

--- a/tests/module_base_test.py
+++ b/tests/module_base_test.py
@@ -8,9 +8,8 @@ class TestModuleBase:
                 [module.get_dpu_id],
                 [module.get_reboot_cause],
                 [module.get_state_info],
-                [module.get_bus_info, "module_name"],
-                [module.pci_detach, "module_name"],
-                [module.pci_reattach, "module_name"],
+                [module.get_bus_info],
+                [module.pci_detach],
             ]
 
         for method in not_implemented_methods:

--- a/tests/module_base_test.py
+++ b/tests/module_base_test.py
@@ -10,6 +10,7 @@ class TestModuleBase:
                 [module.get_state_info],
                 [module.get_bus_info],
                 [module.pci_detach],
+                [module.pci_reattach],
             ]
 
         for method in not_implemented_methods:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
Address the comments added in https://github.com/sonic-net/sonic-platform-common/pull/501

#### Description
<!--
     Describe your changes in detail
-->
- Add negative for pci_detach() and pci_reattach()
- Remove module_name from get_bus_info(), pci_reattach() and pci_detach()
- Add MODULE_TYPE_SMARTSWITCH to reboot API. This reboot_type is used for rebooting DPUs when entire smartswitch undergoes for a reboot.
- Also fix unittests accordingly.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)

