### PR TITLE
Adding is_copper api to cmis

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -524,6 +524,13 @@ class CmisApi(XcvrApi):
             return None
         return float("{:.3f}".format(voltage))
 
+    def is_copper(self):
+        '''
+        Returns True if the module is copper, False otherwise
+        '''
+        media_intf = self.get_module_media_type()
+        return media_intf == "passive_copper_media_interface" if media_intf else None
+
     def is_flat_memory(self):
         return self.xcvr_eeprom.read(consts.FLAT_MEM_FIELD) is not False
 

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -169,6 +169,19 @@ class TestCmis(object):
         result = self.api.get_voltage()
         assert result == expected
 
+    def test_is_copper(self):
+      with patch.object(self.api, 'xcvr_eeprom') as mock_eeprom:
+         mock_eeprom.read = MagicMock()
+         mock_eeprom.read.return_value = None
+         assert self.api.is_copper() is None
+         self.api.get_module_media_type = MagicMock()
+         self.api.get_module_media_type.return_value = "passive_copper_media_interface"
+         assert self.api.is_copper()
+         self.api.get_module_media_type.return_value = "active_cable_media_interface"
+         assert not self.api.is_copper()
+         self.api.get_module_media_type.return_value = "sm_media_interface"
+         assert not self.api.is_copper()
+
     @pytest.mark.parametrize("mock_response, expected", [
         (False, False)
     ])


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
For CMISwe can tell if a module is copper because the media interface will always be passive_copper_media_interface. This PR adds a check for that.

#### Motivation and Context
Similar to other SFF xcvr api's it would be helpful to know if a CMIS module is copper or optical. We can use this information for tunings and in other areas where appropriate.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Wrote a unit test and tested manually on device using multiple optics and DACs

#### Additional Information (Optional)

