### PR TITLE
[cmis] add a parameter to cmis.set_lpmode to ignore the time wait

### DIFF
--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -1130,6 +1130,7 @@ class TestCmis(object):
         self.api.get_lpmode.return_value = True
         self.api.get_module_state.return_value = "ModuleReady"
         self.api.set_lpmode(lpmode)
+        self.api.set_lpmode(lpmode, wait_state_change = False)
 
     @pytest.mark.parametrize("mock_response, expected", [
         (


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
Add a parameter to `cmis.set_lpmode` to allow user ignore the time wait

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
In `CmisManagerTask`, it calls `cmis.set_lpmode` for each logical port. The time wait causes a `wait_time * num_of_logical_port` delay in link up time. The PR is to optimize it.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
- Unit test
- manual test

#### Additional Information (Optional)

