### PR TITLE
Extend wait time in cable firmware download flow

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/cmisCDB.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmisCDB.py
@@ -284,7 +284,7 @@ class CmisCdbApi(XcvrApi):
         cmd += header
         cmd[133-INIT_OFFSET] = self.cdb_chkcode(cmd)
         self.write_cdb(cmd)
-        time.sleep(2)
+        time.sleep(4)
         status = self.cdb1_chkstatus()
         if (status != 0x1):
             if status > 127:
@@ -415,6 +415,7 @@ class CmisCdbApi(XcvrApi):
         cmd = bytearray(b'\x01\x07\x00\x00\x00\x00\x00\x00')
         cmd[133-INIT_OFFSET] = self.cdb_chkcode(cmd)
         self.write_cdb(cmd)
+        time.sleep(2)
         status = self.cdb1_chkstatus()
         if (status != 0x1):
             if status > 127:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

Extend the wait time in the cable firmware download flow

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

The cable firmware download flow is the following:

1. Start download (CMIS CDB command 0x0101)
2. Write firmware to LPL or EPL (CMIS CDB command 0x103 or 0x104), depending on the module's capability
3. Complete download and verify image (CMIS CDB command 0x0107)

For each CMIS CDB command, it writes the command and then waits for the cable's response. Sometimes it takes several seconds for the cable to handle the command and provide the response. In that scenario, we must delay a few seconds to avoid error messages.
There has been a 2-second delay in step 1 but it's not sufficient on some platforms with certain cables.

We extend the delay to 5 seconds in step 1 and introduce a 2-second delay in step 3 to secure a successful cable firmware download without any error.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)

