### PR TITLE
High power class enabling for SFF-8636 modules

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/sff8636.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/sff8636.py
@@ -440,11 +440,9 @@ class Sff8636Api(XcvrApi):
         '''
         ret = True
 
-        if power_class < 5:
-            return ret
-        elif power_class >= 8:
+        if power_class >= 8:
             ret = self.xcvr_eeprom.write(consts.HIGH_POWER_CLASS_ENABLE_CLASS_8, enable)
-        else:  # Power class 5, 6, 7
+        elif power_class >= 5:
             ret = self.xcvr_eeprom.write(consts.HIGH_POWER_CLASS_ENABLE_CLASS_5_TO_7, enable)
 
         return ret

--- a/sonic_platform_base/sonic_xcvr/api/public/sff8636.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/sff8636.py
@@ -4,6 +4,7 @@
     Implementation of XcvrApi that corresponds to the SFF-8636 specification for
     QSFP28 pluggable transceivers.
 """
+import re
 
 from ...fields import consts
 from ..xcvr_api import XcvrApi
@@ -12,7 +13,7 @@ from ...codes.public.sff8636 import Sff8636Codes
 
 class Sff8636Api(XcvrApi):
     NUM_CHANNELS = 4
-    POWER_CLASS_PREFIX = "Power Class "
+    POWER_CLASS_PATTERN = r'^Power Class ([1-8])'
 
     def __init__(self, xcvr_eeprom):
         super(Sff8636Api, self).__init__(xcvr_eeprom)
@@ -410,33 +411,33 @@ class Sff8636Api(XcvrApi):
         Retrieves power class of the module.
 
         Returns:
-            int: Power class of the module, -1 if it fails
+            int: Power class of the module, None if it fails
         '''
         power_class_str = self.xcvr_eeprom.read(consts.POWER_CLASS_FIELD)
-        power_class = -1
+        power_class = None
 
         if power_class_str is None:
             return power_class
-        if not power_class_str.startswith(self.POWER_CLASS_PREFIX):
-            return power_class
 
-        prefix_len = len(self.POWER_CLASS_PREFIX)
-        power_class = int(power_class_str[prefix_len:prefix_len + 1])
+        pattern = re.compile(self.POWER_CLASS_PATTERN)
+        match = pattern.match(power_class_str)
+        if match:
+            power_class = int(match.group(1))
 
         return power_class
 
-    def set_high_power_class(self, enable):
+    def set_high_power_class(self, power_class, enable):
         '''
-        This function sets high power class for the module if needed.
+        This function sets high power class for the module.
         It is only applicable for power class >= 5.
 
         Args:
+            power_class (int): Power class to be enabled/disabled
             enable (bool): True to enable high power class, False to disable
 
         Returns:
             bool: True if the provision succeeds, False if it fails
         '''
-        power_class = self.get_power_class()
         ret = True
 
         if power_class < 5:

--- a/sonic_platform_base/sonic_xcvr/api/public/sff8636.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/sff8636.py
@@ -425,10 +425,13 @@ class Sff8636Api(XcvrApi):
 
         return power_class
 
-    def handle_high_power_class(self):
+    def set_high_power_class(self, enable):
         '''
-        This function enables high power class for the module if needed.
+        This function sets high power class for the module if needed.
         It is only applicable for power class >= 5.
+
+        Args:
+            enable (bool): True to enable high power class, False to disable
 
         Returns:
             bool: True if the provision succeeds, False if it fails
@@ -438,11 +441,9 @@ class Sff8636Api(XcvrApi):
 
         if power_class < 5:
             return ret
-        if power_class >= 8:
-            if not self.xcvr_eeprom.read(consts.HIGH_POWER_CLASS_ENABLE_CLASS_8):
-                ret = self.xcvr_eeprom.write(consts.HIGH_POWER_CLASS_ENABLE_CLASS_8, 0x1)
-        # Power class 5, 6, 7
-        if not self.xcvr_eeprom.read(consts.HIGH_POWER_CLASS_ENABLE_CLASS_5_TO_7):
-            ret = self.xcvr_eeprom.write(consts.HIGH_POWER_CLASS_ENABLE_CLASS_5_TO_7, 0x1)
+        elif power_class >= 8:
+            ret = self.xcvr_eeprom.write(consts.HIGH_POWER_CLASS_ENABLE_CLASS_8, enable)
+        else:  # Power class 5, 6, 7
+            ret = self.xcvr_eeprom.write(consts.HIGH_POWER_CLASS_ENABLE_CLASS_5_TO_7, enable)
 
         return ret

--- a/sonic_platform_base/sonic_xcvr/api/xcvr_api.py
+++ b/sonic_platform_base/sonic_xcvr/api/xcvr_api.py
@@ -637,11 +637,21 @@ class XcvrApi(object):
         """
         raise NotImplementedError
 
-    def set_high_power_class(self, enable):
+    def get_power_class(self):
         """
-        This function sets high power class for the module if needed.
+        Retrieves the power class of the module
+
+        Returns:
+            int: Power class of the module, None if it fails
+        """
+        raise NotImplementedError
+
+    def set_high_power_class(self, power_class, enable):
+        """
+        This function sets high power class for the module.
 
         Args:
+            power_class (int): Power class to enable/disable
             enable (bool): True to enable high power class, False to disable
 
         Returns:

--- a/sonic_platform_base/sonic_xcvr/api/xcvr_api.py
+++ b/sonic_platform_base/sonic_xcvr/api/xcvr_api.py
@@ -637,3 +637,14 @@ class XcvrApi(object):
         """
         raise NotImplementedError
 
+    def set_high_power_class(self, enable):
+        """
+        This function sets high power class for the module if needed.
+
+        Args:
+            enable (bool): True to enable high power class, False to disable
+
+        Returns:
+            bool: True if the provision succeeds, False if it fails
+        """
+        raise NotImplementedError

--- a/sonic_platform_base/sonic_xcvr/fields/consts.py
+++ b/sonic_platform_base/sonic_xcvr/fields/consts.py
@@ -104,6 +104,8 @@ OPTIONS_FIELD = "Options"
 POWER_CTRL_FIELD = "Power Control"
 POWER_OVERRIDE_FIELD = "Power Override"
 POWER_SET_FIELD = "Power Set"
+HIGH_POWER_CLASS_ENABLE_CLASS_5_TO_7 = "High Power Class Enable (Class 5-7)"
+HIGH_POWER_CLASS_ENABLE_CLASS_8 = "High Power Class Enable (Class 8)"
 
 # SFF-8636
 

--- a/sonic_platform_base/sonic_xcvr/mem_maps/public/sff8636.py
+++ b/sonic_platform_base/sonic_xcvr/mem_maps/public/sff8636.py
@@ -128,6 +128,8 @@ class Sff8636MemMap(XcvrMemMap):
         self.POWER_CTRL = NumberRegField(consts.POWER_CTRL_FIELD, self.get_addr(0, 93),
             RegBitField(consts.POWER_OVERRIDE_FIELD, 0, ro=False),
             RegBitField(consts.POWER_SET_FIELD, 1, ro=False),
+            RegBitField(consts.HIGH_POWER_CLASS_ENABLE_CLASS_5_TO_7, 2, ro=False),
+            RegBitField(consts.HIGH_POWER_CLASS_ENABLE_CLASS_8, 3, ro=False),
             ro=False
         )
 

--- a/sonic_platform_base/sonic_xcvr/sfp_optoe_base.py
+++ b/sonic_platform_base/sonic_xcvr/sfp_optoe_base.py
@@ -280,3 +280,27 @@ class SfpOptoeBase(SfpBase):
         """
         api = self.get_xcvr_api()
         return api.get_error_description() if api is not None else None
+
+    def get_power_class(self):
+        """
+        Get the power class of the module
+
+        Returns:
+            Integer that represents the power class of the module, None if it fails
+        """
+        api = self.get_xcvr_api()
+        return api.get_power_class() if api is not None else None
+
+    def set_high_power_class(self, power_class, enable):
+        """
+        Set the high power class of the module
+
+        Args:
+            power_class: Integer that represents the power class to enable or disable
+            enable: Boolean that represents whether to enable or disable the high power class
+
+        Returns:
+            Boolean, True if successful, False if not
+        """
+        api = self.get_xcvr_api()
+        return api.set_high_power_class(power_class, enable) if api is not None else False

--- a/tests/sonic_xcvr/test_sff8636.py
+++ b/tests/sonic_xcvr/test_sff8636.py
@@ -156,6 +156,43 @@ class TestSff8636(object):
         self.api.get_power_override_support.return_value = False
         assert not self.api.set_lpmode(True)
 
+    def test_set_high_power_class(self):
+        with patch.object(self.api, 'get_power_class', new=MagicMock()) as mock_get_power_class, \
+                patch.object(self.api, 'xcvr_eeprom', new=MagicMock()) as mock_eeprom:
+
+            # Mock read method
+            mock_eeprom.read = MagicMock()
+            mock_get_power_class.return_value = 4
+
+            # Test low power class
+            mock_eeprom.read.return_value = 1
+            assert self.api.set_high_power_class(True)
+
+            # Test high power class 5-7
+            mock_get_power_class.return_value = 5
+            assert self.api.set_high_power_class(True)
+
+            # Test high power class 8
+            mock_get_power_class.return_value = 8
+            assert self.api.set_high_power_class(True)
+
+            # Test high power class disable
+            mock_get_power_class.return_value = 8
+            assert self.api.set_high_power_class(False)
+
+    def test_get_power_class(self):
+        with patch.object(self.api, 'xcvr_eeprom') as mock_eeprom:
+            mock_eeprom.read = MagicMock()
+
+            mock_eeprom.read.return_value = "Power Class 1 Module (1.5W max.)"
+            assert self.api.get_power_class() == 1
+
+            mock_eeprom.read.return_value = "XYZ"
+            assert self.api.get_power_class() == -1
+
+            mock_eeprom.read.return_value = None
+            assert self.api.get_power_class() == -1
+
     @pytest.mark.parametrize("mock_response, expected",[
         (
             [

--- a/tests/sonic_xcvr/test_sff8636.py
+++ b/tests/sonic_xcvr/test_sff8636.py
@@ -157,28 +157,18 @@ class TestSff8636(object):
         assert not self.api.set_lpmode(True)
 
     def test_set_high_power_class(self):
-        with patch.object(self.api, 'get_power_class', new=MagicMock()) as mock_get_power_class, \
-                patch.object(self.api, 'xcvr_eeprom', new=MagicMock()) as mock_eeprom:
-
-            # Mock read method
-            mock_eeprom.read = MagicMock()
-            mock_get_power_class.return_value = 4
-
+        with patch.object(self.api, 'xcvr_eeprom'):
             # Test low power class
-            mock_eeprom.read.return_value = 1
-            assert self.api.set_high_power_class(True)
+            assert self.api.set_high_power_class(1, True)
 
             # Test high power class 5-7
-            mock_get_power_class.return_value = 5
-            assert self.api.set_high_power_class(True)
+            assert self.api.set_high_power_class(5, True)
 
             # Test high power class 8
-            mock_get_power_class.return_value = 8
-            assert self.api.set_high_power_class(True)
+            assert self.api.set_high_power_class(8, True)
 
             # Test high power class disable
-            mock_get_power_class.return_value = 8
-            assert self.api.set_high_power_class(False)
+            assert self.api.set_high_power_class(8, False)
 
     def test_get_power_class(self):
         with patch.object(self.api, 'xcvr_eeprom') as mock_eeprom:
@@ -187,11 +177,19 @@ class TestSff8636(object):
             mock_eeprom.read.return_value = "Power Class 1 Module (1.5W max.)"
             assert self.api.get_power_class() == 1
 
+            # Invalid power class
+            mock_eeprom.read.return_value = "Power Class 9 Module (555.5W max.)"
+            assert self.api.get_power_class() is None
+
+            # Invalid power class string
+            mock_eeprom.read.return_value = "XXX Power Class 1 Module (1.5W max.)"
+            assert self.api.get_power_class() is None
+
             mock_eeprom.read.return_value = "XYZ"
-            assert self.api.get_power_class() == -1
+            assert self.api.get_power_class() is None
 
             mock_eeprom.read.return_value = None
-            assert self.api.get_power_class() == -1
+            assert self.api.get_power_class() is None
 
     @pytest.mark.parametrize("mock_response, expected",[
         (


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

Add platform common API support for enabling high power class if module's power class is greater or equal to 5 (Refer to SFF-8636 spec `6.2.6 Control Functions (Page 00h, Bytes 86-99)` for byte 93 definition)

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
Without enabling high power class for those modules, the module won't operate properly with power output and link won't come up.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Verified the module operate with proper power output. 

#### Additional Information (Optional)

