### PR TITLE
Fix KeyError for unsupported CMIS applications

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -1096,7 +1096,11 @@ class CmisApi(XcvrApi):
             return 0
 
         appl_advt = self.get_application_advertisement()
-        return appl_advt[appl]['host_lane_assignment_options'] if len(appl_advt) >= appl else 0
+        if appl not in appl_advt:
+            logger.error('Application {} not found in application advertisement'.format(appl))
+            return 0
+
+        return appl_advt[appl].get('host_lane_assignment_options', 0)
 
     def get_media_lane_assignment_option(self, appl=1):
         '''


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
The logic in get_host_lane_assignment_option() was updated to handle missing application entries more safely.

Old behavior: Returned host_lane_assignment_options if the application index was within range based on dictionary length; otherwise returned 0. This could lead to KeyError if appl was not a valid key.

New behavior:
Checks if appl exists in appl_advt.
Logs an error and returns 0 if it's missing.
Uses .get() to safely access 'host_lane_assignment_options', defaulting to 0 if the key is missing.

This improves robustness and avoids runtime errors from unexpected or unsupported application values.

#### Motivation and Context
Some CMIS applications—such as XDR/1.6TB and possibly others—are currently not supported by SONiC.
If a module with such applications is plugged in, xcvrd may crash due to a KeyError raised by the get_host_lane_assignment_option() function while parsing these applications.
This PR addresses the issue by adding proper handling to prevent the crash.

#### How Has This Been Tested?
Manual test

#### Additional Information (Optional)

