### PR TITLE
[SmartSwitch] Add a new API for the DPU chassis to query dataplane and midplane states

### DIFF
--- a/sonic_platform_base/chassis_base.py
+++ b/sonic_platform_base/chassis_base.py
@@ -280,25 +280,59 @@ class ChassisBase(device_base.DeviceBase):
     # SmartSwitch methods
     ##############################################
 
-    def get_dpu_id(self, name):
+    def get_dpu_id(self, **kwargs):
         """
-        Retrieves the DPU ID for the given dpu-module name.
-        Returns None for non-smartswitch chassis.
+        Retrieves the DPU ID for the specified DPU module on a Smart Switch chassis.
+
+        When run on the Smart Switch chassis, it fetches the ID corresponding to provided DPU module name.
+        When run on the Smart Switch DPU chassis, returns the ID of the DPU.
+        This method is relevant only for Smart Switch chassis.
+
+        Args:
+            name (str, optional): The name of the DPU module (e.g., "DPU0", "DPU1").
 
         Returns:
-            An integer, indicating the DPU ID Ex: name:DPU0 return value 0,
-            name:DPU1 return value 1, name:DPUX return value X
+            int: The DPU ID associated with the given module name.
+            For example, for name "DPU0", returns 0; for "DPU1", returns 1, and so on.
         """
         raise NotImplementedError
 
     def is_smartswitch(self):
         """
-        Retrieves whether the sonic instance is part of smartswitch
+        Checks whether the current SONiC instance is part of a Smart Switch platform.
 
         Returns:
-            Returns:True for SmartSwitch and False for other platforms
+            bool: True if the instance is part of a Smart Switch, False otherwise.
         """
         return False
+
+    def is_dpu(self):
+        """
+        Checks whether the current SONiC instance is running on a DPU.
+
+        Returns:
+            bool: True if the instance is running on a DPU, False otherwise.
+        """
+        return False
+
+    def get_dataplane_state(self):
+        """
+        Retrieves the status of the dataplane.
+
+        Returns:
+            bool: True if the dataplane is UP, False if it is down.
+        """
+        raise NotImplementedError
+
+    def get_controlplane_state(self):
+        """
+        Retrieves the status of the DPU control plane.
+
+        Returns:
+            bool: True if the control plane is UP, False if it is down.
+        """
+        raise NotImplementedError
+
 
     ##############################################
     # Fan methods

--- a/tests/chassis_base_test.py
+++ b/tests/chassis_base_test.py
@@ -20,17 +20,20 @@ class TestChassisBase:
     def test_chassis_base(self):
         chassis = ChassisBase()
         not_implemented_methods = [
-                [chassis.get_uid_led],
-                [chassis.set_uid_led, "COLOR"],
-                [chassis.get_dpu_id, "DPU0"],
+                [chassis.get_uid_led, [], {}],
+                [chassis.set_uid_led, ["COLOR"], {}],
+                [chassis.get_dpu_id, [], {"name": "DPU0"}],
+                [chassis.get_dataplane_state, [], {}],
+                [chassis.get_controlplane_state, [], {}],
             ]
 
         for method in not_implemented_methods:
             exception_raised = False
             try:
                 func = method[0]
-                args = method[1:]
-                func(*args)
+                args = method[1]
+                kwargs = method[2]
+                func(*args, **kwargs)
             except NotImplementedError:
                 exception_raised = True
 
@@ -39,6 +42,7 @@ class TestChassisBase:
     def test_smartswitch(self):
         chassis = ChassisBase()
         assert(chassis.is_smartswitch() == False)
+        assert(chassis.is_dpu() == False)
 
     def test_sensors(self):
         chassis = ChassisBase()


### PR DESCRIPTION
#### Description
Add a definition for a new DPU chassis API required for querying DPU dataplane and midplane states.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
A new API is required to enable querying of the DPU dataplane and midplane states. These states will be monitored by the chassisd service running on the DPU and pushed to the CHASSIS_STATE_DB upon any changes. This will allow the NPU to subscribe to DPU state changes.  

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
The API tests will be added in scope of chassisd changes.

#### Additional Information (Optional)

