### PR TITLE
Implement get/set_lpmode API for SFF8472

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/sff8472.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/sff8472.py
@@ -37,7 +37,7 @@ class Sff8472Api(XcvrApi):
             if len > 0:
                 cable_len = len
                 cable_type = type
- 
+
         xcvr_info = {
             "type": serial_id[consts.ID_FIELD],
             "type_abbrv_name": serial_id[consts.ID_ABBRV_FIELD],
@@ -294,6 +294,27 @@ class Sff8472Api(XcvrApi):
         return False
 
     def get_power_override_support(self):
+        return False
+
+    def get_lpmode(self):
+        '''
+        Retrieves low power mode status
+
+        Returns:
+            bool: True if module in low power else returns False.
+        '''
+        return False
+
+    def set_lpmode(self, lpmode):
+        '''
+        This function sets LPMode for the module.
+
+        Args:
+            lpmode (bool): False means LPMode Off, True means LPMode On
+
+        Returns:
+            bool: True if the provision succeeds, False if it fails
+        '''
         return False
 
     def is_copper(self):

--- a/tests/sonic_xcvr/test_sff8472.py
+++ b/tests/sonic_xcvr/test_sff8472.py
@@ -290,3 +290,9 @@ class TestSff8472(object):
         result = self.api.get_transceiver_bulk_status()
         assert result == expected
 
+    def test_get_lpmode(self):
+        assert not self.api.get_lpmode()
+
+    def test_set_lpmode(self):
+        assert not self.api.set_lpmode(True)
+        assert not self.api.set_lpmode(False)


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
Implement get/set_lpmode API for SFF8472

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

The cli "sfputil show lpmode" depends on this implemenation for SFP+ ports on Arista platform. 

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Run the cli "sfputil show lpmode" on Arista platform, and check the result is Off for SFP+ ports

#### Additional Information (Optional)
SFF8472 does not support setting lp mode, so both get_lpmode() and set_lpmode() is returned false. This is consistent with the existing implementation for SFF8436 in https://github.com/sonic-net/sonic-platform-common/blob/master/sonic_platform_base/sonic_xcvr/api/public/sff8436.py#L334, for the condition of "if not self.get_lpmode_support() or not self.get_power_override_support()"

