### PR TITLE
Restore optoe page to default 0 for active cables

### DIFF
--- a/sonic_platform_base/sonic_xcvr/sfp_optoe_base.py
+++ b/sonic_platform_base/sonic_xcvr/sfp_optoe_base.py
@@ -7,7 +7,9 @@
 
 from ..sfp_base import SfpBase
 
-SFP_OPTOE_PAGE_OFFSET = 127
+SFP_OPTOE_PAGE_SELECT_OFFSET = 127
+SFP_OPTOE_UPPER_PAGE0_OFFSET = 128
+SFP_OPTOE_PAGE_SIZE = 128
 
 class SfpOptoeBase(SfpBase):
     def __init__(self):
@@ -264,10 +266,10 @@ class SfpOptoeBase(SfpBase):
             pass
 
     def get_optoe_current_page(self):
-        return self.read_eeprom(SFP_OPTOE_PAGE_OFFSET, 1)
+        return self.read_eeprom(SFP_OPTOE_PAGE_SELECT_OFFSET, 1)[0]
 
     def set_page0(self):
-        self.write_eeprom(SFP_OPTOE_PAGE_OFFSET, 1, bytearray([0x00]))
+        self.write_eeprom(SFP_OPTOE_PAGE_SELECT_OFFSET, 1, bytearray([0x00]))
 
     def set_optoe_write_timeout(self, write_timeout):
         sys_path = self.get_eeprom_path()
@@ -281,7 +283,9 @@ class SfpOptoeBase(SfpBase):
     def read_eeprom(self, offset, num_bytes):
         try:
             with open(self.get_eeprom_path(), mode='rb', buffering=0) as f:
-                if offset > 127 and offset < 256 and self.get_optoe_current_page() != 0:
+                if offset >= SFP_OPTOE_UPPER_PAGE0_OFFSET  and \
+                    offset < (SFP_OPTOE_UPPER_PAGE0_OFFSET+SFP_OPTOE_PAGE_SIZE) and \
+                        self.get_optoe_current_page() != 0:
                 # Restoring the page to 0 helps in cases where the optoe driver failed to restore
                 # the page when say the module was busy with CDB command processing
                    self.set_page0()

--- a/sonic_platform_base/sonic_xcvr/sfp_optoe_base.py
+++ b/sonic_platform_base/sonic_xcvr/sfp_optoe_base.py
@@ -286,8 +286,8 @@ class SfpOptoeBase(SfpBase):
                 if offset >= SFP_OPTOE_UPPER_PAGE0_OFFSET  and \
                     offset < (SFP_OPTOE_UPPER_PAGE0_OFFSET+SFP_OPTOE_PAGE_SIZE) and \
                         self.get_optoe_current_page() != 0:
-                # Restoring the page to 0 helps in cases where the optoe driver failed to restore
-                # the page when say the module was busy with CDB command processing
+                    # Restoring the page to 0 helps in cases where the optoe driver failed to restore
+                    # the page when say the module was busy with CDB command processing
                    self.set_page0()
                 f.seek(offset)
                 return bytearray(f.read(num_bytes))


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
Restore the optoe's page to page ZERO before reading the Lower page > 127



#### Motivation and Context
When the module is busy with CDB command, the optoe kernel driver at the end of user page read request, tries to restore the page to Page ZERO and if this write fails because the module could be busy with CDB command (since these modules donot support background CDB mode).  Because of this when Xcvrd tries to read offset (> 127) in Lower page, since optoe does not restore the page to 0 for any Lower page access, the page read to these offset will result in wrong page to be read (because of previous page select write failure) and Xcvrd parsing fails causing crash.

Now in optoe EEPROM read API we ensure to restore the Page to ZERO page if the Page select byte is non-zero

#### How Has This Been Tested?
TBD:
1. Test on Arista switch
2. Test on Cisco switch

#### Additional Information (Optional)

