### PR TITLE
[202405] Override MaxDurationDPInit through software for values <= 1s

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -21,6 +21,9 @@ from collections import defaultdict
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
+DATAPATH_INIT_DURATION_MULTIPLIER = 10
+DATAPATH_INIT_DURATION_OVERRIDE_THRESHOLD = 1000
+
 CMIS_VDM_KEY_TO_DB_PREFIX_KEY_MAP = {
     "Laser Temperature [C]" : "laser_temperature_media",
     "eSNR Media Input [dB]" : "esnr_media_input",
@@ -745,7 +748,10 @@ class CmisApi(XcvrApi):
         if self.is_flat_memory():
             return 0
         duration = self.xcvr_eeprom.read(consts.DP_PATH_INIT_DURATION)
-        return float(duration) if duration is not None else 0
+        if duration is None:
+            return 0
+        value = float(duration)
+        return value * DATAPATH_INIT_DURATION_MULTIPLIER if value <= DATAPATH_INIT_DURATION_OVERRIDE_THRESHOLD else value
 
     def get_datapath_deinit_duration(self):
         '''

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -650,7 +650,9 @@ class TestCmis(object):
     @pytest.mark.parametrize("mock_response1, mock_response2, expected", [
         (True, '1', 0 ),
         (False, None, 0),
-        (False, '5', 5.0),
+        (False, '500', 5000.0),
+        (False, '1000', 10000.0),
+        (False, '5000', 5000.0),
         (False, '60000', 60000.0),
     ])
     def test_get_datapath_init_duration(self, mock_response1, mock_response2, expected):


### PR DESCRIPTION
202405 cherry-pick PR for https://github.com/sonic-net/sonic-platform-common/pull/533

<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
For some transceivers, the `MaxDurationDPInit` encoded in EEPROM might be lesser than the actual time taken to reach DP init state by the transceivers. This causes the CMIS initialization to fail with the below error
```
Jan 23 19:28:12.207053 DUT1 NOTICE pmon#xcvrd[36]: CMIS: Ethernet96: 400G, lanemask=0xff, state=DP_INIT, appl 1 host_lane_count 8 retries=0
Jan 23 19:28:12.221832 DUT1 NOTICE pmon#xcvrd[36]: CMIS: Ethernet96: DpInit duration 0.5 secs
Jan 23 19:28:13.230593 DUT1 NOTICE pmon#xcvrd[36]: CMIS: Ethernet96: 400G, lanemask=0xff, state=DP_TXON, appl 1 host_lane_count 8 retries=0
Jan 23 19:28:13.234448 DUT1 NOTICE pmon#xcvrd[36]: CMIS: Ethernet96: timeout for 'DataPathInitialized' <<-- Error
Jan 23 19:28:14.250133 DUT1 NOTICE pmon#xcvrd[36]: CMIS: Ethernet96: 400G, lanemask=0xff, state=INSERTED, appl 1 host_lane_count 8 retries=1
Jan 23 19:28:14.315148 DUT1 NOTICE pmon#xcvrd[36]: CMIS: Ethernet96: Setting appl=1
Jan 23 19:28:14.380452 DUT1 NOTICE pmon#xcvrd[36]: CMIS: Ethernet96: Setting host_lanemask=0xff
Jan 23 19:28:14.511850 DUT1 NOTICE pmon#xcvrd[36]: CMIS: Ethernet96: Setting media_lanemask=0xf
Jan 23 19:28:14.567454 DUT1 NOTICE pmon#xcvrd[36]: CMIS: Ethernet96: force Datapath reinit
Jan 23 19:28:15.575785 DUT1 NOTICE pmon#xcvrd[36]: CMIS: Ethernet96: 400G, lanemask=0xff, state=DP_DEINIT, appl 1 host_lane_count 8 retries=1
Jan 23 19:28:15.598574 DUT1 NOTICE pmon#xcvrd[36]: CMIS: Ethernet96: DpDeinit duration 0.1 secs, modulePwrUp duration 10.0 secs     
Jan 23 19:28:16.606588 DUT1 NOTICE pmon#xcvrd[36]: CMIS: Ethernet96: 400G, lanemask=0xff, state=AP_CONFIGURED, appl 1 host_lane_count 8 retries=1
Jan 23 19:28:17.640929 DUT1 NOTICE pmon#xcvrd[36]: CMIS: Ethernet96: 400G, lanemask=0xff, state=DP_INIT, appl 1 host_lane_count 8 retries=1
Jan 23 19:28:17.656010 DUT1 NOTICE pmon#xcvrd[36]: CMIS: Ethernet96: DpInit duration 0.5 secs
Jan 23 19:28:18.664305 DUT1 NOTICE pmon#xcvrd[36]: CMIS: Ethernet96: 400G, lanemask=0xff, state=DP_TXON, appl 1 host_lane_count 8 retries=1
Jan 23 19:28:18.668263 DUT1 NOTICE pmon#xcvrd[36]: CMIS: Ethernet96: timeout for 'DataPathInitialized' <<-- Error
```
Hence, we need to relax this stringent requirement from software to successfully allow CMIS initialization for such transceivers.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
For transceivers with `MaxDurationDPInit` <= 1s, the CMIS driver will increase the timeout value to 10 times of the corresponding `MaxDurationDPInit` value advertised in the EEPROM to allow the transceiver to reach DP init state successfully.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
For a transceiver with `MaxDurationDPInit` = 0.5s, the `get_datapath_init_duration` API returned a value of 5s.
```
PATELMI@DUT1:~$ sudo sfputil read-eeprom -p Ethernet96 -n 1 -o 144 -s 1
        00000090 45                                               |E|
PATELMI@DUT1:~$ 
.
.
.
Jan 24 06:09:29.896666 DUT1 NOTICE pmon#xcvrd[101451]: CMIS: Ethernet96: 400G, lanemask=0xff, state=DP_INIT, appl 1 host_lane_count 8 retries=0
Jan 24 06:09:29.912270 DUT1 NOTICE pmon#xcvrd[101451]: CMIS: Ethernet96: DpInit duration 5.0 secs
Jan 24 06:09:30.920209 DUT1 NOTICE pmon#xcvrd[101451]: CMIS: Ethernet96: 400G, lanemask=0xff, state=DP_TXON, appl 1 host_lane_count 8 retries=0
Jan 24 06:09:32.957135 DUT1 NOTICE pmon#xcvrd[101451]: message repeated 2 times: [ CMIS: Ethernet96: 400G, lanemask=0xff, state=DP_TXON, appl 1 host_lane_count 8 retries=0]
Jan 24 06:09:32.957135 DUT1 NOTICE pmon#xcvrd[101451]: CMIS: Ethernet96: Turning ON tx power
Jan 24 06:09:33.964916 DUT1 NOTICE pmon#xcvrd[101451]: CMIS: Ethernet96: 400G, lanemask=0xff, state=DP_ACTIVATION, appl 1 host_lane_count 8 retries=0
Jan 24 06:09:33.968630 DUT1 NOTICE pmon#xcvrd[101451]: CMIS: Ethernet96: READY
```

#### Additional Information (Optional)
MSFT ADO - 31007979
