### PR TITLE
azure-pipelines: update to libyang3

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,6 +43,8 @@ steps:
     set -xe
     sudo apt-get -y purge libnl-3-dev libnl-route-3-dev || true
     sudo dpkg -i libyang_1.0.73_amd64.deb \
+                 libyang3_*.deb \
+                 python3-libyang*.deb \
                  libnl-3-200_*.deb \
                  libnl-genl-3-200_*.deb \
                  libnl-route-3-200_*.deb \


### PR DESCRIPTION
#### Description

Port from libyang1 to libyang3. This depends on changes to sonic-buildimage.

Main Tracking ticket https://github.com/sonic-net/sonic-buildimage/issues/22385
Fixes https://github.com/sonic-net/sonic-buildimage/issues/22385
