### PR TITLE
Adding is_copper api to cmis (#547)

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -524,6 +524,13 @@ class CmisApi(XcvrApi):
             return None
         return float("{:.3f}".format(voltage))
 
+    def is_copper(self):
+        '''
+        Returns True if the module is copper, False otherwise
+        '''
+        media_intf = self.get_module_media_type()
+        return media_intf == "passive_copper_media_interface" if media_intf else None
+
     def is_flat_memory(self):
         return self.xcvr_eeprom.read(consts.FLAT_MEM_FIELD) is not False
 

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -169,6 +169,19 @@ class TestCmis(object):
         result = self.api.get_voltage()
         assert result == expected
 
+    def test_is_copper(self):
+      with patch.object(self.api, 'xcvr_eeprom') as mock_eeprom:
+         mock_eeprom.read = MagicMock()
+         mock_eeprom.read.return_value = None
+         assert self.api.is_copper() is None
+         self.api.get_module_media_type = MagicMock()
+         self.api.get_module_media_type.return_value = "passive_copper_media_interface"
+         assert self.api.is_copper()
+         self.api.get_module_media_type.return_value = "active_cable_media_interface"
+         assert not self.api.is_copper()
+         self.api.get_module_media_type.return_value = "sm_media_interface"
+         assert not self.api.is_copper()
+
     @pytest.mark.parametrize("mock_response, expected", [
         (False, False)
     ])


### PR DESCRIPTION
Backport a change from `master` to implement `is_copper` CMIS API. 

(cherry picked from commit 45b10beaabd9bd62c06b4cccdc7a497fc7c30fa2)

<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

Backport a change (45b10beaabd9bd62c06b4cccdc7a497fc7c30fa2) from `master` to provide the `is_copper` CMIS API. 

#### Motivation and Context

Required for `<media>-<rate>` media settings key. (PR: https://github.com/sonic-net/sonic-platform-daemons/pull/617)

#### How Has This Been Tested?

Verified correct application of media settings in 202411 based on the installed transceiver using `<media>-<rate>` media settings key.

#### Additional Information (Optional)

