### PR TITLE
[cmis] Optimize cmis.get_error_description speed for passive module

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -3132,21 +3132,22 @@ class CmisApi(XcvrApi):
         return True
 
     def get_error_description(self):
-        dp_state = self.get_datapath_state()
-        conf_state = self.get_config_datapath_hostlane_status()
-        for lane in range(self.NUM_CHANNELS):
-            name = "{}_{}_{}".format(consts.STAGED_CTRL_APSEL_FIELD, 0, lane + 1)
-            appl = self.xcvr_eeprom.read(name)
-            if (appl is None) or ((appl >> 4) == 0):
-                continue
+        if not self.is_flat_memory():
+            dp_state = self.get_datapath_state()
+            conf_state = self.get_config_datapath_hostlane_status()
+            for lane in range(self.NUM_CHANNELS):
+                name = "{}_{}_{}".format(consts.STAGED_CTRL_APSEL_FIELD, 0, lane + 1)
+                appl = self.xcvr_eeprom.read(name)
+                if (appl is None) or ((appl >> 4) == 0):
+                    continue
 
-            name = "DP{}State".format(lane + 1)
-            if dp_state[name] != CmisCodes.DATAPATH_STATE[4]:
-                return dp_state[name]
+                name = "DP{}State".format(lane + 1)
+                if dp_state[name] != CmisCodes.DATAPATH_STATE[4]:
+                    return dp_state[name]
 
-            name = "ConfigStatusLane{}".format(lane + 1)
-            if conf_state[name] != CmisCodes.CONFIG_STATUS[1]:
-                return conf_state[name]
+                name = "ConfigStatusLane{}".format(lane + 1)
+                if conf_state[name] != CmisCodes.CONFIG_STATUS[1]:
+                    return conf_state[name]
 
         state = self.get_module_state()
         if state != CmisCodes.MODULE_STATE[3]:

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -3038,35 +3038,63 @@ class TestCmis(object):
         assert self.api.xcvr_eeprom.write.call_count == 4
 
     def test_get_error_description(self):
-        self.api.get_module_state = MagicMock()
-        self.api.get_module_state.return_value = 'ModuleReady'
-        self.api.get_datapath_state = MagicMock()
-        self.api.get_datapath_state.return_value = {
-            'DP1State': 'DataPathActivated',
-            'DP2State': 'DataPathActivated',
-            'DP3State': 'DataPathActivated',
-            'DP4State': 'DataPathActivated',
-            'DP5State': 'DataPathActivated',
-            'DP6State': 'DataPathActivated',
-            'DP7State': 'DataPathActivated',
-            'DP8State': 'DataPathActivated'
-        }
-        self.api.get_config_datapath_hostlane_status = MagicMock()
-        self.api.get_config_datapath_hostlane_status.return_value = {
-            'ConfigStatusLane1': 'ConfigSuccess',
-            'ConfigStatusLane2': 'ConfigSuccess',
-            'ConfigStatusLane3': 'ConfigSuccess',
-            'ConfigStatusLane4': 'ConfigSuccess',
-            'ConfigStatusLane5': 'ConfigSuccess',
-            'ConfigStatusLane6': 'ConfigSuccess',
-            'ConfigStatusLane7': 'ConfigSuccess',
-            'ConfigStatusLane8': 'ConfigSuccess'
-        }
-        self.api.xcvr_eeprom.read = MagicMock()
-        self.api.xcvr_eeprom.read.return_value = 0x10
-
-        result = self.api.get_error_description()
-        assert result is 'OK'
+        with patch.object(self.api, 'is_flat_memory') as mock_method:
+            mock_method.return_value = False
+            self.api.get_module_state = MagicMock()
+            self.api.get_module_state.return_value = 'ModuleReady'
+            self.api.get_datapath_state = MagicMock()
+            self.api.get_datapath_state.return_value = {
+                'DP1State': 'DataPathActivated',
+                'DP2State': 'DataPathActivated',
+                'DP3State': 'DataPathActivated',
+                'DP4State': 'DataPathActivated',
+                'DP5State': 'DataPathActivated',
+                'DP6State': 'DataPathActivated',
+                'DP7State': 'DataPathActivated',
+                'DP8State': 'DataPathActivated'
+            }
+            self.api.get_config_datapath_hostlane_status = MagicMock()
+            self.api.get_config_datapath_hostlane_status.return_value = {
+                'ConfigStatusLane1': 'ConfigSuccess',
+                'ConfigStatusLane2': 'ConfigSuccess',
+                'ConfigStatusLane3': 'ConfigSuccess',
+                'ConfigStatusLane4': 'ConfigSuccess',
+                'ConfigStatusLane5': 'ConfigSuccess',
+                'ConfigStatusLane6': 'ConfigSuccess',
+                'ConfigStatusLane7': 'ConfigSuccess',
+                'ConfigStatusLane8': 'ConfigSuccess'
+            }
+            self.api.xcvr_eeprom.read = MagicMock()
+            self.api.xcvr_eeprom.read.return_value = 0x10
+    
+            result = self.api.get_error_description()
+            assert result is 'OK'
+            
+            self.api.get_config_datapath_hostlane_status.return_value = {
+                'ConfigStatusLane1': 'ConfigRejected',
+                'ConfigStatusLane2': 'ConfigRejected',
+                'ConfigStatusLane3': 'ConfigRejected',
+                'ConfigStatusLane4': 'ConfigRejected',
+                'ConfigStatusLane5': 'ConfigRejected',
+                'ConfigStatusLane6': 'ConfigRejected',
+                'ConfigStatusLane7': 'ConfigRejected',
+                'ConfigStatusLane8': 'ConfigRejected'
+            }
+            result = self.api.get_error_description()
+            assert result is 'ConfigRejected'
+            
+            self.api.get_datapath_state.return_value = {
+                'DP1State': 'DataPathDeactivated',
+                'DP2State': 'DataPathActivated',
+                'DP3State': 'DataPathActivated',
+                'DP4State': 'DataPathActivated',
+                'DP5State': 'DataPathActivated',
+                'DP6State': 'DataPathActivated',
+                'DP7State': 'DataPathActivated',
+                'DP8State': 'DataPathActivated'
+            }
+            result = self.api.get_error_description()
+            assert result is 'DataPathDeactivated'
 
     def test_random_read_fail(self):
         def mock_read_raw(offset, size):


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

cmis.get_error_description is very slow for passive module:

```
>>> begin = time.time()
>>> s.get_error_description()
'ModuleLowPwr'
>>> print(time.time() - begin)
2.905252695083618
```

For a module that has flat memory, it does not need check data path state. Because of this issue, `show error-status --fetch-from-hardware` takes very long time if there are many passive modules present:

```
real    1m12.116s
user    0m5.852s
sys     0m15.491s
```

After the fix, it changes to:

```
real    0m1.051s
user    0m0.499s
sys     0m0.059s
```

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

Optimize cmis.get_error_description for passive module

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

Manual test
Unit test

#### Additional Information (Optional)

