### PR TITLE
Test sonic xcvr with emu

### DIFF
--- a/.github/workflows/test_sonic_xcvr_with_emu.yml
+++ b/.github/workflows/test_sonic_xcvr_with_emu.yml
@@ -1,0 +1,20 @@
+name: Test sonic-xcvr with xcvr-emu
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: test sonic-xcvr with xcvr-emu
+      run: make test_sonic_xcvr_with_emu

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+DOCKER_CMD ?= docker
+SONIC_XCVR_IMAGE ?= sonic-xcvr
+
+.PHONY: test_sonic_xcvr_with_emu
+test_sonic_xcvr_with_emu:
+	$(DOCKER_CMD) build -f docker/Dockerfile -t $(SONIC_XCVR_IMAGE) .
+	$(DOCKER_CMD) run -it \
+	-v `pwd`/docker/pyproject.toml:/sonic_platform_base/pyproject.toml \
+	-v `pwd`/sonic_platform_base:/sonic_platform_base/sonic_platform_base \
+	-v `pwd`/docker/tests:/sonic_platform_base/tests \
+	-w /sonic_platform_base \
+	$(SONIC_XCVR_IMAGE) \
+	python -m pytest -v .

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,12 @@
+FROM ghcr.io/ishidawataru/xcvr-emu:main
+
+WORKDIR /sonic_platform_base
+
+RUN --mount=type=bind,source=docker/sonic_py_common,target=/sonic_py_common,rw \
+    cd /sonic_py_common && pip install .
+
+RUN mkdir sonic_platform_base && touch sonic_platform_base/__init__.py
+
+COPY docker/pyproject.toml .
+
+RUN pip install '.[dev]'

--- a/docker/pyproject.toml
+++ b/docker/pyproject.toml
@@ -1,0 +1,10 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "sonic-platform-common"
+version = "1.0.0"
+
+[project.optional-dependencies]
+dev = ["pytest", "mock", "PyYAML", "pytest-asyncio"]

--- a/docker/sonic_py_common/pyproject.toml
+++ b/docker/sonic_py_common/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "sonic-py-common"
+version = "1.0.0"

--- a/docker/sonic_py_common/sonic_py_common/logger.py
+++ b/docker/sonic_py_common/sonic_py_common/logger.py
@@ -1,0 +1,3 @@
+from unittest.mock import MagicMock
+
+Logger = MagicMock()

--- a/docker/tests/sonic_xcvr_with_emu/test_cmis.py
+++ b/docker/tests/sonic_xcvr_with_emu/test_cmis.py
@@ -1,0 +1,82 @@
+import pytest
+
+from sonic_platform_base.sonic_xcvr.xcvr_eeprom import XcvrEeprom
+from sonic_platform_base.sonic_xcvr.api.public.cmis import CmisApi
+from sonic_platform_base.sonic_xcvr.mem_maps.public.cmis import CmisMemMap
+from sonic_platform_base.sonic_xcvr.codes.public.cmis import CmisCodes
+
+from xcvr_emu.transceiver import CMISTransceiver  # type: ignore
+from xcvr_emu.proto.emulator_pb2 import (  # type: ignore
+    ReadRequest,
+    WriteRequest,
+)
+
+
+class XcvrEmuEeprom(XcvrEeprom):
+    def __init__(self, config: dict):
+
+        codes = CmisCodes
+        mem_map = CmisMemMap(codes)
+
+        self.xcvr = CMISTransceiver(
+            0,
+            {
+                "present": True,
+                "defaults": config,
+            },
+        )
+
+        super().__init__(self._read, self._write, mem_map)
+
+    def _read(self, offset, num_bytes):
+        if not self.xcvr.present:
+            return None
+        # convert optoe offset to SFF page and offset
+        # optoe maps the SFF 2D address to a linear address
+        page = offset // 128
+        if page > 0:
+            page = page - 1
+
+        if offset > 128:
+            offset = (offset % 128) + 128
+
+        return self.xcvr.read(
+            ReadRequest(index=0, offset=offset, page=page, length=num_bytes)
+        )
+
+    def _write(self, offset, num_bytes, write_buffer):
+        assert len(write_buffer) <= num_bytes
+        # convert optoe offset to SFF page and offset
+        # optoe maps the SFF 2D address to a linear address
+        page = offset // 128
+        if page > 0:
+            page = page - 1
+
+        if offset > 128:
+            offset = (offset % 128) + 128
+
+        return self.xcvr.write(
+            WriteRequest(
+                index=0,
+                page=page,
+                offset=offset,
+                length=num_bytes,
+                data=bytes(write_buffer),
+            )
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "emu_response, expected", [("1234567890", "1234567890"), ("ABCD", "ABCD")]
+)
+async def test_get_model(emu_response, expected):
+    eeprom = XcvrEmuEeprom(
+        {
+            "VendorPN": emu_response,
+        },
+    )
+    api = CmisApi(eeprom)
+    result = api.get_model()
+    await eeprom.xcvr.plugout()
+    assert result == expected

--- a/sonic_platform_base/sonic_xcvr/fields/xcvr_field.py
+++ b/sonic_platform_base/sonic_xcvr/fields/xcvr_field.py
@@ -221,7 +221,7 @@ class StringRegField(RegField):
         self.format = kwargs.get("format", ">%ds" % self.size)
 
     def decode(self, raw_data, **decoded_deps):
-        return struct.unpack(self.format, raw_data)[0].decode(self.encoding, 'ignore')
+        return struct.unpack(self.format, raw_data)[0].decode(self.encoding, 'ignore').rstrip("\x00")
 
 class CodeRegField(RegField):
     """


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description

This PR adds sonic-xcvr testing platform that uses [xcvr-emu](https://github.com/ishidawataru/xcvr-emu).

Also, this PR includes a fix for a possible bug found by the test with xcvr-emu.

This PR mainly aims to show how xcvr-emu can be integrated into the sonic-platform-common CI pipeline.

#### Motivation and Context

https://github.com/sonic-net/SONiC/pull/1849


#### How Has This Been Tested?

Run `make test_sonic_xcvr_with_emu` at the top directory of this repo.

```
$ make test_sonic_xcvr_with_emu 
docker build -f docker/Dockerfile -t sonic-xcvr .                                                                                                            
[+] Building 0.0s (11/11) FINISHED                                                                                                      docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                    0.0s
 => => transferring dockerfile: 360B                                                                                                                    0.0s
 => [internal] load metadata for ghcr.io/ishidawataru/xcvr-emu:main                                                                                     0.0s
 => [internal] load .dockerignore                                                                                                                       0.0s
 => => transferring context: 2B                                                                                                                         0.0s
 => [stage-0 1/6] FROM ghcr.io/ishidawataru/xcvr-emu:main                                                                                               0.0s
 => [internal] load build context                                                                                                                       0.0s  => => transferring context: 360B                                                                                                                       0.0s
 => CACHED [stage-0 2/6] WORKDIR /sonic_platform_base                                                                                                   0.0s  => CACHED [stage-0 3/6] RUN --mount=type=bind,source=docker/sonic_py_common,target=/sonic_py_common,rw     cd /sonic_py_common && pip install .        0.0s  => CACHED [stage-0 4/6] RUN mkdir sonic_platform_base && touch sonic_platform_base/__init__.py                                                         0.0s
 => CACHED [stage-0 5/6] COPY docker/pyproject.toml .                                                                                                   0.0s
 => CACHED [stage-0 6/6] RUN pip install '.[dev]'                                                                                                       0.0s
 => exporting to image                                                                                                                                  0.0s 
 => => exporting layers                                                                                                                                 0.0s
 => => writing image sha256:882ddc798bca7515e3941f96c61424921cd2fee074f567b5c2ecaf7eab85e3ea                                                            0.0s
 => => naming to docker.io/library/sonic-xcvr  
docker run -it \
        -v `pwd`/docker/pyproject.toml:/sonic_platform_base/pyproject.toml \
        -v `pwd`/sonic_platform_base:/sonic_platform_base/sonic_platform_base \
        -v `pwd`/docker/tests:/sonic_platform_base/tests \
        -w /sonic_platform_base \
        sonic-xcvr \
        python -m pytest -v .
/usr/local/lib/python3.11/site-packages/pytest_asyncio/plugin.py:207: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"

  warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
==================================================================== test session starts ====================================================================
platform linux -- Python 3.11.11, pytest-8.3.4, pluggy-1.5.0 -- /usr/local/bin/python
cachedir: .pytest_cache
rootdir: /sonic_platform_base
configfile: pyproject.toml
plugins: asyncio-0.25.2
asyncio: mode=Mode.STRICT, asyncio_default_fixture_loop_scope=None
collected 2 items                                                                                                                                           

tests/sonic_xcvr_with_emu/test_cmis.py::test_get_model[1234567890-1234567890] PASSED                                                                  [ 50%]
tests/sonic_xcvr_with_emu/test_cmis.py::test_get_model[ABCD-ABCD] PASSED                                                                              [100%]
$
```

#### Additional Information (Optional)

