### PR TITLE
[202411][cmis] Fix cmis.get_error_description speed for passive module

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,7 @@ pool:
   vmImage: 'ubuntu-20.04'
 
 container:
-  image: sonicdev-microsoft.azurecr.io:443/sonic-slave-bullseye:latest
+  image: sonicdev-microsoft.azurecr.io:443/sonic-slave-bookworm:latest
 
 steps:
 - task: DownloadPipelineArtifact@2
@@ -49,7 +49,7 @@ steps:
                  libnl-nf-3-200_*.deb \
                  libswsscommon_1.0.0_amd64.deb \
                  python3-swsscommon_1.0.0_amd64.deb
-  workingDirectory: $(Build.ArtifactStagingDirectory)/target/debs/bullseye/
+  workingDirectory: $(Build.ArtifactStagingDirectory)/target/debs/bookworm/
   displayName: 'Install Debian dependencies'
 
 - script: |
@@ -59,7 +59,7 @@ steps:
     sudo pip3 install sonic_yang_mgmt-1.0-py3-none-any.whl
     sudo pip3 install sonic_yang_models-1.0-py3-none-any.whl
     sudo pip3 install sonic_config_engine-1.0-py3-none-any.whl
-  workingDirectory: $(Build.ArtifactStagingDirectory)/target/python-wheels/bullseye/
+  workingDirectory: $(Build.ArtifactStagingDirectory)/target/python-wheels/bookworm/
   displayName: 'Install Python dependencies'
 
 - script: |
@@ -69,12 +69,15 @@ steps:
     . /etc/os-release
     sudo apt-add-repository https://packages.microsoft.com/debian/$VERSION_ID/prod
     sudo apt-get update
-    sudo apt-get install -y dotnet-sdk-5.0
+    sudo apt-get install -y dotnet-sdk-8.0
   displayName: "Install .NET CORE"
 
 # Python 3
 - script: |
-    python3 setup.py test
+    set -ex
+    pip3 install ".[testing]"
+    pip3 uninstall --yes sonic-platform-common
+    pytest
   displayName: 'Test Python 3'
 
 - task: PublishTestResults@2
@@ -93,8 +96,7 @@ steps:
   displayName: 'Publish Python 3 test coverage'
 
 - script: |
-    set -e
-    python3 setup.py bdist_wheel
+    python3 -m build -n
   displayName: 'Build Python 3 wheel'
 
 - publish: '$(System.DefaultWorkingDirectory)/dist/'

--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -3144,21 +3144,22 @@ class CmisApi(XcvrApi):
         return True
 
     def get_error_description(self):
-        dp_state = self.get_datapath_state()
-        conf_state = self.get_config_datapath_hostlane_status()
-        for lane in range(self.NUM_CHANNELS):
-            name = "{}_{}_{}".format(consts.STAGED_CTRL_APSEL_FIELD, 0, lane + 1)
-            appl = self.xcvr_eeprom.read(name)
-            if (appl is None) or ((appl >> 4) == 0):
-                continue
+        if not self.is_flat_memory():
+            dp_state = self.get_datapath_state()
+            conf_state = self.get_config_datapath_hostlane_status()
+            for lane in range(self.NUM_CHANNELS):
+                name = "{}_{}_{}".format(consts.STAGED_CTRL_APSEL_FIELD, 0, lane + 1)
+                appl = self.xcvr_eeprom.read(name)
+                if (appl is None) or ((appl >> 4) == 0):
+                    continue
 
-            name = "DP{}State".format(lane + 1)
-            if dp_state[name] != CmisCodes.DATAPATH_STATE[4]:
-                return dp_state[name]
+                name = "DP{}State".format(lane + 1)
+                if dp_state[name] != CmisCodes.DATAPATH_STATE[4]:
+                    return dp_state[name]
 
-            name = "ConfigStatusLane{}".format(lane + 1)
-            if conf_state[name] != CmisCodes.CONFIG_STATUS[1]:
-                return conf_state[name]
+                name = "ConfigStatusLane{}".format(lane + 1)
+                if conf_state[name] != CmisCodes.CONFIG_STATUS[1]:
+                    return conf_state[name]
 
         state = self.get_module_state()
         if state != CmisCodes.MODULE_STATE[3]:

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -3054,35 +3054,63 @@ class TestCmis(object):
         assert self.api.xcvr_eeprom.write.call_count == 4
 
     def test_get_error_description(self):
-        self.api.get_module_state = MagicMock()
-        self.api.get_module_state.return_value = 'ModuleReady'
-        self.api.get_datapath_state = MagicMock()
-        self.api.get_datapath_state.return_value = {
-            'DP1State': 'DataPathActivated',
-            'DP2State': 'DataPathActivated',
-            'DP3State': 'DataPathActivated',
-            'DP4State': 'DataPathActivated',
-            'DP5State': 'DataPathActivated',
-            'DP6State': 'DataPathActivated',
-            'DP7State': 'DataPathActivated',
-            'DP8State': 'DataPathActivated'
-        }
-        self.api.get_config_datapath_hostlane_status = MagicMock()
-        self.api.get_config_datapath_hostlane_status.return_value = {
-            'ConfigStatusLane1': 'ConfigSuccess',
-            'ConfigStatusLane2': 'ConfigSuccess',
-            'ConfigStatusLane3': 'ConfigSuccess',
-            'ConfigStatusLane4': 'ConfigSuccess',
-            'ConfigStatusLane5': 'ConfigSuccess',
-            'ConfigStatusLane6': 'ConfigSuccess',
-            'ConfigStatusLane7': 'ConfigSuccess',
-            'ConfigStatusLane8': 'ConfigSuccess'
-        }
-        self.api.xcvr_eeprom.read = MagicMock()
-        self.api.xcvr_eeprom.read.return_value = 0x10
-
-        result = self.api.get_error_description()
-        assert result is 'OK'
+        with patch.object(self.api, 'is_flat_memory') as mock_method:
+            mock_method.return_value = False
+            self.api.get_module_state = MagicMock()
+            self.api.get_module_state.return_value = 'ModuleReady'
+            self.api.get_datapath_state = MagicMock()
+            self.api.get_datapath_state.return_value = {
+                'DP1State': 'DataPathActivated',
+                'DP2State': 'DataPathActivated',
+                'DP3State': 'DataPathActivated',
+                'DP4State': 'DataPathActivated',
+                'DP5State': 'DataPathActivated',
+                'DP6State': 'DataPathActivated',
+                'DP7State': 'DataPathActivated',
+                'DP8State': 'DataPathActivated'
+            }
+            self.api.get_config_datapath_hostlane_status = MagicMock()
+            self.api.get_config_datapath_hostlane_status.return_value = {
+                'ConfigStatusLane1': 'ConfigSuccess',
+                'ConfigStatusLane2': 'ConfigSuccess',
+                'ConfigStatusLane3': 'ConfigSuccess',
+                'ConfigStatusLane4': 'ConfigSuccess',
+                'ConfigStatusLane5': 'ConfigSuccess',
+                'ConfigStatusLane6': 'ConfigSuccess',
+                'ConfigStatusLane7': 'ConfigSuccess',
+                'ConfigStatusLane8': 'ConfigSuccess'
+            }
+            self.api.xcvr_eeprom.read = MagicMock()
+            self.api.xcvr_eeprom.read.return_value = 0x10
+    
+            result = self.api.get_error_description()
+            assert result is 'OK'
+            
+            self.api.get_config_datapath_hostlane_status.return_value = {
+                'ConfigStatusLane1': 'ConfigRejected',
+                'ConfigStatusLane2': 'ConfigRejected',
+                'ConfigStatusLane3': 'ConfigRejected',
+                'ConfigStatusLane4': 'ConfigRejected',
+                'ConfigStatusLane5': 'ConfigRejected',
+                'ConfigStatusLane6': 'ConfigRejected',
+                'ConfigStatusLane7': 'ConfigRejected',
+                'ConfigStatusLane8': 'ConfigRejected'
+            }
+            result = self.api.get_error_description()
+            assert result is 'ConfigRejected'
+            
+            self.api.get_datapath_state.return_value = {
+                'DP1State': 'DataPathDeactivated',
+                'DP2State': 'DataPathActivated',
+                'DP3State': 'DataPathActivated',
+                'DP4State': 'DataPathActivated',
+                'DP5State': 'DataPathActivated',
+                'DP6State': 'DataPathActivated',
+                'DP7State': 'DataPathActivated',
+                'DP8State': 'DataPathActivated'
+            }
+            result = self.api.get_error_description()
+            assert result is 'DataPathDeactivated'
 
     def test_random_read_fail(self):
         def mock_read_raw(offset, size):


### PR DESCRIPTION
This is 202411 dedicated version of @Junchao-Mellanox 's PR https://github.com/sonic-net/sonic-platform-common/pull/526

#### Description
For copper passive modules with flat memory cmis.get_error_description should not try to read from paged memory (CMIS spec indicates page 0x11, which is irrelevant for flat memory modules) of the EEPROM instead it will read module state.

#### Motivation and Context
Read data path state from the correct field on the EEPROM for copper passive modules in SW mode.

#### How Has This Been Tested?
Manual test
Unit test

#### Additional Information (Optional)

