### PR TITLE
[Smartswitch] Add module specific pcie attach/detach functions for smartswitch platforms

### DIFF
--- a/sonic_platform_base/module_base.py
+++ b/sonic_platform_base/module_base.py
@@ -26,7 +26,7 @@ class ModuleBase(device_base.DeviceBase):
     """
     # Device type definition. Note, this is a constant.
     DEVICE_TYPE = "module"
-    PCI_OPERATION_LOCK_FILE_PATH = "/tmp/{}_pci.lock"
+    PCI_OPERATION_LOCK_FILE_PATH = "/var/lock/{}_pci.lock"
 
     # Possible card types for modular chassis
     MODULE_TYPE_SUPERVISOR = "SUPERVISOR"

--- a/tests/module_base_test.py
+++ b/tests/module_base_test.py
@@ -1,4 +1,8 @@
 from sonic_platform_base.module_base import ModuleBase
+import pytest
+import json
+import os
+from unittest.mock import patch, mock_open, MagicMock
 
 class TestModuleBase:
 
@@ -38,4 +42,131 @@ class TestModuleBase:
         module._current_sensor_list = ["s1"]
         assert(module.get_all_current_sensors() == ["s1"])
         assert(module.get_current_sensor(0) == "s1")
+
+    def test_get_pci_bus_from_platform_json(self):
+        module = ModuleBase()
+        module.pci_bus_info = "0000:00:00.0"
+        assert module.get_pci_bus_from_platform_json() == "0000:00:00.0"
+        mock_json_data = {
+            "DPUS": {
+                "DPU0": {"bus_info": "0000:01:00.0"}
+            }
+        }
+        module.pci_bus_info = None
+        platform_json_path = "/usr/share/sonic/platform/platform.json"
+        with patch('builtins.open', mock_open(read_data=json.dumps(mock_json_data))) as mock_open_call, \
+             patch.object(module, 'get_name', return_value="DPU0"):
+            assert module.get_pci_bus_from_platform_json() == "0000:01:00.0"
+            mock_open_call.assert_called_once_with(platform_json_path, 'r')
+            assert module.pci_bus_info == "0000:01:00.0"
+
+        module.pci_bus_info = None
+        with patch('builtins.open', mock_open(read_data=json.dumps(mock_json_data))) as mock_open_call, \
+             patch.object(module, 'get_name', return_value="ABC"):
+            assert module.get_pci_bus_from_platform_json() is None
+            mock_open_call.assert_called_once_with(platform_json_path, 'r')
+
+        with patch('builtins.open', side_effect=Exception()) as mock_open_call:
+            assert module.get_pci_bus_from_platform_json() is None
+
+    def test_pci_entry_state_db(self):
+        module = ModuleBase()
+        mock_connector = MagicMock()
+        module.state_db_connector = mock_connector
+
+        module.pci_entry_state_db("0000:00:00.0", "detaching")
+        mock_connector.hset.assert_called_with("PCIE_DETACH_INFO", "0000:00:00.0", "detaching")
+
+        module.pci_entry_state_db("0000:00:00.0", "attaching")
+        mock_connector.hdel.assert_called_with("PCIE_DETACH_INFO", "0000:00:00.0")
+
+        mock_connector.hset.side_effect = Exception("DB Error")
+        module.pci_entry_state_db("0000:00:00.0", "detaching")
+
+    @patch('builtins.open')
+    def test_pci_removal_from_platform_json(self, mock_open):
+        module = ModuleBase()
+        mock_file = MagicMock()
+        mock_open.return_value.__enter__.return_value = mock_file
+
+        with patch.object(module, 'get_pci_bus_from_platform_json', return_value="0000:00:00.0"), \
+             patch.object(module, 'pci_entry_state_db') as mock_db:
+            assert module.pci_removal_from_platform_json() is True
+            mock_db.assert_called_with("0000:00:00.0", "detaching")
+            mock_file.write.assert_called_with("1")
+            mock_open.assert_called_once_with("/sys/bus/pci/devices/0000:00:00.0/remove", 'w')
+
+        mock_open.reset_mock()
+        with patch.object(module, 'get_pci_bus_from_platform_json', return_value=None):
+            assert module.pci_removal_from_platform_json() is False
+            mock_open.assert_not_called()
+
+    @patch('builtins.open')
+    def test_pci_reattach_from_platform_json(self, mock_open):
+        module = ModuleBase()
+        mock_file = MagicMock()
+        mock_open.return_value.__enter__.return_value = mock_file
+
+        with patch.object(module, 'get_pci_bus_from_platform_json', return_value="0000:00:00.0"), \
+             patch.object(module, 'pci_entry_state_db') as mock_db:
+            assert module.pci_reattach_from_platform_json() is True
+            mock_db.assert_called_with("0000:00:00.0", "attaching")
+            mock_file.write.assert_called_with("1")
+            mock_open.assert_called_once_with("/sys/bus/pci/rescan", 'w')
+
+
+        mock_open.reset_mock()
+        with patch.object(module, 'get_pci_bus_from_platform_json', return_value=None):
+            assert module.pci_reattach_from_platform_json() is False
+            mock_open.assert_not_called()
+
+    def test_handle_pci_removal(self):
+        module = ModuleBase()
+
+        with patch.object(module, 'get_pci_bus_info', return_value=["0000:00:00.0"]), \
+             patch.object(module, 'pci_entry_state_db') as mock_db, \
+             patch.object(module, 'pci_detach', return_value=True):
+            assert module.handle_pci_removal() is True
+            mock_db.assert_called_with("0000:00:00.0", "detaching")
+
+        with patch.object(module, 'get_pci_bus_info', side_effect=NotImplementedError()), \
+             patch.object(module, 'pci_removal_from_platform_json', return_value=True):
+            assert module.handle_pci_removal() is True
+
+        with patch.object(module, 'get_pci_bus_info', side_effect=Exception()):
+            assert module.handle_pci_removal() is False
+
+    def test_handle_pci_rescan(self):
+        module = ModuleBase()
+
+        with patch.object(module, 'get_pci_bus_info', return_value=["0000:00:00.0"]), \
+             patch.object(module, 'pci_entry_state_db') as mock_db, \
+             patch.object(module, 'pci_reattach', return_value=True):
+            assert module.handle_pci_rescan() is True
+            mock_db.assert_called_with("0000:00:00.0", "attaching")
+
+        with patch.object(module, 'get_pci_bus_info', side_effect=NotImplementedError()), \
+             patch.object(module, 'pci_reattach_from_platform_json', return_value=True):
+            assert module.handle_pci_rescan() is True
+
+        with patch.object(module, 'get_pci_bus_info', side_effect=Exception()):
+            assert module.handle_pci_rescan() is False
+
+    def test_module_cleanup(self):
+        module = ModuleBase()
+
+        with patch.object(module, 'get_pci_bus_info', return_value=["0000:00:00.0"]), \
+             patch.object(module, 'pci_entry_state_db') as mock_db:
+            module.__del__()
+            mock_db.assert_called_with("0000:00:00.0", "attaching")
+
+        with patch.object(module, 'get_pci_bus_info', side_effect=NotImplementedError()), \
+             patch.object(module, 'get_pci_bus_from_platform_json', return_value="0000:01:00.0"), \
+             patch.object(module, 'pci_entry_state_db') as mock_db:
+            module.__del__()
+            mock_db.assert_called_with("0000:01:00.0", "attaching")
+
+        with patch.object(module, 'get_pci_bus_info', side_effect=Exception()), \
+             patch.object(module, 'get_pci_bus_from_platform_json', return_value=None):
+            module.__del__()
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
As there could be platforms which have multiple PCIE devices per dpu, the module_base implementation is handling the PCIE removal and attachment along with adding the entry details in the PCIE table, so that the pcie daemon which is running will ignore the errors generated from the DPUs,

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
This was done because there are multiple PCIE devices in some platforms and only one in others, we need to have a platform independent method for removal and attach algorithms along with state db entries

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)

