### PR TITLE
Add support for rx_disable, rx_disable_channel in CMIS_API for transceivers

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -838,44 +838,44 @@ class CmisApi(XcvrApi):
         return self.xcvr_eeprom.write(consts.TX_DISABLE_FIELD, channel_state)
 
     def get_rx_disable_support(self):
-	return not self.is_flat_memory() and self.xcvr_eeprom.read(consts.RX_DISABLE_SUPPORT_FIELD)
+        return not self.is_flat_memory() and self.xcvr_eeprom.read(consts.RX_DISABLE_SUPPORT_FIELD)
 
     def get_rx_disable(self):
-	rx_disable_support = self.get_rx_disable_support()
-	if rx_disable_support is None:
-	    return None
-	if not rx_disable_support:
-	    return ["N/A" for _ in range(self.NUM_CHANNELS)]
-	rx_disable = self.xcvr_eeprom.read(consts.RX_DISABLE_FIELD)
-	if rx_disable is None:
-	    return None
-	return [bool(rx_disable & (1 << i)) for i in range(self.NUM_CHANNELS)]
+        rx_disable_support = self.get_rx_disable_support()
+        if rx_disable_support is None:
+            return None
+        if not rx_disable_support:
+            return ["N/A" for _ in range(self.NUM_CHANNELS)]
+        rx_disable = self.xcvr_eeprom.read(consts.RX_DISABLE_FIELD)
+        if rx_disable is None:
+            return None
+        return [bool(rx_disable & (1 << i)) for i in range(self.NUM_CHANNELS)]
 
     def rx_disable(self, rx_disable):
-	val = 0xFF if rx_disable else 0x0
-	return self.xcvr_eeprom.write(consts.RX_DISABLE_FIELD, val)
+        val = 0xFF if rx_disable else 0x0
+        return self.xcvr_eeprom.write(consts.RX_DISABLE_FIELD, val)
 
     def get_rx_disable_channel(self):
-	rx_disable_support = self.get_rx_disable_support()
-	if rx_disable_support is None:
-	    return None
-	if not rx_disable_support:
-	    return 'N/A'
-	return self.xcvr_eeprom.read(consts.RX_DISABLE_FIELD)
+        rx_disable_support = self.get_rx_disable_support()
+        if rx_disable_support is None:
+            return None
+        if not rx_disable_support:
+            return 'N/A'
+        return self.xcvr_eeprom.read(consts.RX_DISABLE_FIELD)
 
     def rx_disable_channel(self, channel, disable):
-	channel_state = self.get_rx_disable_channel()
-	if channel_state is None or channel_state == 'N/A':
-	    return False
+        channel_state = self.get_rx_disable_channel()
+        if channel_state is None or channel_state == 'N/A':
+            return False
 
-	for i in range(self.NUM_CHANNELS):
-	    mask = (1 << i)
-	    if not (channel & mask):
-		continue
-	    if disable:
-		channel_state |= mask
-	    else:
-		channel_state &= ~mask
+        for i in range(self.NUM_CHANNELS):
+            mask = (1 << i)
+            if not (channel & mask):
+                continue
+            if disable:
+                channel_state |= mask
+            else:
+                channel_state &= ~mask
 
         return self.xcvr_eeprom.write(consts.RX_DISABLE_FIELD, channel_state)
 

--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -837,6 +837,48 @@ class CmisApi(XcvrApi):
 
         return self.xcvr_eeprom.write(consts.TX_DISABLE_FIELD, channel_state)
 
+    def get_rx_disable_support(self):
+	return not self.is_flat_memory() and self.xcvr_eeprom.read(consts.RX_DISABLE_SUPPORT_FIELD)
+
+    def get_rx_disable(self):
+	rx_disable_support = self.get_rx_disable_support()
+	if rx_disable_support is None:
+	    return None
+	if not rx_disable_support:
+	    return ["N/A" for _ in range(self.NUM_CHANNELS)]
+	rx_disable = self.xcvr_eeprom.read(consts.RX_DISABLE_FIELD)
+	if rx_disable is None:
+	    return None
+	return [bool(rx_disable & (1 << i)) for i in range(self.NUM_CHANNELS)]
+
+    def rx_disable(self, rx_disable):
+	val = 0xFF if rx_disable else 0x0
+	return self.xcvr_eeprom.write(consts.RX_DISABLE_FIELD, val)
+
+    def get_rx_disable_channel(self):
+	rx_disable_support = self.get_rx_disable_support()
+	if rx_disable_support is None:
+	    return None
+	if not rx_disable_support:
+	    return 'N/A'
+	return self.xcvr_eeprom.read(consts.RX_DISABLE_FIELD)
+
+    def rx_disable_channel(self, channel, disable):
+	channel_state = self.get_rx_disable_channel()
+	if channel_state is None or channel_state == 'N/A':
+	    return False
+
+	for i in range(self.NUM_CHANNELS):
+	    mask = (1 << i)
+	    if not (channel & mask):
+		continue
+	    if disable:
+		channel_state |= mask
+	    else:
+		channel_state &= ~mask
+
+    return self.xcvr_eeprom.write(consts.RX_DISABLE_FIELD, channel_state)
+
     def get_laser_tuning_summary(self):
         '''
         This function returns laser tuning status summary on media lane

--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -864,24 +864,24 @@ class CmisApi(XcvrApi):
         return self.xcvr_eeprom.read(consts.RX_DISABLE_FIELD)
 
     def rx_disable_channel(self, channel, disable):
-	# Check if channel state is available
-	channel_state = self.get_rx_disable_channel()
-	if channel_state is None or channel_state == 'N/A':
-	    return False
+        # Check if channel state is available
+        channel_state = self.get_rx_disable_channel()
+        if channel_state is None or channel_state == 'N/A':
+            return False
 
-	# Disable or enable the specific channel based on the input
-	if 1 <= channel <= self.NUM_CHANNELS:
-	    # The channel is represented by individual RegBitField entries
-	    field_name = f"{consts.RX_DISABLE_FIELD}_{channel}"
+        # Disable or enable the specific channel based on the input
+        if 1 <= channel <= self.NUM_CHANNELS:
+            # The channel is represented by individual RegBitField entries
+            field_name = f"{consts.RX_DISABLE_FIELD}_{channel}"
 
-	    if disable:
-		# Disable the channel (set the bit to 1)
-		return self.xcvr_eeprom.write(field_name, 1)
-	    else:
-		# Enable the channel (set the bit to 0)
-		return self.xcvr_eeprom.write(field_name, 0)
+            if disable:
+                # Disable the channel (set the bit to 1)
+                return self.xcvr_eeprom.write(field_name, 1)
+            else:
+                # Enable the channel (set the bit to 0)
+                return self.xcvr_eeprom.write(field_name, 0)
 
-	return False
+        return False
 
     def get_laser_tuning_summary(self):
         '''

--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -877,7 +877,7 @@ class CmisApi(XcvrApi):
 	    else:
 		channel_state &= ~mask
 
-    return self.xcvr_eeprom.write(consts.RX_DISABLE_FIELD, channel_state)
+        return self.xcvr_eeprom.write(consts.RX_DISABLE_FIELD, channel_state)
 
     def get_laser_tuning_summary(self):
         '''

--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -864,20 +864,24 @@ class CmisApi(XcvrApi):
         return self.xcvr_eeprom.read(consts.RX_DISABLE_FIELD)
 
     def rx_disable_channel(self, channel, disable):
-        channel_state = self.get_rx_disable_channel()
-        if channel_state is None or channel_state == 'N/A':
-            return False
+	# Check if channel state is available
+	channel_state = self.get_rx_disable_channel()
+	if channel_state is None or channel_state == 'N/A':
+	    return False
 
-        for i in range(self.NUM_CHANNELS):
-            mask = (1 << i)
-            if not (channel & mask):
-                continue
-            if disable:
-                channel_state |= mask
-            else:
-                channel_state &= ~mask
+	# Disable or enable the specific channel based on the input
+	if 1 <= channel <= self.NUM_CHANNELS:
+	    # The channel is represented by individual RegBitField entries
+	    field_name = f"{consts.RX_DISABLE_FIELD}_{channel}"
 
-        return self.xcvr_eeprom.write(consts.RX_DISABLE_FIELD, channel_state)
+	    if disable:
+		# Disable the channel (set the bit to 1)
+		return self.xcvr_eeprom.write(field_name, 1)
+	    else:
+		# Enable the channel (set the bit to 0)
+		return self.xcvr_eeprom.write(field_name, 0)
+
+	return False
 
     def get_laser_tuning_summary(self):
         '''

--- a/sonic_platform_base/sonic_xcvr/api/xcvr_api.py
+++ b/sonic_platform_base/sonic_xcvr/api/xcvr_api.py
@@ -289,12 +289,6 @@ class XcvrApi(object):
         """
         raise NotImplementedError
 
-    def is_transceiver_vdm_supported(self):
-        """
-        Retrieves VDM support status for this xcvr (applicable for CMIS and C-CMIS)
-        """
-        raise NotImplementedError
-
     def get_transceiver_vdm_real_value(self):
         """
         Retrieves VDM real (sample) values for this xcvr (applicable for CMIS and C-CMIS)

--- a/sonic_platform_base/sonic_xcvr/api/xcvr_api.py
+++ b/sonic_platform_base/sonic_xcvr/api/xcvr_api.py
@@ -488,6 +488,34 @@ class XcvrApi(object):
         """
         raise NotImplementedError
 
+    def rx_disable(self, rx_disable):
+	"""
+	Disable xcvr RX for all channels
+
+	Args:
+	    rx_disable : A Boolean, True to enable rx_disable mode, False to disable
+			 rx_disable mode.
+
+	Returns:
+	    A boolean, True if rx_disable is set successfully, False if not
+	"""
+	raise NotImplementedError
+
+    def rx_disable_channel(self, channel, disable):
+	"""
+	Sets the rx_disable for specified xcvr channels
+
+	Args:
+	    channel : A hex of 4 bits (bit 0 to bit 3) which represent channel 0 to 3,
+		      e.g. 0x5 for channel 0 and channel 2.
+	    disable : A boolean, True to disable RX channels specified in channel,
+		      False to enable
+
+	Returns:
+	    A boolean, True if successful, False if not
+	"""
+	raise NotImplementedError
+
     def get_power_override(self):
         """
         Retrieves the power-override status of this xcvr

--- a/sonic_platform_base/sonic_xcvr/api/xcvr_api.py
+++ b/sonic_platform_base/sonic_xcvr/api/xcvr_api.py
@@ -29,35 +29,35 @@ class XcvrApi(object):
         raise NotImplementedError
 
     def get_rx_disable(self):
-	"""
-	Retrieves the rx_disable status of this xcvr.
+        """
+        Retrieves the rx_disable status of this xcvr.
 
-	Returns:
-	    A list of boolean values, representing the RX disable status
-	    of each available channel. The value is True if the xcvr channel
-	    is RX disabled, False if not.
+        Returns:
+            A list of boolean values, representing the RX disable status
+            of each available channel. The value is True if the xcvr channel
+            is RX disabled, False if not.
 
-	    E.g., for a transceiver with four channels: [False, False, True, False]
+            E.g., for a transceiver with four channels: [False, False, True, False]
 
-	    If RX disable status is unsupported on the xcvr, each list element should be "N/A" instead.
+            If RX disable status is unsupported on the xcvr, each list element should be "N/A" instead.
 
-	    If there is an issue with reading the xcvr, None should be returned.
-	"""
-	raise NotImplementedError
+            If there is an issue with reading the xcvr, None should be returned.
+        """
+        raise NotImplementedError
 
     def get_rx_disable_channel(self):
-	"""
-	Retrieves the RX disabled channels in this xcvr.
+        """
+        Retrieves the RX disabled channels in this xcvr.
 
-	Returns:
-	    A hex of 4 bits (bit 0 to bit 3 as channel 0 to channel 3) to represent
-	    RX channels which have been disabled in this xcvr.
-	    As an example, a returned value of 0x5 indicates that channel 0
-	    and channel 2 have been disabled.
+        Returns:
+            A hex of 4 bits (bit 0 to bit 3 as channel 0 to channel 3) to represent
+            RX channels which have been disabled in this xcvr.
+            As an example, a returned value of 0x5 indicates that channel 0
+            and channel 2 have been disabled.
 
-	    If there is an issue with reading the xcvr, None should be returned.
-	"""
-	raise NotImplementedError
+            If there is an issue with reading the xcvr, None should be returned.
+        """
+        raise NotImplementedError
 
 
     def get_serial(self):

--- a/sonic_platform_base/sonic_xcvr/api/xcvr_api.py
+++ b/sonic_platform_base/sonic_xcvr/api/xcvr_api.py
@@ -28,6 +28,38 @@ class XcvrApi(object):
         """
         raise NotImplementedError
 
+    def get_rx_disable(self):
+	"""
+	Retrieves the rx_disable status of this xcvr.
+
+	Returns:
+	    A list of boolean values, representing the RX disable status
+	    of each available channel. The value is True if the xcvr channel
+	    is RX disabled, False if not.
+
+	    E.g., for a transceiver with four channels: [False, False, True, False]
+
+	    If RX disable status is unsupported on the xcvr, each list element should be "N/A" instead.
+
+	    If there is an issue with reading the xcvr, None should be returned.
+	"""
+	raise NotImplementedError
+
+    def get_rx_disable_channel(self):
+	"""
+	Retrieves the RX disabled channels in this xcvr.
+
+	Returns:
+	    A hex of 4 bits (bit 0 to bit 3 as channel 0 to channel 3) to represent
+	    RX channels which have been disabled in this xcvr.
+	    As an example, a returned value of 0x5 indicates that channel 0
+	    and channel 2 have been disabled.
+
+	    If there is an issue with reading the xcvr, None should be returned.
+	"""
+	raise NotImplementedError
+
+
     def get_serial(self):
         """
         Retrieves the serial number of the xcvr
@@ -257,6 +289,12 @@ class XcvrApi(object):
         """
         raise NotImplementedError
 
+    def is_transceiver_vdm_supported(self):
+        """
+        Retrieves VDM support status for this xcvr (applicable for CMIS and C-CMIS)
+        """
+        raise NotImplementedError
+
     def get_transceiver_vdm_real_value(self):
         """
         Retrieves VDM real (sample) values for this xcvr (applicable for CMIS and C-CMIS)
@@ -391,6 +429,34 @@ class XcvrApi(object):
         """
         raise NotImplementedError
 
+    def rx_disable(self, rx_disable):
+        """
+        Disable xcvr RX for all channels
+
+        Args:
+            rx_disable : A Boolean, True to enable rx_disable mode, False to disable
+                         rx_disable mode.
+
+        Returns:
+            A boolean, True if rx_disable is set successfully, False if not
+        """
+        raise NotImplementedError
+
+    def rx_disable_channel(self, channel, disable):
+        """
+        Sets the rx_disable for specified xcvr channels
+
+        Args:
+            channel : A hex of 4 bits (bit 0 to bit 3) which represent channel 0 to 3,
+                      e.g. 0x5 for channel 0 and channel 2.
+            disable : A boolean, True to disable RX channels specified in channel,
+                      False to enable
+
+        Returns:
+            A boolean, True if successful, False if not
+        """
+        raise NotImplementedError
+
     def get_module_temperature(self):
         """
         Retrieves the temperature of this xcvr
@@ -487,34 +553,6 @@ class XcvrApi(object):
             A boolean, True if successful, False if not
         """
         raise NotImplementedError
-
-    def rx_disable(self, rx_disable):
-	"""
-	Disable xcvr RX for all channels
-
-	Args:
-	    rx_disable : A Boolean, True to enable rx_disable mode, False to disable
-			 rx_disable mode.
-
-	Returns:
-	    A boolean, True if rx_disable is set successfully, False if not
-	"""
-	raise NotImplementedError
-
-    def rx_disable_channel(self, channel, disable):
-	"""
-	Sets the rx_disable for specified xcvr channels
-
-	Args:
-	    channel : A hex of 4 bits (bit 0 to bit 3) which represent channel 0 to 3,
-		      e.g. 0x5 for channel 0 and channel 2.
-	    disable : A boolean, True to disable RX channels specified in channel,
-		      False to enable
-
-	Returns:
-	    A boolean, True if successful, False if not
-	"""
-	raise NotImplementedError
 
     def get_power_override(self):
         """

--- a/sonic_platform_base/sonic_xcvr/fields/consts.py
+++ b/sonic_platform_base/sonic_xcvr/fields/consts.py
@@ -32,7 +32,6 @@ RX_POWER_LOW_ALARM_FIELD = "RxPowerLowAlarm"
 RX_POWER_HIGH_WARNING_FIELD = "RxPowerHighWarning"
 RX_POWER_LOW_WARNING_FIELD = "RxPowerLowWarning"
 
-RX_FAULT_SUPPORT_FIELD = "RxFaultSupported"
 RX_DISABLE_FIELD = "RxDisable"
 RX_DISABLE_SUPPORT_FIELD = "RxDisableSupported"
 

--- a/sonic_platform_base/sonic_xcvr/fields/consts.py
+++ b/sonic_platform_base/sonic_xcvr/fields/consts.py
@@ -32,7 +32,6 @@ RX_POWER_LOW_ALARM_FIELD = "RxPowerLowAlarm"
 RX_POWER_HIGH_WARNING_FIELD = "RxPowerHighWarning"
 RX_POWER_LOW_WARNING_FIELD = "RxPowerLowWarning"
 
-
 RX_FAULT_FIELD = "RxFault"
 RX_FAULT_SUPPORT_FIELD = "RxFaultSupported"
 RX_DISABLE_FIELD = "RxDisable"

--- a/sonic_platform_base/sonic_xcvr/fields/consts.py
+++ b/sonic_platform_base/sonic_xcvr/fields/consts.py
@@ -32,6 +32,12 @@ RX_POWER_LOW_ALARM_FIELD = "RxPowerLowAlarm"
 RX_POWER_HIGH_WARNING_FIELD = "RxPowerHighWarning"
 RX_POWER_LOW_WARNING_FIELD = "RxPowerLowWarning"
 
+
+RX_FAULT_FIELD = "RxFault"
+RX_FAULT_SUPPORT_FIELD = "RxFaultSupported"
+RX_DISABLE_FIELD = "RxDisable"
+RX_DISABLE_SUPPORT_FIELD = "RxDisableSupported"
+
 TEMPERATURE_FIELD = "Temperature"
 TEMP_SUPPORT_FIELD = "Temperature Monitoring Implemented"
 TEMP_THRESHOLDS_FIELD = "TempThresholds"

--- a/sonic_platform_base/sonic_xcvr/fields/consts.py
+++ b/sonic_platform_base/sonic_xcvr/fields/consts.py
@@ -32,7 +32,6 @@ RX_POWER_LOW_ALARM_FIELD = "RxPowerLowAlarm"
 RX_POWER_HIGH_WARNING_FIELD = "RxPowerHighWarning"
 RX_POWER_LOW_WARNING_FIELD = "RxPowerLowWarning"
 
-RX_FAULT_FIELD = "RxFault"
 RX_FAULT_SUPPORT_FIELD = "RxFaultSupported"
 RX_DISABLE_FIELD = "RxDisable"
 RX_DISABLE_SUPPORT_FIELD = "RxDisableSupported"

--- a/sonic_platform_base/sonic_xcvr/mem_maps/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/mem_maps/public/cmis.py
@@ -226,7 +226,6 @@ class CmisMemMap(XcvrMemMap):
                 RegBitField(consts.TX_ADAPTIVE_INPUT_EQ_FAIL_FLAG_SUPPORTED, 3),
             ),
             NumberRegField(consts.RX_FLAGS_ADVT_FIELD, self.getaddr(0x1, 158),
-                RegBitField(consts.RX_FAULT_SUPPORT_FIELD, 0),
                 RegBitField(consts.RX_LOS_SUPPORT, 1),
                 RegBitField(consts.RX_CDR_LOL_SUPPORT_FIELD, 2),
             ),

--- a/sonic_platform_base/sonic_xcvr/mem_maps/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/mem_maps/public/cmis.py
@@ -213,9 +213,13 @@ class CmisMemMap(XcvrMemMap):
             ),
             NumberRegField(consts.CTRLS_ADVT_FIELD, self.getaddr(0x1, 155),
                 RegBitField(consts.TX_DISABLE_SUPPORT_FIELD, 1),
-                RegBitField(consts.RX_DISABLE_SUPPORT_FIELD, 2),
                 size=2, format="<H"
             ),
+            NumberRegField(consts.CTRLS_ADVT_FIELD, self.getaddr(0x1, 156),
+                RegBitField(consts.RX_DISABLE_SUPPORT_FIELD, 1),
+                size=2, format="<H"
+            ),
+            NumberRegField(consts.TX_FLAGS_ADVT_FIELD, self.getaddr(0x1, 157),
             NumberRegField(consts.TX_FLAGS_ADVT_FIELD, self.getaddr(0x1, 157),
                 RegBitField(consts.TX_FAULT_SUPPORT_FIELD, 0),
                 RegBitField(consts.TX_LOS_SUPPORT_FIELD, 1),

--- a/sonic_platform_base/sonic_xcvr/mem_maps/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/mem_maps/public/cmis.py
@@ -277,7 +277,7 @@ class CmisMemMap(XcvrMemMap):
         self.LANE_DATAPATH_CTRL = RegGroupField(consts.LANE_DATAPATH_CTRL_FIELD,
             NumberRegField(consts.DATAPATH_DEINIT_FIELD, self.getaddr(0x10, 128), ro=False),
             NumberRegField(consts.TX_DISABLE_FIELD, self.getaddr(0x10, 130), ro=False),
-            NumberRegField(consts.RX_DISABLE_FIELD, self.get_addr(0x10, 138), ro=False,
+            NumberRegField(consts.RX_DISABLE_FIELD, self.getaddr(0x10, 138), ro=False,
                 *(RegBitField("%s_%d" % (consts.RX_DISABLE_FIELD, channel), bitpos) 
                   for channel, bitpos in zip(range(1, 9), range(0, 8)))  # 8 channels
             )

--- a/sonic_platform_base/sonic_xcvr/mem_maps/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/mem_maps/public/cmis.py
@@ -220,7 +220,6 @@ class CmisMemMap(XcvrMemMap):
                 size=2, format="<H"
             ),
             NumberRegField(consts.TX_FLAGS_ADVT_FIELD, self.getaddr(0x1, 157),
-            NumberRegField(consts.TX_FLAGS_ADVT_FIELD, self.getaddr(0x1, 157),
                 RegBitField(consts.TX_FAULT_SUPPORT_FIELD, 0),
                 RegBitField(consts.TX_LOS_SUPPORT_FIELD, 1),
                 RegBitField(consts.TX_CDR_LOL_SUPPORT_FIELD, 2),

--- a/sonic_platform_base/sonic_xcvr/mem_maps/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/mem_maps/public/cmis.py
@@ -211,12 +211,9 @@ class CmisMemMap(XcvrMemMap):
             NumberRegField(consts.RX_OUTPUT_EQ_POST_CURSOR_MAX, self.getaddr(0x1, 154),
                 *(RegBitField("Bit%d" % (bit), bit) for bit in range (4 , 8))
             ),
-            NumberRegField(consts.CTRLS_ADVT_FIELD, self.getaddr(0x1, 138),
-                RegBitField(consts.RX_DISABLE_SUPPORT_FIELD, 1),
-                size=2, format="<H"
-            ),
-	    NumberRegField(consts.CTRLS_ADVT_FIELD, self.getaddr(0x1, 156),
+            NumberRegField(consts.CTRLS_ADVT_FIELD, self.getaddr(0x1, 155),
                 RegBitField(consts.TX_DISABLE_SUPPORT_FIELD, 1),
+                RegBitField(consts.RX_DISABLE_SUPPORT_FIELD, 2),
                 size=2, format="<H"
             ),
             NumberRegField(consts.TX_FLAGS_ADVT_FIELD, self.getaddr(0x1, 157),
@@ -277,7 +274,7 @@ class CmisMemMap(XcvrMemMap):
 
         self.LANE_DATAPATH_CTRL = RegGroupField(consts.LANE_DATAPATH_CTRL_FIELD,
             NumberRegField(consts.DATAPATH_DEINIT_FIELD, self.getaddr(0x10, 128), ro=False),
-            NumberRegField(consts.TX_DISABLE_FIELD, self.getaddr(0x10, 130), ro=False)
+            NumberRegField(consts.TX_DISABLE_FIELD, self.getaddr(0x10, 130), ro=False),
             NumberRegField(consts.RX_DISABLE_FIELD, self.getaddr(0x10, 138), ro=False)
         )
 

--- a/sonic_platform_base/sonic_xcvr/mem_maps/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/mem_maps/public/cmis.py
@@ -226,6 +226,7 @@ class CmisMemMap(XcvrMemMap):
                 RegBitField(consts.TX_ADAPTIVE_INPUT_EQ_FAIL_FLAG_SUPPORTED, 3),
             ),
             NumberRegField(consts.RX_FLAGS_ADVT_FIELD, self.getaddr(0x1, 158),
+                RegBitField(consts.RX_FAULT_SUPPORT_FIELD, 0),
                 RegBitField(consts.RX_LOS_SUPPORT, 1),
                 RegBitField(consts.RX_CDR_LOL_SUPPORT_FIELD, 2),
             ),
@@ -277,6 +278,7 @@ class CmisMemMap(XcvrMemMap):
         self.LANE_DATAPATH_CTRL = RegGroupField(consts.LANE_DATAPATH_CTRL_FIELD,
             NumberRegField(consts.DATAPATH_DEINIT_FIELD, self.getaddr(0x10, 128), ro=False),
             NumberRegField(consts.TX_DISABLE_FIELD, self.getaddr(0x10, 130), ro=False)
+            NumberRegField(consts.RX_DISABLE_FIELD, self.getaddr(0x10, 138), ro=False)
         )
 
         self.LANE_DATAPATH_STATUS = RegGroupField(consts.LANE_DATAPATH_STATUS_FIELD,

--- a/sonic_platform_base/sonic_xcvr/mem_maps/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/mem_maps/public/cmis.py
@@ -211,7 +211,11 @@ class CmisMemMap(XcvrMemMap):
             NumberRegField(consts.RX_OUTPUT_EQ_POST_CURSOR_MAX, self.getaddr(0x1, 154),
                 *(RegBitField("Bit%d" % (bit), bit) for bit in range (4 , 8))
             ),
-            NumberRegField(consts.CTRLS_ADVT_FIELD, self.getaddr(0x1, 155),
+            NumberRegField(consts.CTRLS_ADVT_FIELD, self.getaddr(0x1, 138),
+                RegBitField(consts.RX_DISABLE_SUPPORT_FIELD, 1),
+                size=2, format="<H"
+            ),
+	    NumberRegField(consts.CTRLS_ADVT_FIELD, self.getaddr(0x1, 156),
                 RegBitField(consts.TX_DISABLE_SUPPORT_FIELD, 1),
                 size=2, format="<H"
             ),

--- a/sonic_platform_base/sonic_xcvr/mem_maps/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/mem_maps/public/cmis.py
@@ -278,7 +278,7 @@ class CmisMemMap(XcvrMemMap):
             NumberRegField(consts.DATAPATH_DEINIT_FIELD, self.getaddr(0x10, 128), ro=False),
             NumberRegField(consts.TX_DISABLE_FIELD, self.getaddr(0x10, 130), ro=False),
             NumberRegField(consts.RX_DISABLE_FIELD, self.getaddr(0x10, 138), ro=False,
-                *(RegBitField("%s_%d" % (consts.RX_DISABLE_FIELD, channel), bitpos) 
+                *(RegBitField("%s_%d" % (consts.RX_DISABLE_FIELD, channel), bitpos, ro=False) 
                   for channel, bitpos in zip(range(1, 9), range(0, 8)))  # 8 channels
             )
         )

--- a/sonic_platform_base/sonic_xcvr/mem_maps/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/mem_maps/public/cmis.py
@@ -277,7 +277,10 @@ class CmisMemMap(XcvrMemMap):
         self.LANE_DATAPATH_CTRL = RegGroupField(consts.LANE_DATAPATH_CTRL_FIELD,
             NumberRegField(consts.DATAPATH_DEINIT_FIELD, self.getaddr(0x10, 128), ro=False),
             NumberRegField(consts.TX_DISABLE_FIELD, self.getaddr(0x10, 130), ro=False),
-            NumberRegField(consts.RX_DISABLE_FIELD, self.getaddr(0x10, 138), ro=False)
+            NumberRegField(consts.RX_DISABLE_FIELD, self.get_addr(0x10, 138), ro=False,
+                *(RegBitField("%s_%d" % (consts.RX_DISABLE_FIELD, channel), bitpos) 
+                  for channel, bitpos in zip(range(1, 9), range(0, 8)))  # 8 channels
+            )
         )
 
         self.LANE_DATAPATH_STATUS = RegGroupField(consts.LANE_DATAPATH_STATUS_FIELD,

--- a/sonic_platform_base/sonic_xcvr/sfp_optoe_base.py
+++ b/sonic_platform_base/sonic_xcvr/sfp_optoe_base.py
@@ -152,6 +152,14 @@ class SfpOptoeBase(SfpBase):
             return tx_fault
         return None
 
+    def get_rx_disable(self):
+        api = self.get_xcvr_api()
+        return api.get_rx_disable() if api is not None else None
+
+    def get_rx_disable_channel(self):
+        api = self.get_xcvr_api()
+        return api.get_rx_disable_channel() if api is not None else None
+
     def get_tx_disable(self):
         api = self.get_xcvr_api()
         return api.get_tx_disable() if api is not None else None
@@ -159,14 +167,6 @@ class SfpOptoeBase(SfpBase):
     def get_tx_disable_channel(self):
         api = self.get_xcvr_api()
         return api.get_tx_disable_channel() if api is not None else None
-
-    def get_rx_disable(self):
-	api = self.get_xcvr_api()
-	return api.get_rx_disable() if api is not None else None
-
-    def get_rx_disable_channel(self):
-	api = self.get_xcvr_api()
-	return api.get_rx_disable_channel() if api is not None else None
 
     def get_temperature(self):
         api = self.get_xcvr_api()
@@ -223,6 +223,15 @@ class SfpOptoeBase(SfpBase):
     def tx_disable_channel(self, channel, disable):
         api = self.get_xcvr_api()
         return api.tx_disable_channel(channel, disable) if api is not None else None
+
+    def rx_disable(self, rx_disable):
+        api = self.get_xcvr_api()
+        return api.rx_disable(rx_disable) if api is not None else None
+
+    def rx_disable_channel(self, channel, disable):
+        api = self.get_xcvr_api()
+        return api.rx_disable_channel(channel, disable) if api is not None else None
+
 
     def get_power_override(self):
         api = self.get_xcvr_api()

--- a/sonic_platform_base/sonic_xcvr/sfp_optoe_base.py
+++ b/sonic_platform_base/sonic_xcvr/sfp_optoe_base.py
@@ -160,6 +160,14 @@ class SfpOptoeBase(SfpBase):
         api = self.get_xcvr_api()
         return api.get_tx_disable_channel() if api is not None else None
 
+    def get_rx_disable(self):
+	api = self.get_xcvr_api()
+	return api.get_rx_disable() if api is not None else None
+
+    def get_rx_disable_channel(self):
+	api = self.get_xcvr_api()
+	return api.get_rx_disable_channel() if api is not None else None
+
     def get_temperature(self):
         api = self.get_xcvr_api()
         if api is not None:

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -638,6 +638,7 @@ class TestCmis(object):
         (0, (0, True)),
         (0, (0, False)),
         (0, (1, False)),
+        (0, (1, True)),
         (None, (0, False))
     ])
     def test_rx_disable_channel(self, mock_response, input_param):

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -575,72 +575,74 @@ class TestCmis(object):
         self.api.tx_disable_channel(*input_param)
 
     @pytest.mark.parametrize("mock_response, expected", [
-	([True, {'RxLOS1': 0}], [False]),
-	([False, {'RxLOS1': 0}], ['N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A']),
-	([None, None], None),
-	([True, None], None)
+        ([True, {'RxLOS1': 0}], [False]),
+        ([False, {'RxLOS1': 0}], ['N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A']),
+        ([None, None], None),
+        ([True, None], None)
     ])
     def test_get_rx_los(self, mock_response, expected):
-	self.api.get_rx_los_support = MagicMock()
-	self.api.get_rx_los_support.return_value = mock_response[0]
-	self.api.xcvr_eeprom.read = MagicMock()
-	self.api.xcvr_eeprom.read.return_value = mock_response[1]
-	result = self.api.get_rx_los()
-	assert result == expected
+        self.api.get_rx_los_support = MagicMock()
+        self.api.get_rx_los_support.return_value = mock_response[0]
+        self.api.xcvr_eeprom.read = MagicMock()
+        self.api.xcvr_eeprom.read.return_value = mock_response[1]
+        result = self.api.get_rx_los()
+        assert result == expected
 
     @pytest.mark.parametrize("mock_response, expected", [
-	([False, True], True)
+        ([False, True], True)
     ])
     def test_get_rx_disable_support(self, mock_response, expected):
-	self.api.is_flat_memory = MagicMock()
-	self.api.is_flat_memory.return_value = mock_response[0]
-	self.api.xcvr_eeprom.read = MagicMock()
-	self.api.xcvr_eeprom.read.return_value = mock_response[1]
-	result = self.api.get_rx_disable_support()
-	assert result == expected
+        self.api.is_flat_memory = MagicMock()
+        self.api.is_flat_memory.return_value = mock_response[0]
+        self.api.xcvr_eeprom.read = MagicMock()
+        self.api.xcvr_eeprom.read.return_value = mock_response[1]
+        result = self.api.get_rx_disable_support()
+        assert result == expected
 
     @pytest.mark.parametrize("mock_response, expected", [
-	([True, 0x00], [False, False, False, False, False, False, False, False]),
-	([False, 0x00], ['N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A']),
-	([None, None], None),
-	([True, None], None)
+        ([True, 0x00], [False, False, False, False, False, False, False, False]),
+        ([False, 0x00], ['N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A']),
+        ([None, None], None),
+        ([True, None], None)
     ])
     def test_get_rx_disable(self, mock_response, expected):
-	self.api.get_rx_disable_support = MagicMock()
-	self.api.get_rx_disable_support.return_value = mock_response[0]
-	self.api.xcvr_eeprom.read = MagicMock()
-	self.api.xcvr_eeprom.read.return_value = mock_response[1]
-	result = self.api.get_rx_disable()
-	assert result == expected
+        self.api.get_rx_disable_support = MagicMock()
+        self.api.get_rx_disable_support.return_value = mock_response[0]
+        self.api.xcvr_eeprom.read = MagicMock()
+        self.api.xcvr_eeprom.read.return_value = mock_response[1]
+        result = self.api.get_rx_disable()
+        assert result == expected
 
     @pytest.mark.parametrize("input_param", [
-	(True), (False)
+        (True), (False)
     ])
     def test_rx_disable(self, input_param):
-	self.api.rx_disable(input_param)
+        rc = self.api.rx_disable(input_param)
+        assert(rc == None)
 
     @pytest.mark.parametrize("mock_response, expected", [
-	([True, 0x00], 0),
-	([False, 0x00], 'N/A'),
-	([None, None], None)
+        ([True, 0x00], 0),
+        ([False, 0x00], 'N/A'),
+        ([None, None], None)
     ])
     def test_get_rx_disable_channel(self, mock_response, expected):
-	self.api.get_rx_disable_support = MagicMock()
-	self.api.get_rx_disable_support.return_value = mock_response[0]
-	self.api.xcvr_eeprom.read = MagicMock()
-	self.api.xcvr_eeprom.read.return_value = mock_response[1]
-	result = self.api.get_rx_disable_channel()
-	assert result == expected
+        self.api.get_rx_disable_support = MagicMock()
+        self.api.get_rx_disable_support.return_value = mock_response[0]
+        self.api.xcvr_eeprom.read = MagicMock()
+        self.api.xcvr_eeprom.read.return_value = mock_response[1]
+        result = self.api.get_rx_disable_channel()
+        assert result == expected
 
     @pytest.mark.parametrize("mock_response, input_param", [
-	(0, (0xff, True)),
-	(0, (0, True)),
-	(None, (0, False))
+        (0, (0xff, True)),
+        (0, (0, True)),
+        (None, (0, False))
     ])
     def test_rx_disable_channel(self, mock_response, input_param):
-	self.api.get_rx_disable_channel = MagicMock()
-	self.api.get_rx_disable_channel.return_value = mock_response
-	self.api.rx_disable_channel(*input_param)
+        self.api.get_rx_disable_channel = MagicMock()
+        self.api.get_rx_disable_channel.return_value = mock_response
+        rc = self.api.rx_disable_channel(*input_param)
+        assert(rc == None)
 
     @pytest.mark.parametrize("mock_response, expected", [
         (1, ['TuningComplete']),

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -618,7 +618,7 @@ class TestCmis(object):
     ])
     def test_rx_disable(self, input_param):
         rc = self.api.rx_disable(input_param)
-        assert(rc == None)
+        assert(rc != None)
 
     @pytest.mark.parametrize("mock_response, expected", [
         ([True, 0x00], 0),
@@ -642,7 +642,7 @@ class TestCmis(object):
         self.api.get_rx_disable_channel = MagicMock()
         self.api.get_rx_disable_channel.return_value = mock_response
         rc = self.api.rx_disable_channel(*input_param)
-        assert(rc == None)
+        assert(rc != None)
 
     @pytest.mark.parametrize("mock_response, expected", [
         (1, ['TuningComplete']),

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -637,6 +637,7 @@ class TestCmis(object):
         (0, (0xff, True)),
         (0, (0, True)),
         (0, (0, False)),
+        (0, (1, False)),
         (None, (0, False))
     ])
     def test_rx_disable_channel(self, mock_response, input_param):

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -575,6 +575,74 @@ class TestCmis(object):
         self.api.tx_disable_channel(*input_param)
 
     @pytest.mark.parametrize("mock_response, expected", [
+	([True, {'RxLOS1': 0}], [False]),
+	([False, {'RxLOS1': 0}], ['N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A']),
+	([None, None], None),
+	([True, None], None)
+    ])
+    def test_get_rx_los(self, mock_response, expected):
+	self.api.get_rx_los_support = MagicMock()
+	self.api.get_rx_los_support.return_value = mock_response[0]
+	self.api.xcvr_eeprom.read = MagicMock()
+	self.api.xcvr_eeprom.read.return_value = mock_response[1]
+	result = self.api.get_rx_los()
+	assert result == expected
+
+    @pytest.mark.parametrize("mock_response, expected", [
+	([False, True], True)
+    ])
+    def test_get_rx_disable_support(self, mock_response, expected):
+	self.api.is_flat_memory = MagicMock()
+	self.api.is_flat_memory.return_value = mock_response[0]
+	self.api.xcvr_eeprom.read = MagicMock()
+	self.api.xcvr_eeprom.read.return_value = mock_response[1]
+	result = self.api.get_rx_disable_support()
+	assert result == expected
+
+    @pytest.mark.parametrize("mock_response, expected", [
+	([True, 0x00], [False, False, False, False, False, False, False, False]),
+	([False, 0x00], ['N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A']),
+	([None, None], None),
+	([True, None], None)
+    ])
+    def test_get_rx_disable(self, mock_response, expected):
+	self.api.get_rx_disable_support = MagicMock()
+	self.api.get_rx_disable_support.return_value = mock_response[0]
+	self.api.xcvr_eeprom.read = MagicMock()
+	self.api.xcvr_eeprom.read.return_value = mock_response[1]
+	result = self.api.get_rx_disable()
+	assert result == expected
+
+    @pytest.mark.parametrize("input_param", [
+	(True), (False)
+    ])
+    def test_rx_disable(self, input_param):
+	self.api.rx_disable(input_param)
+
+    @pytest.mark.parametrize("mock_response, expected", [
+	([True, 0x00], 0),
+	([False, 0x00], 'N/A'),
+	([None, None], None)
+    ])
+    def test_get_rx_disable_channel(self, mock_response, expected):
+	self.api.get_rx_disable_support = MagicMock()
+	self.api.get_rx_disable_support.return_value = mock_response[0]
+	self.api.xcvr_eeprom.read = MagicMock()
+	self.api.xcvr_eeprom.read.return_value = mock_response[1]
+	result = self.api.get_rx_disable_channel()
+	assert result == expected
+
+    @pytest.mark.parametrize("mock_response, input_param", [
+	(0, (0xff, True)),
+	(0, (0, True)),
+	(None, (0, False))
+    ])
+    def test_rx_disable_channel(self, mock_response, input_param):
+	self.api.get_rx_disable_channel = MagicMock()
+	self.api.get_rx_disable_channel.return_value = mock_response
+	self.api.rx_disable_channel(*input_param)
+
+    @pytest.mark.parametrize("mock_response, expected", [
         (1, ['TuningComplete']),
         (62, ['TargetOutputPowerOOR', 'FineTuningOutOfRange', 'TuningNotAccepted',
               'InvalidChannel', 'WavelengthUnlocked']),

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -636,6 +636,7 @@ class TestCmis(object):
     @pytest.mark.parametrize("mock_response, input_param", [
         (0, (0xff, True)),
         (0, (0, True)),
+        (0, (0, False)),
         (None, (0, False))
     ])
     def test_rx_disable_channel(self, mock_response, input_param):

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -643,6 +643,8 @@ class TestCmis(object):
     def test_rx_disable_channel(self, mock_response, input_param):
         self.api.get_rx_disable_channel = MagicMock()
         self.api.get_rx_disable_channel.return_value = mock_response
+        self.api.xcvr_eeprom.write = MagicMock()
+        self.api.xcvr_eeprom.write.return_value = mock_response
         rc = self.api.rx_disable_channel(*input_param)
         assert(rc != None)
 

--- a/tests/sonic_xcvr/test_sfp_optoe_base.py
+++ b/tests/sonic_xcvr/test_sfp_optoe_base.py
@@ -56,6 +56,22 @@ class TestSfpOptoeBase(object):
         (None, None, False),
         (False, cmis_api, False),
     ])
+    def test_get_rx_disable_channel(self, mock_response1, mock_response2, expected):
+        self.sfp_optoe_api.get_xcvr_api = MagicMock()
+        self.sfp_optoe_api.get_xcvr_api.return_value = mock_response2
+        self.cmis_api.get_rx_disable_channel = MagicMock()
+        self.cmis_api.get_rx_disable_channelreturn_value = mock_response1
+
+        result = self.sfp_optoe_api.get_rx_disable_channel()
+        assert result == expected
+
+
+    @pytest.mark.parametrize("mock_response1, mock_response2, expected", [
+        (0, cmis_api, 0),
+        (1, cmis_api, 1),
+        (None, None, False),
+        (False, cmis_api, False),
+    ])
     def test_get_vdm_freeze_status(self, mock_response1, mock_response2, expected):
         self.sfp_optoe_api.get_xcvr_api = MagicMock()
         self.sfp_optoe_api.get_xcvr_api.return_value = mock_response2

--- a/tests/sonic_xcvr/test_sfp_optoe_base.py
+++ b/tests/sonic_xcvr/test_sfp_optoe_base.py
@@ -60,7 +60,7 @@ class TestSfpOptoeBase(object):
         self.sfp_optoe_api.get_xcvr_api = MagicMock()
         self.sfp_optoe_api.get_xcvr_api.return_value = mock_response2
         self.cmis_api.get_rx_disable_channel = MagicMock()
-        self.cmis_api.get_rx_disable_channelreturn_value = mock_response1
+        self.cmis_api.get_rx_disable_channel.return_value = mock_response1
 
         result = self.sfp_optoe_api.get_rx_disable_channel()
         assert result == expected

--- a/tests/sonic_xcvr/test_sfp_optoe_base.py
+++ b/tests/sonic_xcvr/test_sfp_optoe_base.py
@@ -53,7 +53,7 @@ class TestSfpOptoeBase(object):
     @pytest.mark.parametrize("mock_response1, mock_response2, expected", [
         (0, cmis_api, 0),
         (1, cmis_api, 1),
-        (None, None, False),
+        (None, None, None),
         (False, cmis_api, False),
     ])
     def test_get_rx_disable_channel(self, mock_response1, mock_response2, expected):


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
This PR introduces **RX disable support** for CMIS-compliant transceivers, aligning it with TX disable functionality.
<!--
     Describe your changes in detail
     This PR introduces **RX disable support** for CMIS-compliant transceivers, aligning it with TX disable functionality.
-->

#### Motivation and Context
- Added the following methods in `CmisApi` and `XcvrApi`:
  - `get_rx_disable()`
  - `get_rx_disable_channel()`
  - `rx_disable()`
  - `rx_disable_channel()`
- Updated `SfpOptoeBase` to expose RX disable functionality.
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

- Defined `RX_DISABLE_SUPPORT_FIELD` in `consts.py`.
- Added `RX_DISABLE_FIELD` at **Byte 138** in `CmisMemMap`.
- Updated `CTRLS_ADVT_FIELD` to include `RX_DISABLE_SUPPORT_FIELD`.


- Integrated RX disable methods into `sfp_optoe_base.py`, mirroring TX disable operations.

#### How Has This Been Tested?
UT and deploy on testbed, please see attached testbed results
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
```
sfp1 = platform_chassis.get_sfp(1)>>> platform_chassis = sonic_platform.platform.Platform().get_chassis()
>>> sfp1 = platform_chassis.get_sfp(1)
>>> sfp1.get_rx_disable()
[True, False, False, False, False, False, False, False]
>>> sfp1.rx_disable_channel(1, 1)
True
>>> sfp1.get_rx_disable()
[True, False, False, False, False, False, False, False]
>>> sfp1.rx_disable_channel(1, 0)
True
>>> sfp1.get_rx_disable()
[False, False, False, False, False, False, False, False]
>>> sfp1.rx_disable_channel(2, 0)
True
>>> sfp1.rx_disable_channel(2, 1)
True
>>> sfp1.get_rx_disable()
[False, True, False, False, False, False, False, False]
>>> sfp1.rx_disable_channel(2, 0)
True
>>> sfp1.get_rx_disable()
[False, False, False, False, False, False, False, False]
>>> 
```
#### Additional Information (Optional)

