### PR TITLE
Add Changes to align the RX disable channel logic with the existing TX disable channel implementation 

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -903,24 +903,20 @@ class CmisApi(XcvrApi):
         return self.xcvr_eeprom.read(consts.RX_DISABLE_FIELD)
 
     def rx_disable_channel(self, channel, disable):
-        # Check if channel state is available
         channel_state = self.get_rx_disable_channel()
         if channel_state is None or channel_state == 'N/A':
             return False
 
-        # Disable or enable the specific channel based on the input
-        if 1 <= channel <= self.NUM_CHANNELS:
-            # The channel is represented by individual RegBitField entries
-            field_name = f"{consts.RX_DISABLE_FIELD}_{channel}"
-
+        for i in range(self.NUM_CHANNELS):
+            mask = (1 << i)
+            if not (channel & mask):
+                continue
             if disable:
-                # Disable the channel (set the bit to 1)
-                return self.xcvr_eeprom.write(field_name, 1)
+                channel_state |= mask
             else:
-                # Enable the channel (set the bit to 0)
-                return self.xcvr_eeprom.write(field_name, 0)
+                channel_state &= ~mask
 
-        return False
+        return self.xcvr_eeprom.write(consts.RX_DISABLE_FIELD, channel_state)
 
     def get_laser_tuning_summary(self):
         '''


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
Refactored the `rx_disable_channel` method to use a bitmask-based approach instead of handling individual `RegBitField` entries. This change ensures that multiple channels can be updated in a single operation rather than writing to individual fields separately.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
The previous implementation used per-channel field writes, which were inefficient and inconsistent with the `tx_disable_channel` implementation. The new approach improves performance and maintains uniform handling of RX and TX disable states.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
- Verified correct bitmask application by testing with various `channel` values.  
- Confirmed EEPROM write operations correctly update the `RX_DISABLE_FIELD`.  


#### Additional Information (Optional)
This update aligns the RX disable logic with the existing TX disable implementation for better maintainability and consistency.
