### PR TITLE
Correct bit range for ACTIVE_APSEL_CODE

### DIFF
--- a/sonic_platform_base/sonic_xcvr/mem_maps/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/mem_maps/public/cmis.py
@@ -147,7 +147,7 @@ class CmisMemMap(CmisFlatMemMap):
 
             RegGroupField(consts.ACTIVE_APSEL_CODE,
                 *(NumberRegField("%s%d" % (consts.ACTIVE_APSEL_HOSTLANE, lane) , self.getaddr(0x11, offset),
-                    *(RegBitField("Bit%d" % bit, bit) for bit in range(4, 7)))
+                    *(RegBitField("Bit%d" % bit, bit) for bit in range(4, 8)))
                  for lane, offset in zip(range(1, 9), range(206, 214)))
             ),
 


### PR DESCRIPTION
AppSelCode in cmis uses bits 4-7, range api in python is not inclusive.

#### Description
Fix range for ACTIVE_APSEL_HOSTLANE.

#### Motivation and Context
Reporting op active apsel is wrong for applications larger than 8.

#### How Has This Been Tested?
Reading active apsel for when apsel is larger than 8. 



