### PR TITLE
Create is_transceiver_vdm_supported API for CMIS transceivers

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -1505,6 +1505,12 @@ class CmisApi(XcvrApi):
         logger.error('Invalid loopback mode:%s, lane_mask:%#x', loopback_mode, lane_mask)
         return False
 
+    def is_transceiver_vdm_supported(self):
+        '''
+        This function returns whether VDM is supported
+        '''
+        return self.vdm is not None and self.xcvr_eeprom.read(consts.VDM_SUPPORTED)
+
     def get_vdm(self, field_option=None):
         '''
         This function returns all the VDM items, including real time monitor value, threholds and flags

--- a/sonic_platform_base/sonic_xcvr/api/xcvr_api.py
+++ b/sonic_platform_base/sonic_xcvr/api/xcvr_api.py
@@ -257,6 +257,12 @@ class XcvrApi(object):
         """
         raise NotImplementedError
 
+    def is_transceiver_vdm_supported(self):
+        """
+        Retrieves VDM support status for this xcvr (applicable for CMIS and C-CMIS)
+        """
+        raise NotImplementedError
+
     def get_transceiver_vdm_real_value(self):
         """
         Retrieves VDM real (sample) values for this xcvr (applicable for CMIS and C-CMIS)

--- a/sonic_platform_base/sonic_xcvr/sfp_optoe_base.py
+++ b/sonic_platform_base/sonic_xcvr/sfp_optoe_base.py
@@ -55,6 +55,10 @@ class SfpOptoeBase(SfpBase):
         api = self.get_xcvr_api()
         return api.is_coherent_module() if api is not None else None
 
+    def is_transceiver_vdm_supported(self):
+        api = self.get_xcvr_api()
+        return api.is_transceiver_vdm_supported() if api is not None else None
+
     def get_transceiver_vdm_real_value(self):
         """
         Retrieves VDM real (sample) values for this xcvr (applicable for CMIS and C-CMIS)

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -1242,6 +1242,20 @@ class TestCmis(object):
         result = self.api.set_loopback_mode(input_param[0], input_param[1])
         assert result == expected
 
+    def test_is_transceiver_vdm_supported_no_vdm(self):
+        self.api.vdm = None
+        assert self.api.is_transceiver_vdm_supported() == False
+
+    def test_is_transceiver_vdm_supported_true(self):
+        self.api.vdm = MagicMock()
+        self.api.xcvr_eeprom.read = MagicMock(return_value=1)
+        assert self.api.is_transceiver_vdm_supported() == True
+
+    def test_is_transceiver_vdm_supported_false(self):
+        self.api.vdm = MagicMock()
+        self.api.xcvr_eeprom.read = MagicMock(return_value=0)
+        assert self.api.is_transceiver_vdm_supported() == False
+
     @pytest.mark.parametrize("mock_response, expected",[
         (
             [

--- a/tests/sonic_xcvr/test_sfp_optoe_base.py
+++ b/tests/sonic_xcvr/test_sfp_optoe_base.py
@@ -8,6 +8,7 @@ from sonic_platform_base.sonic_xcvr.api.public.cmis import CmisApi
 from sonic_platform_base.sonic_xcvr.mem_maps.public.c_cmis import CCmisMemMap 
 from sonic_platform_base.sonic_xcvr.xcvr_eeprom import XcvrEeprom 
 from sonic_platform_base.sonic_xcvr.codes.public.cmis import CmisCodes 
+from sonic_platform_base.sonic_xcvr.api.public.sff8472 import Sff8472Api
 
 class TestSfpOptoeBase(object): 
  
@@ -19,8 +20,10 @@ class TestSfpOptoeBase(object):
     sfp_optoe_api = SfpOptoeBase() 
     ccmis_api = CCmisApi(eeprom) 
     cmis_api = CmisApi(eeprom) 
+    sff8472_api = Sff8472Api(eeprom)
  
     def test_is_transceiver_vdm_supported_non_cmis(self):
+        self.sfp_optoe_api.get_xcvr_api = MagicMock(return_value=self.sff8472_api)
         try:
             self.sfp_optoe_api.is_transceiver_vdm_supported()
         except NotImplementedError:

--- a/tests/sonic_xcvr/test_sfp_optoe_base.py
+++ b/tests/sonic_xcvr/test_sfp_optoe_base.py
@@ -20,6 +20,13 @@ class TestSfpOptoeBase(object):
     ccmis_api = CCmisApi(eeprom) 
     cmis_api = CmisApi(eeprom) 
  
+    def test_is_transceiver_vdm_supported_non_cmis(self):
+        try:
+            self.sfp_optoe_api.is_transceiver_vdm_supported()
+        except NotImplementedError:
+            exception_raised = True
+        assert exception_raised
+
     @pytest.mark.parametrize("mock_response1, mock_response2, expected", [ 
         (0, cmis_api, 0), 
         (1, cmis_api, 1),


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
is_transceiver_vdm_supported API needs to be created so that xcvrd can directly skip freezing/unfreezing of VDM stats (done to read VDM and PM data from the transceiver) for transceivers which do not support VDM feature.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
XCVRD will call `is_transceiver_vdm_supported` API before performing freeze of VDM stats.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Following types of modules were tested with this changeset
1. CMIS module supporting VDM - ensured is_transceiver_vdm_supported returns True
2. SFF-8472 module - ensured is_transceiver_vdm_supported returns False

#### Additional Information (Optional)
MSFT ADO - 30657693
