### PR TITLE
[CMIS]The "get_error_description" function should return 'OK' instead of None when there are no errors.

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -3152,6 +3152,6 @@ class CmisApi(XcvrApi):
         if state != CmisCodes.MODULE_STATE[3]:
             return state
 
-        return None
+        return 'OK'
 
     # TODO: other XcvrApi methods

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -3066,7 +3066,7 @@ class TestCmis(object):
         self.api.xcvr_eeprom.read.return_value = 0x10
 
         result = self.api.get_error_description()
-        assert result is None
+        assert result is 'OK'
 
     def test_random_read_fail(self):
         def mock_read_raw(offset, size):


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->

#### Description

The "get_error_description" function should return 'OK' instead of 'None' when there are no errors.

#### Motivation and Context
When there are no errors on the cable, get_error_description currently returns 'None'. In this case, we should return 'OK' so that the CLI (show interface transceiver error-description) provides a proper output. 

#### How Has This Been Tested?
Call this API directly on different cables with different error statuses.

#### Additional Information (Optional)

