### PR TITLE
[cmis] Add delay during CDB firmware download to remove I2C errors

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/cmisCDB.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmisCDB.py
@@ -19,6 +19,7 @@ PAGE_LENGTH = 128
 INIT_OFFSET = 128
 CMDLEN = 2
 MAX_WAIT = 600
+MAX_CDB_CMD_FOREGROUND_PROCESSING_TIME_tCDBF = 5  # seconds, as per tCDBF in CMIS spec
 
 
 class CmisCdbApi(XcvrApi):
@@ -284,7 +285,7 @@ class CmisCdbApi(XcvrApi):
         cmd += header
         cmd[133-INIT_OFFSET] = self.cdb_chkcode(cmd)
         self.write_cdb(cmd)
-        time.sleep(2)
+        time.sleep(MAX_CDB_CMD_FOREGROUND_PROCESSING_TIME_tCDBF)
         status = self.cdb1_chkstatus()
         if (status != 0x1):
             if status > 127:
@@ -415,6 +416,7 @@ class CmisCdbApi(XcvrApi):
         cmd = bytearray(b'\x01\x07\x00\x00\x00\x00\x00\x00')
         cmd[133-INIT_OFFSET] = self.cdb_chkcode(cmd)
         self.write_cdb(cmd)
+        time.sleep(MAX_CDB_CMD_FOREGROUND_PROCESSING_TIME_tCDBF)
         status = self.cdb1_chkstatus()
         if (status != 0x1):
             if status > 127:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
During CDB firmware download, I2C errors are seeing on certain transceivers.
```
025 Jun 24 05:38:58.506741 DUT WARNING sfputil: Failed to read sfp=19 EEPROM page=/sys/module/sx_core/asic0/module19/eeprom/pages/0/i2c-0x50/data, page_offset=37, size=1, offset=37, error = [Errno 5] Input/output error
2025 Jun 24 05:38:58.508432 DUT NOTICE kernel: [966205.569354] sxd_kernel: No access to MCIA due to unavailable hw link, status: 9.
```

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
The I2C errors are seen since in some instances, the module is busy handling CDB command for a long time. However, the SONiC CMIS driver queries for command completion while the module is busy processing CDB command which eventually causes an I2C error to be seen in the logs. However, the I2C error does not impact firmware download since the CMIS driver has retry mechanism in place to handle such errors.

Hence, adding delay inline to `tCDBF` as defined in the CMIS spec to allow the transceiver to complete the processing of CDB command before SONiC queries the command completion status.

![image](https://github.com/user-attachments/assets/ac24f55d-6e0b-4e73-9e9d-80d0002ff57f)

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Performed CMIS CDB firmware download + run + commit for 100 times successfully.

#### Additional Information (Optional)
MSFT ADO - 33480518
