### PR TITLE
[202411] [cmis] Separate Flag-Specific Fields for DOM and Status APIs (#556)

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/c_cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/c_cmis.py
@@ -363,367 +363,64 @@ class CCmisApi(CmisApi):
         trans_info['supported_min_laser_freq'] = low_freq_supported
         return trans_info
 
-    def get_transceiver_bulk_status(self):
+    def get_transceiver_dom_real_value(self):
         """
-        Retrieves bulk status info for this xcvr
+        Retrieves DOM sensor values for this transceiver
+
+        The returned dictionary contains floating-point values corresponding to various
+        DOM sensor readings, as defined in the TRANSCEIVER_DOM_SENSOR table in STATE_DB.
 
         Returns:
-            A dict containing the following keys/values :
-        ========================================================================
-        key                          = TRANSCEIVER_DOM_SENSOR|ifname    ; information module DOM sensors on port
-        ; field                      = value
-        temperature                  = FLOAT                            ; temperature value in Celsius
-        voltage                      = FLOAT                            ; voltage value
-        txpower                      = FLOAT                            ; tx power in mW
-        rxpower                      = FLOAT                            ; rx power in mW
-        txbias                       = FLOAT                            ; tx bias in mA
-        laser_temperature	         = FLOAT                            ; laser temperature value in Celsius
-        prefec_ber                   = FLOAT                            ; prefec ber
-        postfec_ber                  = FLOAT                            ; postfec ber
-        cd_shortlink                 = FLOAT                            ; chromatic dispersion, high granularity, short link in ps/nm
-        cd_longlink                  = FLOAT                            ; chromatic dispersion, low granularity, long link in ps/nm
-        dgd                          = FLOAT                            ; differential group delay in ps
-        sopmd                        = FLOAT                            ; second order polarization mode dispersion in ps^2
-        pdl                          = FLOAT                            ; polarization dependent loss in db
-        osnr                         = FLOAT                            ; optical signal to noise ratio in db
-        esnr                         = FLOAT                            ; electrical signal to noise ratio in db
-        cfo                          = FLOAT                            ; carrier frequency offset in MHz
-        soproc                       = FLOAT                            ; state of polarization rate of change in krad/s
-        laser_config_freq            = FLOAT                            ; laser configured frequency in MHz
-        laser_curr_freq              = FLOAT                            ; laser current frequency in MHz
-        tx_config_power              = FLOAT                            ; configured tx output power in dbm
-        tx_curr_power                = FLOAT                            ; tx current output power in dbm
-        rx_tot_power                 = FLOAT                            ; rx total power in  dbm
-        rx_sig_power                 = FLOAT                            ; rx signal power in dbm
-        bias_xi                      = FLOAT                            ; modulator bias xi
-        bias_xq                      = FLOAT                            ; modulator bias xq
-        bias_xp                      = FLOAT                            ; modulator bias xp
-        bias_yi                      = FLOAT                            ; modulator bias yi
-        bias_yq                      = FLOAT                            ; modulator bias yq
-        bias_yp                      = FLOAT                            ; modulator bias yp
-        ========================================================================
+            Dictionary
         """
-        trans_dom = super(CCmisApi,self).get_transceiver_bulk_status()
-
-        for vdm_key, trans_dom_key in C_CMIS_DELTA_VDM_KEY_TO_DB_PREFIX_KEY_MAP.items():
-            self._update_dict_if_vdm_key_exists(trans_dom, trans_dom_key, vdm_key, 0)
+        trans_dom = super(CCmisApi,self).get_transceiver_dom_real_value()
 
         trans_dom['laser_config_freq'] = self.get_laser_config_freq()
         trans_dom['laser_curr_freq'] = self.get_current_laser_freq()
         trans_dom['tx_config_power'] = self.get_tx_config_power()
         return trans_dom
 
-    def get_transceiver_threshold_info(self):
-        """
-        Retrieves threshold info for this xcvr
-
-        Returns:
-            A dict containing the following keys/values :
-        ========================================================================
-        key                          = TRANSCEIVER_STATUS|ifname        ; DOM threshold information for module on port
-        ; field                      = value
-        temphighalarm                = FLOAT                            ; temperature high alarm threshold in Celsius
-        temphighwarning              = FLOAT                            ; temperature high warning threshold in Celsius
-        templowalarm                 = FLOAT                            ; temperature low alarm threshold in Celsius
-        templowwarning               = FLOAT                            ; temperature low warning threshold in Celsius
-        vcchighalarm                 = FLOAT                            ; vcc high alarm threshold in V
-        vcchighwarning               = FLOAT                            ; vcc high warning threshold in V
-        vcclowalarm                  = FLOAT                            ; vcc low alarm threshold in V
-        vcclowwarning                = FLOAT                            ; vcc low warning threshold in V
-        txpowerhighalarm             = FLOAT                            ; tx power high alarm threshold in mW
-        txpowerlowalarm              = FLOAT                            ; tx power low alarm threshold in mW
-        txpowerhighwarning           = FLOAT                            ; tx power high warning threshold in mW
-        txpowerlowwarning            = FLOAT                            ; tx power low alarm threshold in mW
-        rxpowerhighalarm             = FLOAT                            ; rx power high alarm threshold in mW
-        rxpowerlowalarm              = FLOAT                            ; rx power low alarm threshold in mW
-        rxpowerhighwarning           = FLOAT                            ; rx power high warning threshold in mW
-        rxpowerlowwarning            = FLOAT                            ; rx power low warning threshold in mW
-        txbiashighalarm              = FLOAT                            ; tx bias high alarm threshold in mA
-        txbiaslowalarm               = FLOAT                            ; tx bias low alarm threshold in mA
-        txbiashighwarning            = FLOAT                            ; tx bias high warning threshold in mA
-        txbiaslowwarning             = FLOAT                            ; tx bias low warning threshold in mA
-        lasertemphighalarm           = FLOAT                            ; laser temperature high alarm threshold in Celsius
-        lasertemplowalarm            = FLOAT                            ; laser temperature low alarm threshold in Celsius
-        lasertemphighwarning         = FLOAT                            ; laser temperature high warning threshold in Celsius
-        lasertemplowwarning          = FLOAT                            ; laser temperature low warning threshold in Celsius
-        prefecberhighalarm           = FLOAT                            ; prefec ber high alarm threshold
-        prefecberlowalarm            = FLOAT                            ; prefec ber low alarm threshold
-        prefecberhighwarning         = FLOAT                            ; prefec ber high warning threshold
-        prefecberlowwarning          = FLOAT                            ; prefec ber low warning threshold
-        postfecberhighalarm          = FLOAT                            ; postfec ber high alarm threshold
-        postfecberlowalarm           = FLOAT                            ; postfec ber low alarm threshold
-        postfecberhighwarning        = FLOAT                            ; postfec ber high warning threshold
-        postfecberlowwarning         = FLOAT                            ; postfec ber low warning threshold
-        biasxihighalarm              = FLOAT                            ; bias xi high alarm threshold in percent
-        biasxilowalarm               = FLOAT                            ; bias xi low alarm threshold in percent
-        biasxihighwarning            = FLOAT                            ; bias xi high warning threshold in percent
-        biasxilowwarning             = FLOAT                            ; bias xi low warning threshold in percent
-        biasxqhighalarm              = FLOAT                            ; bias xq high alarm threshold in percent
-        biasxqlowalarm               = FLOAT                            ; bias xq low alarm threshold in percent
-        biasxqhighwarning            = FLOAT                            ; bias xq high warning threshold in percent
-        biasxqlowwarning             = FLOAT                            ; bias xq low warning threshold in percent
-        biasxphighalarm              = FLOAT                            ; bias xp high alarm threshold in percent
-        biasxplowalarm               = FLOAT                            ; bias xp low alarm threshold in percent
-        biasxphighwarning            = FLOAT                            ; bias xp high warning threshold in percent
-        biasxplowwarning             = FLOAT                            ; bias xp low warning threshold in percent
-        biasyihighalarm              = FLOAT                            ; bias yi high alarm threshold in percent
-        biasyilowalarm               = FLOAT                            ; bias yi low alarm threshold in percent
-        biasyihighwarning            = FLOAT                            ; bias yi high warning threshold in percent
-        biasyilowwarning             = FLOAT                            ; bias yi low warning threshold in percent
-        biasyqhighalarm              = FLOAT                            ; bias yq high alarm threshold in percent
-        biasyqlowalarm               = FLOAT                            ; bias yq low alarm threshold in percent
-        biasyqhighwarning            = FLOAT                            ; bias yq high warning threshold in percent
-        biasyqlowwarning             = FLOAT                            ; bias yq low warning threshold in percent
-        biasyphighalarm              = FLOAT                            ; bias yp high alarm threshold in percent
-        biasyplowalarm               = FLOAT                            ; bias yp low alarm threshold in percent
-        biasyphighwarning            = FLOAT                            ; bias yp high warning threshold in percent
-        biasyplowwarning             = FLOAT                            ; bias yp low warning threshold in percent
-        cdshorthighalarm             = FLOAT                            ; cd short high alarm threshold in ps/nm
-        cdshortlowalarm              = FLOAT                            ; cd short low alarm threshold in ps/nm
-        cdshorthighwarning           = FLOAT                            ; cd short high warning threshold in ps/nm
-        cdshortlowwarning            = FLOAT                            ; cd short low warning threshold in ps/nm
-        cdlonghighalarm              = FLOAT                            ; cd long high alarm threshold in ps/nm
-        cdlonglowalarm               = FLOAT                            ; cd long low alarm threshold in ps/nm
-        cdlonghighwarning            = FLOAT                            ; cd long high warning threshold in ps/nm
-        cdlonglowwarning             = FLOAT                            ; cd long low warning threshold in ps/nm
-        dgdhighalarm                 = FLOAT                            ; dgd high alarm threshold in ps
-        dgdlowalarm                  = FLOAT                            ; dgd low alarm threshold in ps
-        dgdhighwarning               = FLOAT                            ; dgd high warning threshold in ps
-        dgdlowwarning                = FLOAT                            ; dgd low warning threshold in ps
-        sopmdhighalarm               = FLOAT                            ; sopmd high alarm threshold in ps^2
-        sopmdlowalarm                = FLOAT                            ; sopmd low alarm threshold in ps^2
-        sopmdhighwarning             = FLOAT                            ; sopmd high warning threshold in ps^2
-        sopmdlowwarning              = FLOAT                            ; sopmd low warning threshold in ps^2
-        pdlhighalarm                 = FLOAT                            ; pdl high alarm threshold in db
-        pdllowalarm                  = FLOAT                            ; pdl low alarm threshold in db
-        pdlhighwarning               = FLOAT                            ; pdl high warning threshold in db
-        pdllowwarning                = FLOAT                            ; pdl low warning threshold in db
-        osnrhighalarm                = FLOAT                            ; osnr high alarm threshold in db
-        osnrlowalarm                 = FLOAT                            ; osnr low alarm threshold in db
-        osnrhighwarning              = FLOAT                            ; osnr high warning threshold in db
-        osnrlowwarning               = FLOAT                            ; osnr low warning threshold in db
-        esnrhighalarm                = FLOAT                            ; esnr high alarm threshold in db
-        esnrlowalarm                 = FLOAT                            ; esnr low alarm threshold in db
-        esnrhighwarning              = FLOAT                            ; esnr high warning threshold in db
-        esnrlowwarning               = FLOAT                            ; esnr low warning threshold in db
-        cfohighalarm                 = FLOAT                            ; cfo high alarm threshold in MHz
-        cfolowalarm                  = FLOAT                            ; cfo low alarm threshold in MHz
-        cfohighwarning               = FLOAT                            ; cfo high warning threshold in MHz
-        cfolowwarning                = FLOAT                            ; cfo low warning threshold in MHz
-        txcurrpowerhighalarm         = FLOAT                            ; txcurrpower high alarm threshold in dbm
-        txcurrpowerlowalarm          = FLOAT                            ; txcurrpower low alarm threshold in dbm
-        txcurrpowerhighwarning       = FLOAT                            ; txcurrpower high warning threshold in dbm
-        txcurrpowerlowwarning        = FLOAT                            ; txcurrpower low warning threshold in dbm
-        rxtotpowerhighalarm          = FLOAT                            ; rxtotpower high alarm threshold in dbm
-        rxtotpowerlowalarm           = FLOAT                            ; rxtotpower low alarm threshold in dbm
-        rxtotpowerhighwarning        = FLOAT                            ; rxtotpower high warning threshold in dbm
-        rxtotpowerlowwarning         = FLOAT                            ; rxtotpower low warning threshold in dbm
-        rxsigpowerhighalarm          = FLOAT                            ; rxsigpower high alarm threshold in dbm
-        rxsigpowerlowalarm           = FLOAT                            ; rxsigpower low alarm threshold in dbm
-        rxsigpowerhighwarning        = FLOAT                            ; rxsigpower high warning threshold in dbm
-        rxsigpowerlowwarning         = FLOAT                            ; rxsigpower low warning threshold in dbm
-        ========================================================================
-        """
-        trans_dom_th = super(CCmisApi,self).get_transceiver_threshold_info()
-
-        for vdm_key, trans_dom_th_key_prefix in C_CMIS_DELTA_VDM_KEY_TO_DB_PREFIX_KEY_MAP.items():
-            for i in range(1, 5):
-                trans_dom_th_key = trans_dom_th_key_prefix + VDM_SUBTYPE_IDX_MAP[i]
-                self._update_dict_if_vdm_key_exists(trans_dom_th, trans_dom_th_key, vdm_key, i)
-
-        return trans_dom_th
-
     def get_transceiver_status(self):
         """
-        Retrieves transceiver status of this SFP
+        Retrieves the current status of the transceiver module.
+
+        Accesses non-latched registers to gather information about the module's state,
+        fault causes, and datapath-level statuses, including TX and RX statuses.
 
         Returns:
-            A dict which contains following keys/values :
-        ================================================================================
-        key                          = TRANSCEIVER_STATUS|ifname        ; Error information for module on port
-        ; field                      = value
-        module_state                 = 1*255VCHAR                       ; current module state (ModuleLowPwr, ModulePwrUp, ModuleReady, ModulePwrDn, Fault)
-        module_fault_cause           = 1*255VCHAR                       ; reason of entering the module fault state
-        datapath_firmware_fault      = BOOLEAN                          ; datapath (DSP) firmware fault
-        module_firmware_fault        = BOOLEAN                          ; module firmware fault
-        module_state_changed         = BOOLEAN                          ; module state changed
-        datapath_hostlane1           = 1*255VCHAR                       ; data path state indicator on host lane 1
-        datapath_hostlane2           = 1*255VCHAR                       ; data path state indicator on host lane 2
-        datapath_hostlane3           = 1*255VCHAR                       ; data path state indicator on host lane 3
-        datapath_hostlane4           = 1*255VCHAR                       ; data path state indicator on host lane 4
-        datapath_hostlane5           = 1*255VCHAR                       ; data path state indicator on host lane 5
-        datapath_hostlane6           = 1*255VCHAR                       ; data path state indicator on host lane 6
-        datapath_hostlane7           = 1*255VCHAR                       ; data path state indicator on host lane 7
-        datapath_hostlane8           = 1*255VCHAR                       ; data path state indicator on host lane 8
-        txoutput_status              = BOOLEAN                          ; tx output status on media lane
-        rxoutput_status_hostlane1    = BOOLEAN                          ; rx output status on host lane 1
-        rxoutput_status_hostlane2    = BOOLEAN                          ; rx output status on host lane 2
-        rxoutput_status_hostlane3    = BOOLEAN                          ; rx output status on host lane 3
-        rxoutput_status_hostlane4    = BOOLEAN                          ; rx output status on host lane 4
-        rxoutput_status_hostlane5    = BOOLEAN                          ; rx output status on host lane 5
-        rxoutput_status_hostlane6    = BOOLEAN                          ; rx output status on host lane 6
-        rxoutput_status_hostlane7    = BOOLEAN                          ; rx output status on host lane 7
-        rxoutput_status_hostlane8    = BOOLEAN                          ; rx output status on host lane 8
-        txfault                      = BOOLEAN                          ; tx fault flag on media lane
-        txlos_hostlane1              = BOOLEAN                          ; tx loss of signal flag on host lane 1
-        txlos_hostlane2              = BOOLEAN                          ; tx loss of signal flag on host lane 2
-        txlos_hostlane3              = BOOLEAN                          ; tx loss of signal flag on host lane 3
-        txlos_hostlane4              = BOOLEAN                          ; tx loss of signal flag on host lane 4
-        txlos_hostlane5              = BOOLEAN                          ; tx loss of signal flag on host lane 5
-        txlos_hostlane6              = BOOLEAN                          ; tx loss of signal flag on host lane 6
-        txlos_hostlane7              = BOOLEAN                          ; tx loss of signal flag on host lane 7
-        txlos_hostlane8              = BOOLEAN                          ; tx loss of signal flag on host lane 8
-        txcdrlol_hostlane1           = BOOLEAN                          ; tx clock and data recovery loss of lock on host lane 1
-        txcdrlol_hostlane2           = BOOLEAN                          ; tx clock and data recovery loss of lock on host lane 2
-        txcdrlol_hostlane3           = BOOLEAN                          ; tx clock and data recovery loss of lock on host lane 3
-        txcdrlol_hostlane4           = BOOLEAN                          ; tx clock and data recovery loss of lock on host lane 4
-        txcdrlol_hostlane5           = BOOLEAN                          ; tx clock and data recovery loss of lock on host lane 5
-        txcdrlol_hostlane6           = BOOLEAN                          ; tx clock and data recovery loss of lock on host lane 6
-        txcdrlol_hostlane7           = BOOLEAN                          ; tx clock and data recovery loss of lock on host lane 7
-        txcdrlol_hostlane8           = BOOLEAN                          ; tx clock and data recovery loss of lock on host lane 8
-        rxlos                        = BOOLEAN                          ; rx loss of signal flag on media lane
-        rxcdrlol                     = BOOLEAN                          ; rx clock and data recovery loss of lock on media lane
-        config_state_hostlane1       = 1*255VCHAR                       ; configuration status for the data path of host line 1
-        config_state_hostlane2       = 1*255VCHAR                       ; configuration status for the data path of host line 2
-        config_state_hostlane3       = 1*255VCHAR                       ; configuration status for the data path of host line 3
-        config_state_hostlane4       = 1*255VCHAR                       ; configuration status for the data path of host line 4
-        config_state_hostlane5       = 1*255VCHAR                       ; configuration status for the data path of host line 5
-        config_state_hostlane6       = 1*255VCHAR                       ; configuration status for the data path of host line 6
-        config_state_hostlane7       = 1*255VCHAR                       ; configuration status for the data path of host line 7
-        config_state_hostlane8       = 1*255VCHAR                       ; configuration status for the data path of host line 8
-        dpinit_pending_hostlane1     = BOOLEAN                          ; data path configuration updated on host lane 1 
-        dpinit_pending_hostlane2     = BOOLEAN                          ; data path configuration updated on host lane 2
-        dpinit_pending_hostlane3     = BOOLEAN                          ; data path configuration updated on host lane 3
-        dpinit_pending_hostlane4     = BOOLEAN                          ; data path configuration updated on host lane 4
-        dpinit_pending_hostlane5     = BOOLEAN                          ; data path configuration updated on host lane 5
-        dpinit_pending_hostlane6     = BOOLEAN                          ; data path configuration updated on host lane 6
-        dpinit_pending_hostlane7     = BOOLEAN                          ; data path configuration updated on host lane 7
-        dpinit_pending_hostlane8     = BOOLEAN                          ; data path configuration updated on host lane 8
-        tuning_in_progress           = BOOLEAN                          ; tuning in progress status
-        wavelength_unlock_status     = BOOLEAN                          ; laser unlocked status
-        target_output_power_oor      = BOOLEAN                          ; target output power out of range flag
-        fine_tuning_oor              = BOOLEAN                          ; fine tuning out of range flag
-        tuning_not_accepted          = BOOLEAN                          ; tuning not accepted flag
-        invalid_channel_num          = BOOLEAN                          ; invalid channel number flag
-        tuning_complete              = BOOLEAN                          ; tuning complete flag
-        temphighalarm_flag           = BOOLEAN                          ; temperature high alarm flag 
-        temphighwarning_flag         = BOOLEAN                          ; temperature high warning flag
-        templowalarm_flag            = BOOLEAN                          ; temperature low alarm flag
-        templowwarning_flag          = BOOLEAN                          ; temperature low warning flag
-        vcchighalarm_flag            = BOOLEAN                          ; vcc high alarm flag
-        vcchighwarning_flag          = BOOLEAN                          ; vcc high warning flag
-        vcclowalarm_flag             = BOOLEAN                          ; vcc low alarm flag
-        vcclowwarning_flag           = BOOLEAN                          ; vcc low warning flag
-        txpowerhighalarm_flag        = BOOLEAN                          ; tx power high alarm flag
-        txpowerlowalarm_flag         = BOOLEAN                          ; tx power low alarm flag
-        txpowerhighwarning_flag      = BOOLEAN                          ; tx power high warning flag
-        txpowerlowwarning_flag       = BOOLEAN                          ; tx power low alarm flag
-        rxpowerhighalarm_flag        = BOOLEAN                          ; rx power high alarm flag
-        rxpowerlowalarm_flag         = BOOLEAN                          ; rx power low alarm flag
-        rxpowerhighwarning_flag      = BOOLEAN                          ; rx power high warning flag
-        rxpowerlowwarning_flag       = BOOLEAN                          ; rx power low warning flag
-        txbiashighalarm_flag         = BOOLEAN                          ; tx bias high alarm flag
-        txbiaslowalarm_flag          = BOOLEAN                          ; tx bias low alarm flag
-        txbiashighwarning_flag       = BOOLEAN                          ; tx bias high warning flag
-        txbiaslowwarning_flag        = BOOLEAN                          ; tx bias low warning flag
-        lasertemphighalarm_flag      = BOOLEAN                          ; laser temperature high alarm flag
-        lasertemplowalarm_flag       = BOOLEAN                          ; laser temperature low alarm flag
-        lasertemphighwarning_flag    = BOOLEAN                          ; laser temperature high warning flag
-        lasertemplowwarning_flag     = BOOLEAN                          ; laser temperature low warning flag
-        prefecberhighalarm_flag      = BOOLEAN                          ; prefec ber high alarm flag
-        prefecberlowalarm_flag       = BOOLEAN                          ; prefec ber low alarm flag
-        prefecberhighwarning_flag    = BOOLEAN                          ; prefec ber high warning flag
-        prefecberlowwarning_flag     = BOOLEAN                          ; prefec ber low warning flag
-        postfecberhighalarm_flag     = BOOLEAN                          ; postfec ber high alarm flag
-        postfecberlowalarm_flag      = BOOLEAN                          ; postfec ber low alarm flag
-        postfecberhighwarning_flag   = BOOLEAN                          ; postfec ber high warning flag
-        postfecberlowwarning_flag    = BOOLEAN                          ; postfec ber low warning flag
-        biasxihighalarm_flag         = BOOLEAN                          ; bias xi high alarm flag
-        biasxilowalarm_flag          = BOOLEAN                          ; bias xi low alarm flag
-        biasxihighwarning_flag       = BOOLEAN                          ; bias xi high warning flag
-        biasxilowwarning_flag        = BOOLEAN                          ; bias xi low warning flag
-        biasxqhighalarm_flag         = BOOLEAN                          ; bias xq high alarm flag
-        biasxqlowalarm_flag          = BOOLEAN                          ; bias xq low alarm flag
-        biasxqhighwarning_flag       = BOOLEAN                          ; bias xq high warning flag
-        biasxqlowwarning_flag        = BOOLEAN                          ; bias xq low warning flag
-        biasxphighalarm_flag         = BOOLEAN                          ; bias xp high alarm flag
-        biasxplowalarm_flag          = BOOLEAN                          ; bias xp low alarm flag
-        biasxphighwarning_flag       = BOOLEAN                          ; bias xp high warning flag
-        biasxplowwarning_flag        = BOOLEAN                          ; bias xp low warning flag
-        biasyihighalarm_flag         = BOOLEAN                          ; bias yi high alarm flag
-        biasyilowalarm_flag          = BOOLEAN                          ; bias yi low alarm flag
-        biasyihighwarning_flag       = BOOLEAN                          ; bias yi high warning flag
-        biasyilowwarning_flag        = BOOLEAN                          ; bias yi low warning flag
-        biasyqhighalarm_flag         = BOOLEAN                          ; bias yq high alarm flag
-        biasyqlowalarm_flag          = BOOLEAN                          ; bias yq low alarm flag
-        biasyqhighwarning_flag       = BOOLEAN                          ; bias yq high warning flag
-        biasyqlowwarning_flag        = BOOLEAN                          ; bias yq low warning flag
-        biasyphighalarm_flag         = BOOLEAN                          ; bias yp high alarm flag
-        biasyplowalarm_flag          = BOOLEAN                          ; bias yp low alarm flag
-        biasyphighwarning_flag       = BOOLEAN                          ; bias yp high warning flag
-        biasyplowwarning_flag        = BOOLEAN                          ; bias yp low warning flag
-        cdshorthighalarm_flag        = BOOLEAN                          ; cd short high alarm flag
-        cdshortlowalarm_flag         = BOOLEAN                          ; cd short low alarm flag
-        cdshorthighwarning_flag      = BOOLEAN                          ; cd short high warning flag
-        cdshortlowwarning_flag       = BOOLEAN                          ; cd short low warning flag
-        cdlonghighalarm_flag         = BOOLEAN                          ; cd long high alarm flag
-        cdlonglowalarm_flag          = BOOLEAN                          ; cd long low alarm flag
-        cdlonghighwarning_flag       = BOOLEAN                          ; cd long high warning flag
-        cdlonglowwarning_flag        = BOOLEAN                          ; cd long low warning flag
-        dgdhighalarm_flag            = BOOLEAN                          ; dgd high alarm flag
-        dgdlowalarm_flag             = BOOLEAN                          ; dgd low alarm flag
-        dgdhighwarning_flag          = BOOLEAN                          ; dgd high warning flag
-        dgdlowwarning_flag           = BOOLEAN                          ; dgd low warning flag
-        sopmdhighalarm_flag          = BOOLEAN                          ; sopmd high alarm flag
-        sopmdlowalarm_flag           = BOOLEAN                          ; sopmd low alarm flag
-        sopmdhighwarning_flag        = BOOLEAN                          ; sopmd high warning flag
-        sopmdlowwarning_flag         = BOOLEAN                          ; sopmd low warning flag
-        pdlhighalarm_flag            = BOOLEAN                          ; pdl high alarm flag
-        pdllowalarm_flag             = BOOLEAN                          ; pdl low alarm flag
-        pdlhighwarning_flag          = BOOLEAN                          ; pdl high warning flag
-        pdllowwarning_flag           = BOOLEAN                          ; pdl low warning flag
-        osnrhighalarm_flag           = BOOLEAN                          ; osnr high alarm flag
-        osnrlowalarm_flag            = BOOLEAN                          ; osnr low alarm flag
-        osnrhighwarning_flag         = BOOLEAN                          ; osnr high warning flag
-        osnrlowwarning_flag          = BOOLEAN                          ; osnr low warning flag
-        esnrhighalarm_flag           = BOOLEAN                          ; esnr high alarm flag
-        esnrlowalarm_flag            = BOOLEAN                          ; esnr low alarm flag
-        esnrhighwarning_flag         = BOOLEAN                          ; esnr high warning flag
-        esnrlowwarning_flag          = BOOLEAN                          ; esnr low warning flag
-        cfohighalarm_flag            = BOOLEAN                          ; cfo high alarm flag
-        cfolowalarm_flag             = BOOLEAN                          ; cfo low alarm flag
-        cfohighwarning_flag          = BOOLEAN                          ; cfo high warning flag
-        cfolowwarning_flag           = BOOLEAN                          ; cfo low warning flag
-        txcurrpowerhighalarm_flag    = BOOLEAN                          ; txcurrpower high alarm flag
-        txcurrpowerlowalarm_flag     = BOOLEAN                          ; txcurrpower low alarm flag
-        txcurrpowerhighwarning_flag  = BOOLEAN                          ; txcurrpower high warning flag
-        txcurrpowerlowwarning_flag   = BOOLEAN                          ; txcurrpower low warning flag
-        rxtotpowerhighalarm_flag     = BOOLEAN                          ; rxtotpower high alarm flag
-        rxtotpowerlowalarm_flag      = BOOLEAN                          ; rxtotpower low alarm flag
-        rxtotpowerhighwarning_flag   = BOOLEAN                          ; rxtotpower high warning flag
-        rxtotpowerlowwarning_flag    = BOOLEAN                          ; rxtotpower low warning flag
-        rxsigpowerhighalarm_flag     = BOOLEAN                          ; rxsigpower high alarm flag
-        rxsigpowerlowalarm_flag      = BOOLEAN                          ; rxsigpower low alarm flag
-        rxsigpowerhighwarning_flag   = BOOLEAN                          ; rxsigpower high warning flag
-        rxsigpowerlowwarning_flag    = BOOLEAN                          ; rxsigpower low warning flag
-        ================================================================================
+            dict: A dictionary containing boolean values for various status fields, as defined in
+                the TRANSCEIVER_STATUS table in STATE_DB.
+        If there is an issue with reading the xcvr, None should be returned.
         """
         trans_status = super(CCmisApi,self).get_transceiver_status()
         trans_status['tuning_in_progress'] = self.get_tuning_in_progress()
         trans_status['wavelength_unlock_status'] = self.get_wavelength_unlocked()
-        laser_tuning_summary = self.get_laser_tuning_summary()
-        trans_status['target_output_power_oor'] = 'TargetOutputPowerOOR' in laser_tuning_summary
-        trans_status['fine_tuning_oor'] = 'FineTuningOutOfRange' in laser_tuning_summary
-        trans_status['tuning_not_accepted'] = 'TuningNotAccepted' in laser_tuning_summary
-        trans_status['invalid_channel_num'] = 'InvalidChannel' in laser_tuning_summary
-        trans_status['tuning_complete'] = 'TuningComplete' in laser_tuning_summary
-
-        for vdm_key, trans_status_key_prefix in C_CMIS_DELTA_VDM_KEY_TO_DB_PREFIX_KEY_MAP.items():
-            for i in range(5, 9):
-                trans_status_key = trans_status_key_prefix + VDM_SUBTYPE_IDX_MAP[i]
-                self._update_dict_if_vdm_key_exists(trans_status, trans_status_key, vdm_key, i)
 
         return trans_status
+
+    def get_transceiver_status_flags(self):
+        """
+        Retrieves the current flag status of the transceiver module.
+
+        Accesses latched registers to gather information about both
+        module-level and datapath-level states (including TX/RX related flags).
+
+        Returns:
+            dict: A dictionary containing boolean values for various flags, as defined in
+                the TRANSCEIVER_STATUS_FLAGS table in STATE_DB.
+        """
+        status_flags_dict = super().get_transceiver_status_flags()
+
+        laser_tuning_summary = self.get_laser_tuning_summary()
+        status_flags_dict.update({
+            'target_output_power_oor': 'TargetOutputPowerOOR' in laser_tuning_summary,
+            'fine_tuning_oor': 'FineTuningOutOfRange' in laser_tuning_summary,
+            'tuning_not_accepted': 'TuningNotAccepted' in laser_tuning_summary,
+            'invalid_channel_num': 'InvalidChannel' in laser_tuning_summary,
+            'tuning_complete': 'TuningComplete' in laser_tuning_summary
+        })
+
+        return status_flags_dict
 
     def get_transceiver_pm(self):
         """

--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -301,6 +301,7 @@ class CmisApi(XcvrApi):
         xcvr_info['vendor_rev'] = self.get_vendor_rev()
         xcvr_info['cmis_rev'] = self.get_cmis_rev()
         xcvr_info['specification_compliance'] = self.get_module_media_type()
+        xcvr_info['vdm_supported'] = self.is_transceiver_vdm_supported()
 
         # In normal case will get a valid value for each of the fields. If get a 'None' value
         # means there was a failure while reading the EEPROM, either because the EEPROM was
@@ -326,7 +327,16 @@ class CmisApi(XcvrApi):
         return_dict["inactive_firmware"] = InactiveFirmware
         return return_dict
 
-    def get_transceiver_bulk_status(self):
+    def get_transceiver_dom_real_value(self):
+        """
+        Retrieves DOM sensor values for this transceiver
+
+        The returned dictionary contains floating-point values corresponding to various
+        DOM sensor readings, as defined in the TRANSCEIVER_DOM_SENSOR table in STATE_DB.
+
+        Returns:
+            Dictionary
+        """
         temp = self.get_module_temperature()
         voltage = self.get_voltage()
         tx_bias = self.get_tx_bias()
@@ -351,23 +361,24 @@ class CmisApi(XcvrApi):
             bulk_status["tx%dpower" % i] = float("{:.3f}".format(self.mw_to_dbm(tx_power[i - 1]))) if tx_power[i - 1] != 'N/A' else 'N/A'
 
         laser_temp_dict = self.get_laser_temperature()
-        self.vdm_dict = self.get_vdm(self.vdm.VDM_REAL_VALUE)
         try:
             bulk_status['laser_temperature'] = laser_temp_dict['monitor value']
         except (KeyError, TypeError):
             pass
 
-        for vdm_key, db_key in CMIS_VDM_KEY_TO_DB_PREFIX_KEY_MAP.items():
-            for lane in range(1, self.NUM_CHANNELS + 1):
-                try:
-                    bulk_status_key = "%s%d" % (db_key, lane)
-                    bulk_status[bulk_status_key] = self.vdm_dict[vdm_key][lane][0]
-                except (KeyError, TypeError):
-                    pass
-
         return bulk_status
 
     def get_transceiver_dom_flags(self):
+        """
+        Retrieves the DOM flags for this xcvr
+
+        The returned dictionary contains boolean values representing various DOM flags.
+        All registers accessed by this function are latched and correspond to the
+        TRANSCEIVER_DOM_FLAG table in the STATE_DB.
+
+        Returns:
+            Dictionary
+        """
         dom_flag_dict = dict()
         module_flag = self.get_module_level_flag()
 
@@ -375,58 +386,67 @@ class CmisApi(XcvrApi):
             case_temp_flags = module_flag['case_temp_flags']
             voltage_flags = module_flag['voltage_flags']
             dom_flag_dict.update({
-                'temphighalarm': case_temp_flags['case_temp_high_alarm_flag'],
-                'templowalarm': case_temp_flags['case_temp_low_alarm_flag'],
-                'temphighwarning': case_temp_flags['case_temp_high_warn_flag'],
-                'templowwarning': case_temp_flags['case_temp_low_warn_flag'],
-                'vcchighalarm': voltage_flags['voltage_high_alarm_flag'],
-                'vcclowalarm': voltage_flags['voltage_low_alarm_flag'],
-                'vcchighwarning': voltage_flags['voltage_high_warn_flag'],
-                'vcclowwarning': voltage_flags['voltage_low_warn_flag']
+                'tempHAlarm': case_temp_flags['case_temp_high_alarm_flag'],
+                'tempLAlarm': case_temp_flags['case_temp_low_alarm_flag'],
+                'tempHWarn': case_temp_flags['case_temp_high_warn_flag'],
+                'tempLWarn': case_temp_flags['case_temp_low_warn_flag'],
+                'vccHAlarm': voltage_flags['voltage_high_alarm_flag'],
+                'vccLAlarm': voltage_flags['voltage_low_alarm_flag'],
+                'vccHWarn': voltage_flags['voltage_high_warn_flag'],
+                'vccLWarn': voltage_flags['voltage_low_warn_flag']
             })
         except TypeError:
             pass
-
-        tx_power_flag_dict = self.get_tx_power_flag()
-        if tx_power_flag_dict:
-            for lane in range(1, self.NUM_CHANNELS+1):
-                dom_flag_dict['txpowerhighalarm%d' % lane] = tx_power_flag_dict['tx_power_high_alarm']['TxPowerHighAlarmFlag%d' % lane]
-                dom_flag_dict['txpowerlowalarm%d' % lane] = tx_power_flag_dict['tx_power_low_alarm']['TxPowerLowAlarmFlag%d' % lane]
-                dom_flag_dict['txpowerhighwarning%d' % lane] = tx_power_flag_dict['tx_power_high_warn']['TxPowerHighWarnFlag%d' % lane]
-                dom_flag_dict['txpowerlowwarning%d' % lane] = tx_power_flag_dict['tx_power_low_warn']['TxPowerLowWarnFlag%d' % lane]
-        rx_power_flag_dict = self.get_rx_power_flag()
-        if rx_power_flag_dict:
-            for lane in range(1, self.NUM_CHANNELS+1):
-                dom_flag_dict['rxpowerhighalarm%d' % lane] = rx_power_flag_dict['rx_power_high_alarm']['RxPowerHighAlarmFlag%d' % lane]
-                dom_flag_dict['rxpowerlowalarm%d' % lane] = rx_power_flag_dict['rx_power_low_alarm']['RxPowerLowAlarmFlag%d' % lane]
-                dom_flag_dict['rxpowerhighwarning%d' % lane] = rx_power_flag_dict['rx_power_high_warn']['RxPowerHighWarnFlag%d' % lane]
-                dom_flag_dict['rxpowerlowwarning%d' % lane] = rx_power_flag_dict['rx_power_low_warn']['RxPowerLowWarnFlag%d' % lane]
-        tx_bias_flag_dict = self.get_tx_bias_flag()
-        if tx_bias_flag_dict:
-            for lane in range(1, self.NUM_CHANNELS+1):
-                dom_flag_dict['txbiashighalarm%d' % lane] = tx_bias_flag_dict['tx_bias_high_alarm']['TxBiasHighAlarmFlag%d' % lane]
-                dom_flag_dict['txbiaslowalarm%d' % lane] = tx_bias_flag_dict['tx_bias_low_alarm']['TxBiasLowAlarmFlag%d' % lane]
-                dom_flag_dict['txbiashighwarning%d' % lane] = tx_bias_flag_dict['tx_bias_high_warn']['TxBiasHighWarnFlag%d' % lane]
-                dom_flag_dict['txbiaslowwarning%d' % lane] = tx_bias_flag_dict['tx_bias_low_warn']['TxBiasLowWarnFlag%d' % lane]
-
         try:
             _, aux2_mon_type, aux3_mon_type = self.get_aux_mon_type()
             if aux2_mon_type == 0:
-                dom_flag_dict['lasertemphighalarm'] = module_flag['aux2_flags']['aux2_high_alarm_flag']
-                dom_flag_dict['lasertemplowalarm'] = module_flag['aux2_flags']['aux2_low_alarm_flag']
-                dom_flag_dict['lasertemphighwarning'] = module_flag['aux2_flags']['aux2_high_warn_flag']
-                dom_flag_dict['lasertemplowwarning'] = module_flag['aux2_flags']['aux2_low_warn_flag']
+                dom_flag_dict['lasertempHAlarm'] = module_flag['aux2_flags']['aux2_high_alarm_flag']
+                dom_flag_dict['lasertempLAlarm'] = module_flag['aux2_flags']['aux2_low_alarm_flag']
+                dom_flag_dict['lasertempHWarn'] = module_flag['aux2_flags']['aux2_high_warn_flag']
+                dom_flag_dict['lasertempLWarn'] = module_flag['aux2_flags']['aux2_low_warn_flag']
             elif aux2_mon_type == 1 and aux3_mon_type == 0:
-                dom_flag_dict['lasertemphighalarm'] = module_flag['aux3_flags']['aux3_high_alarm_flag']
-                dom_flag_dict['lasertemplowalarm'] = module_flag['aux3_flags']['aux3_low_alarm_flag']
-                dom_flag_dict['lasertemphighwarning'] = module_flag['aux3_flags']['aux3_high_warn_flag']
-                dom_flag_dict['lasertemplowwarning'] = module_flag['aux3_flags']['aux3_low_warn_flag']
+                dom_flag_dict['lasertempHAlarm'] = module_flag['aux3_flags']['aux3_high_alarm_flag']
+                dom_flag_dict['lasertempLAlarm'] = module_flag['aux3_flags']['aux3_low_alarm_flag']
+                dom_flag_dict['lasertempHWarn'] = module_flag['aux3_flags']['aux3_high_warn_flag']
+                dom_flag_dict['lasertempLWarn'] = module_flag['aux3_flags']['aux3_low_warn_flag']
         except TypeError:
             pass
+
+        if not self.is_flat_memory():
+            tx_power_flag_dict = self.get_tx_power_flag()
+            if tx_power_flag_dict:
+                for lane in range(1, self.NUM_CHANNELS+1):
+                    dom_flag_dict['tx%dpowerHAlarm' % lane] = tx_power_flag_dict['tx_power_high_alarm']['TxPowerHighAlarmFlag%d' % lane]
+                    dom_flag_dict['tx%dpowerLAlarm' % lane] = tx_power_flag_dict['tx_power_low_alarm']['TxPowerLowAlarmFlag%d' % lane]
+                    dom_flag_dict['tx%dpowerHWarn' % lane] = tx_power_flag_dict['tx_power_high_warn']['TxPowerHighWarnFlag%d' % lane]
+                    dom_flag_dict['tx%dpowerLWarn' % lane] = tx_power_flag_dict['tx_power_low_warn']['TxPowerLowWarnFlag%d' % lane]
+            rx_power_flag_dict = self.get_rx_power_flag()
+            if rx_power_flag_dict:
+                for lane in range(1, self.NUM_CHANNELS+1):
+                    dom_flag_dict['rx%dpowerHAlarm' % lane] = rx_power_flag_dict['rx_power_high_alarm']['RxPowerHighAlarmFlag%d' % lane]
+                    dom_flag_dict['rx%dpowerLAlarm' % lane] = rx_power_flag_dict['rx_power_low_alarm']['RxPowerLowAlarmFlag%d' % lane]
+                    dom_flag_dict['rx%dpowerHWarn' % lane] = rx_power_flag_dict['rx_power_high_warn']['RxPowerHighWarnFlag%d' % lane]
+                    dom_flag_dict['rx%dpowerLWarn' % lane] = rx_power_flag_dict['rx_power_low_warn']['RxPowerLowWarnFlag%d' % lane]
+            tx_bias_flag_dict = self.get_tx_bias_flag()
+            if tx_bias_flag_dict:
+                for lane in range(1, self.NUM_CHANNELS+1):
+                    dom_flag_dict['tx%dbiasHAlarm' % lane] = tx_bias_flag_dict['tx_bias_high_alarm']['TxBiasHighAlarmFlag%d' % lane]
+                    dom_flag_dict['tx%dbiasLAlarm' % lane] = tx_bias_flag_dict['tx_bias_low_alarm']['TxBiasLowAlarmFlag%d' % lane]
+                    dom_flag_dict['tx%dbiasHWarn' % lane] = tx_bias_flag_dict['tx_bias_high_warn']['TxBiasHighWarnFlag%d' % lane]
+                    dom_flag_dict['tx%dbiasLWarn' % lane] = tx_bias_flag_dict['tx_bias_low_warn']['TxBiasLowWarnFlag%d' % lane]
 
         return dom_flag_dict
 
     def get_transceiver_threshold_info(self):
+        """
+        Retrieves threshold info for this xcvr
+
+        The returned dictionary contains floating-point values corresponding to various
+        DOM sensor threshold readings, as defined in the TRANSCEIVER_DOM_THRESHOLD table in STATE_DB.
+
+        Returns:
+            Dictionary
+        """
         threshold_info_keys = ['temphighalarm',    'temphighwarning',
                                'templowalarm',     'templowwarning',
                                'vcchighalarm',     'vcchighwarning',
@@ -487,18 +507,7 @@ class CmisApi(XcvrApi):
             threshold_info_dict['lasertemplowwarning'] = laser_temp_dict['low warn']
         except (KeyError, TypeError):
             pass
-        self.vdm_dict = self.get_vdm(self.vdm.VDM_THRESHOLD)
-        try:
-            threshold_info_dict['prefecberhighalarm'] = self.vdm_dict['Pre-FEC BER Average Media Input'][1][1]
-            threshold_info_dict['prefecberlowalarm'] = self.vdm_dict['Pre-FEC BER Average Media Input'][1][2]
-            threshold_info_dict['prefecberhighwarning'] = self.vdm_dict['Pre-FEC BER Average Media Input'][1][3]
-            threshold_info_dict['prefecberlowwarning'] = self.vdm_dict['Pre-FEC BER Average Media Input'][1][4]
-            threshold_info_dict['postfecberhighalarm'] = self.vdm_dict['Errored Frames Average Media Input'][1][1]
-            threshold_info_dict['postfecberlowalarm'] = self.vdm_dict['Errored Frames Average Media Input'][1][2]
-            threshold_info_dict['postfecberhighwarning'] = self.vdm_dict['Errored Frames Average Media Input'][1][3]
-            threshold_info_dict['postfecberlowwarning'] = self.vdm_dict['Errored Frames Average Media Input'][1][4]
-        except (KeyError, TypeError):
-            pass
+
         return threshold_info_dict
 
     def get_module_temperature(self):
@@ -2052,142 +2061,18 @@ class CmisApi(XcvrApi):
 
     def get_transceiver_status(self):
         """
-        Retrieves transceiver status of this SFP
+        Retrieves the current status of the transceiver module.
+
+        Accesses non-latched registers to gather information about the module's state,
+        fault causes, and datapath-level statuses, including TX and RX statuses.
 
         Returns:
-            A dict which contains following keys/values :
-        ================================================================================
-        key                          = TRANSCEIVER_STATUS|ifname        ; Error information for module on port
-        ; field                      = value
-        module_state                 = 1*255VCHAR                       ; current module state (ModuleLowPwr, ModulePwrUp, ModuleReady, ModulePwrDn, Fault)
-        module_fault_cause           = 1*255VCHAR                       ; reason of entering the module fault state
-        datapath_firmware_fault      = BOOLEAN                          ; datapath (DSP) firmware fault
-        module_firmware_fault        = BOOLEAN                          ; module firmware fault
-        module_state_changed         = BOOLEAN                          ; module state changed
-        datapath_hostlane1           = 1*255VCHAR                       ; data path state indicator on host lane 1
-        datapath_hostlane2           = 1*255VCHAR                       ; data path state indicator on host lane 2
-        datapath_hostlane3           = 1*255VCHAR                       ; data path state indicator on host lane 3
-        datapath_hostlane4           = 1*255VCHAR                       ; data path state indicator on host lane 4
-        datapath_hostlane5           = 1*255VCHAR                       ; data path state indicator on host lane 5
-        datapath_hostlane6           = 1*255VCHAR                       ; data path state indicator on host lane 6
-        datapath_hostlane7           = 1*255VCHAR                       ; data path state indicator on host lane 7
-        datapath_hostlane8           = 1*255VCHAR                       ; data path state indicator on host lane 8
-        txoutput_status              = BOOLEAN                          ; tx output status on media lane
-        rxoutput_status_hostlane1    = BOOLEAN                          ; rx output status on host lane 1
-        rxoutput_status_hostlane2    = BOOLEAN                          ; rx output status on host lane 2
-        rxoutput_status_hostlane3    = BOOLEAN                          ; rx output status on host lane 3
-        rxoutput_status_hostlane4    = BOOLEAN                          ; rx output status on host lane 4
-        rxoutput_status_hostlane5    = BOOLEAN                          ; rx output status on host lane 5
-        rxoutput_status_hostlane6    = BOOLEAN                          ; rx output status on host lane 6
-        rxoutput_status_hostlane7    = BOOLEAN                          ; rx output status on host lane 7
-        rxoutput_status_hostlane8    = BOOLEAN                          ; rx output status on host lane 8
-        tx_disable                   = BOOLEAN                          ; tx disable status
-        tx_disabled_channel          = INTEGER                          ; disabled TX channels
-        txfault                      = BOOLEAN                          ; tx fault flag on media lane
-        txlos_hostlane1              = BOOLEAN                          ; tx loss of signal flag on host lane 1
-        txlos_hostlane2              = BOOLEAN                          ; tx loss of signal flag on host lane 2
-        txlos_hostlane3              = BOOLEAN                          ; tx loss of signal flag on host lane 3
-        txlos_hostlane4              = BOOLEAN                          ; tx loss of signal flag on host lane 4
-        txlos_hostlane5              = BOOLEAN                          ; tx loss of signal flag on host lane 5
-        txlos_hostlane6              = BOOLEAN                          ; tx loss of signal flag on host lane 6
-        txlos_hostlane7              = BOOLEAN                          ; tx loss of signal flag on host lane 7
-        txlos_hostlane8              = BOOLEAN                          ; tx loss of signal flag on host lane 8
-        txcdrlol_hostlane1           = BOOLEAN                          ; tx clock and data recovery loss of lock on host lane 1
-        txcdrlol_hostlane2           = BOOLEAN                          ; tx clock and data recovery loss of lock on host lane 2
-        txcdrlol_hostlane3           = BOOLEAN                          ; tx clock and data recovery loss of lock on host lane 3
-        txcdrlol_hostlane4           = BOOLEAN                          ; tx clock and data recovery loss of lock on host lane 4
-        txcdrlol_hostlane5           = BOOLEAN                          ; tx clock and data recovery loss of lock on host lane 5
-        txcdrlol_hostlane6           = BOOLEAN                          ; tx clock and data recovery loss of lock on host lane 6
-        txcdrlol_hostlane7           = BOOLEAN                          ; tx clock and data recovery loss of lock on host lane 7
-        txcdrlol_hostlane8           = BOOLEAN                          ; tx clock and data recovery loss of lock on host lane 8
-        rxlos                        = BOOLEAN                          ; rx loss of signal flag on media lane
-        rxcdrlol                     = BOOLEAN                          ; rx clock and data recovery loss of lock on media lane
-        config_state_hostlane1       = 1*255VCHAR                       ; configuration status for the data path of host line 1
-        config_state_hostlane2       = 1*255VCHAR                       ; configuration status for the data path of host line 2
-        config_state_hostlane3       = 1*255VCHAR                       ; configuration status for the data path of host line 3
-        config_state_hostlane4       = 1*255VCHAR                       ; configuration status for the data path of host line 4
-        config_state_hostlane5       = 1*255VCHAR                       ; configuration status for the data path of host line 5
-        config_state_hostlane6       = 1*255VCHAR                       ; configuration status for the data path of host line 6
-        config_state_hostlane7       = 1*255VCHAR                       ; configuration status for the data path of host line 7
-        config_state_hostlane8       = 1*255VCHAR                       ; configuration status for the data path of host line 8
-        dpinit_pending_hostlane1     = BOOLEAN                          ; data path configuration updated on host lane 1
-        dpinit_pending_hostlane2     = BOOLEAN                          ; data path configuration updated on host lane 2
-        dpinit_pending_hostlane3     = BOOLEAN                          ; data path configuration updated on host lane 3
-        dpinit_pending_hostlane4     = BOOLEAN                          ; data path configuration updated on host lane 4
-        dpinit_pending_hostlane5     = BOOLEAN                          ; data path configuration updated on host lane 5
-        dpinit_pending_hostlane6     = BOOLEAN                          ; data path configuration updated on host lane 6
-        dpinit_pending_hostlane7     = BOOLEAN                          ; data path configuration updated on host lane 7
-        dpinit_pending_hostlane8     = BOOLEAN                          ; data path configuration updated on host lane 8
-        temphighalarm_flag           = BOOLEAN                          ; temperature high alarm flag
-        temphighwarning_flag         = BOOLEAN                          ; temperature high warning flag
-        templowalarm_flag            = BOOLEAN                          ; temperature low alarm flag
-        templowwarning_flag          = BOOLEAN                          ; temperature low warning flag
-        vcchighalarm_flag            = BOOLEAN                          ; vcc high alarm flag
-        vcchighwarning_flag          = BOOLEAN                          ; vcc high warning flag
-        vcclowalarm_flag             = BOOLEAN                          ; vcc low alarm flag
-        vcclowwarning_flag           = BOOLEAN                          ; vcc low warning flag
-        txpowerhighalarm_flag        = BOOLEAN                          ; tx power high alarm flag
-        txpowerlowalarm_flag         = BOOLEAN                          ; tx power low alarm flag
-        txpowerhighwarning_flag      = BOOLEAN                          ; tx power high warning flag
-        txpowerlowwarning_flag       = BOOLEAN                          ; tx power low alarm flag
-        rxpowerhighalarm_flag        = BOOLEAN                          ; rx power high alarm flag
-        rxpowerlowalarm_flag         = BOOLEAN                          ; rx power low alarm flag
-        rxpowerhighwarning_flag      = BOOLEAN                          ; rx power high warning flag
-        rxpowerlowwarning_flag       = BOOLEAN                          ; rx power low warning flag
-        txbiashighalarm_flag         = BOOLEAN                          ; tx bias high alarm flag
-        txbiaslowalarm_flag          = BOOLEAN                          ; tx bias low alarm flag
-        txbiashighwarning_flag       = BOOLEAN                          ; tx bias high warning flag
-        txbiaslowwarning_flag        = BOOLEAN                          ; tx bias low warning flag
-        lasertemphighalarm_flag      = BOOLEAN                          ; laser temperature high alarm flag
-        lasertemplowalarm_flag       = BOOLEAN                          ; laser temperature low alarm flag
-        lasertemphighwarning_flag    = BOOLEAN                          ; laser temperature high warning flag
-        lasertemplowwarning_flag     = BOOLEAN                          ; laser temperature low warning flag
-        prefecberhighalarm_flag      = BOOLEAN                          ; prefec ber high alarm flag
-        prefecberlowalarm_flag       = BOOLEAN                          ; prefec ber low alarm flag
-        prefecberhighwarning_flag    = BOOLEAN                          ; prefec ber high warning flag
-        prefecberlowwarning_flag     = BOOLEAN                          ; prefec ber low warning flag
-        postfecberhighalarm_flag     = BOOLEAN                          ; postfec ber high alarm flag
-        postfecberlowalarm_flag      = BOOLEAN                          ; postfec ber low alarm flag
-        postfecberhighwarning_flag   = BOOLEAN                          ; postfec ber high warning flag
-        postfecberlowwarning_flag    = BOOLEAN                          ; postfec ber low warning flag
-        ================================================================================
+            dict: A dictionary containing boolean values for various status fields, as defined in
+                the TRANSCEIVER_STATUS table in STATE_DB.
         """
         trans_status = dict()
         trans_status['module_state'] = self.get_module_state()
         trans_status['module_fault_cause'] = self.get_module_fault_cause()
-        try:
-            dp_fw_fault, module_fw_fault, module_state_changed = self.get_module_firmware_fault_state_changed()
-            trans_status['datapath_firmware_fault'] = dp_fw_fault
-            trans_status['module_firmware_fault'] = module_fw_fault
-            trans_status['module_state_changed'] = module_state_changed
-        except TypeError:
-            pass
-        module_flag = self.get_module_level_flag()
-        try:
-            trans_status['temphighalarm_flag'] = module_flag['case_temp_flags']['case_temp_high_alarm_flag']
-            trans_status['templowalarm_flag'] = module_flag['case_temp_flags']['case_temp_low_alarm_flag']
-            trans_status['temphighwarning_flag'] = module_flag['case_temp_flags']['case_temp_high_warn_flag']
-            trans_status['templowwarning_flag'] = module_flag['case_temp_flags']['case_temp_low_warn_flag']
-            trans_status['vcchighalarm_flag'] = module_flag['voltage_flags']['voltage_high_alarm_flag']
-            trans_status['vcclowalarm_flag'] = module_flag['voltage_flags']['voltage_low_alarm_flag']
-            trans_status['vcchighwarning_flag'] = module_flag['voltage_flags']['voltage_high_warn_flag']
-            trans_status['vcclowwarning_flag'] = module_flag['voltage_flags']['voltage_low_warn_flag']
-        except TypeError:
-            pass
-        try:
-            aux1_mon_type, aux2_mon_type, aux3_mon_type = self.get_aux_mon_type()
-            if aux2_mon_type == 0:
-                trans_status['lasertemphighalarm_flag'] = module_flag['aux2_flags']['aux2_high_alarm_flag']
-                trans_status['lasertemplowalarm_flag'] = module_flag['aux2_flags']['aux2_low_alarm_flag']
-                trans_status['lasertemphighwarning_flag'] = module_flag['aux2_flags']['aux2_high_warn_flag']
-                trans_status['lasertemplowwarning_flag'] = module_flag['aux2_flags']['aux2_low_warn_flag']
-            elif aux2_mon_type == 1 and aux3_mon_type == 0:
-                trans_status['lasertemphighalarm_flag'] = module_flag['aux3_flags']['aux3_high_alarm_flag']
-                trans_status['lasertemplowalarm_flag'] = module_flag['aux3_flags']['aux3_low_alarm_flag']
-                trans_status['lasertemphighwarning_flag'] = module_flag['aux3_flags']['aux3_high_warn_flag']
-                trans_status['lasertemplowwarning_flag'] = module_flag['aux3_flags']['aux3_low_warn_flag']
-        except TypeError:
-            pass
         if not self.is_flat_memory():
             dp_state_dict = self.get_datapath_state()
             if dp_state_dict:
@@ -2196,11 +2081,11 @@ class CmisApi(XcvrApi):
             tx_output_status_dict = self.get_tx_output_status()
             if tx_output_status_dict:
                 for lane in range(1, self.NUM_CHANNELS+1):
-                    trans_status['txoutput_status%d' % lane] = tx_output_status_dict.get('TxOutputStatus%d' % lane)
+                    trans_status['tx%dOutputStatus' % lane] = tx_output_status_dict.get('TxOutputStatus%d' % lane)
             rx_output_status_dict = self.get_rx_output_status()
             if rx_output_status_dict:
                 for lane in range(1, self.NUM_CHANNELS+1):
-                    trans_status['rxoutput_status_hostlane%d' % lane] = rx_output_status_dict.get('RxOutputStatus%d' % lane)
+                    trans_status['rx%dOutputStatusHostlane' % lane] = rx_output_status_dict.get('RxOutputStatus%d' % lane)
             tx_disabled_channel = self.get_tx_disable_channel()
             if tx_disabled_channel is not None:
                 trans_status['tx_disabled_channel'] = tx_disabled_channel
@@ -2208,30 +2093,6 @@ class CmisApi(XcvrApi):
             if tx_disable is not None:
                 for lane in range(1, self.NUM_CHANNELS+1):
                     trans_status['tx%ddisable' % lane] = tx_disable[lane - 1]
-            tx_fault = self.get_tx_fault()
-            if tx_fault:
-                for lane in range(1, self.NUM_CHANNELS+1):
-                    trans_status['txfault%d' % lane] = tx_fault[lane - 1]
-            tx_los = self.get_tx_los()
-            if tx_los:
-                for lane in range(1, self.NUM_CHANNELS+1):
-                    trans_status['txlos_hostlane%d' % lane] = tx_los[lane - 1]
-            tx_lol = self.get_tx_cdr_lol()
-            if tx_lol:
-                for lane in range(1, self.NUM_CHANNELS+1):
-                    trans_status['txcdrlol_hostlane%d' % lane] = tx_lol[lane - 1]
-            rx_los = self.get_rx_los()
-            if rx_los:
-                for lane in range(1, self.NUM_CHANNELS+1):
-                    trans_status['rxlos%d' % lane] = rx_los[lane - 1]
-            rx_lol = self.get_rx_cdr_lol()
-            if rx_lol:
-                for lane in range(1, self.NUM_CHANNELS+1):
-                    trans_status['rxcdrlol%d' % lane] = rx_lol[lane - 1]
-            tx_adaptive_eq_fail_flag_val = self.get_tx_adaptive_eq_fail_flag()
-            if tx_adaptive_eq_fail_flag_val:
-                for lane in range(1, self.NUM_CHANNELS+1):
-                    trans_status['tx_eq_fault%d' % lane] = tx_adaptive_eq_fail_flag_val[lane - 1]
             config_status_dict = self.get_config_datapath_hostlane_status()
             if config_status_dict:
                 for lane in range(1, self.NUM_CHANNELS+1):
@@ -2244,66 +2105,18 @@ class CmisApi(XcvrApi):
             if dpinit_pending_dict:
                 for lane in range(1, self.NUM_CHANNELS+1):
                     trans_status['dpinit_pending_hostlane%d' % lane] = dpinit_pending_dict.get('DPInitPending%d' % lane)
-            tx_power_flag_dict = self.get_tx_power_flag()
-            if tx_power_flag_dict:
-                for lane in range(1, self.NUM_CHANNELS+1):
-                    trans_status['txpowerhighalarm_flag%d' % lane] = tx_power_flag_dict['tx_power_high_alarm']['TxPowerHighAlarmFlag%d' % lane]
-                    trans_status['txpowerlowalarm_flag%d' % lane] = tx_power_flag_dict['tx_power_low_alarm']['TxPowerLowAlarmFlag%d' % lane]
-                    trans_status['txpowerhighwarning_flag%d' % lane] = tx_power_flag_dict['tx_power_high_warn']['TxPowerHighWarnFlag%d' % lane]
-                    trans_status['txpowerlowwarning_flag%d' % lane] = tx_power_flag_dict['tx_power_low_warn']['TxPowerLowWarnFlag%d' % lane]
-            rx_power_flag_dict = self.get_rx_power_flag()
-            if rx_power_flag_dict:
-                for lane in range(1, self.NUM_CHANNELS+1):
-                    trans_status['rxpowerhighalarm_flag%d' % lane] = rx_power_flag_dict['rx_power_high_alarm']['RxPowerHighAlarmFlag%d' % lane]
-                    trans_status['rxpowerlowalarm_flag%d' % lane] = rx_power_flag_dict['rx_power_low_alarm']['RxPowerLowAlarmFlag%d' % lane]
-                    trans_status['rxpowerhighwarning_flag%d' % lane] = rx_power_flag_dict['rx_power_high_warn']['RxPowerHighWarnFlag%d' % lane]
-                    trans_status['rxpowerlowwarning_flag%d' % lane] = rx_power_flag_dict['rx_power_low_warn']['RxPowerLowWarnFlag%d' % lane]
-            tx_bias_flag_dict = self.get_tx_bias_flag()
-            if tx_bias_flag_dict:
-                for lane in range(1, self.NUM_CHANNELS+1):
-                    trans_status['txbiashighalarm_flag%d' % lane] = tx_bias_flag_dict['tx_bias_high_alarm']['TxBiasHighAlarmFlag%d' % lane]
-                    trans_status['txbiaslowalarm_flag%d' % lane] = tx_bias_flag_dict['tx_bias_low_alarm']['TxBiasLowAlarmFlag%d' % lane]
-                    trans_status['txbiashighwarning_flag%d' % lane] = tx_bias_flag_dict['tx_bias_high_warn']['TxBiasHighWarnFlag%d' % lane]
-                    trans_status['txbiaslowwarning_flag%d' % lane] = tx_bias_flag_dict['tx_bias_low_warn']['TxBiasLowWarnFlag%d' % lane]
-            self.vdm_dict = self.get_vdm(self.vdm.VDM_FLAG)
-            try:
-                trans_status['prefecberhighalarm_flag'] = self.vdm_dict['Pre-FEC BER Average Media Input'][1][5]
-                trans_status['prefecberlowalarm_flag'] = self.vdm_dict['Pre-FEC BER Average Media Input'][1][6]
-                trans_status['prefecberhighwarning_flag'] = self.vdm_dict['Pre-FEC BER Average Media Input'][1][7]
-                trans_status['prefecberlowwarning_flag'] = self.vdm_dict['Pre-FEC BER Average Media Input'][1][8]
-                trans_status['postfecberhighalarm_flag'] = self.vdm_dict['Errored Frames Average Media Input'][1][5]
-                trans_status['postfecberlowalarm_flag'] = self.vdm_dict['Errored Frames Average Media Input'][1][6]
-                trans_status['postfecberhighwarning_flag'] = self.vdm_dict['Errored Frames Average Media Input'][1][7]
-                trans_status['postfecberlowwarning_flag'] = self.vdm_dict['Errored Frames Average Media Input'][1][8]
-            except (KeyError, TypeError):
-                pass
         return trans_status
 
     def get_transceiver_status_flags(self):
         """
-        Retrieves transceiver status flags of this SFP
+        Retrieves the current flag status of the transceiver module.
+
+        Accesses latched registers to gather information about both
+        module-level and datapath-level states (including TX/RX related flags).
 
         Returns:
-            A dict which contains following keys/values :
-        ================================================================================
-        ; Defines Transceiver Status info for a port
-        key                                     = TRANSCEIVER_STATUS_FLAG|ifname        ; Flag information for module on port
-        ; field                                 = value
-        datapath_firmware_fault                 = BOOLEAN           ; datapath (DSP) firmware fault
-        module_firmware_fault                   = BOOLEAN           ; module firmware fault
-        module_state_changed                    = BOOLEAN           ; module state changed
-        txfault{lane_num}                       = BOOLEAN           ; tx fault flag on media lane {lane_num}
-        txlos_hostlane{lane_num}                = BOOLEAN           ; tx loss of signal flag on host lane {lane_num}
-        txcdrlol_hostlane{lane_num}             = BOOLEAN           ; tx clock and data recovery loss of lock flag on host lane {lane_num}
-        tx_eq_fault{lane_num}                   = BOOLEAN           ; tx equalization fault flag on host lane {lane_num}
-        rxlos{lane_num}                         = BOOLEAN           ; rx loss of signal flag on media lane {lane_num}
-        rxcdrlol{lane_num}                      = BOOLEAN           ; rx clock and data recovery loss of lock flag on media lane {lane_num}
-        target_output_power_oor                 = BOOLEAN           ; target output power out of range flag
-        fine_tuning_oor                         = BOOLEAN           ; fine tuning  out of range flag
-        tuning_not_accepted                     = BOOLEAN           ; tuning not accepted flag
-        invalid_channel_num                     = BOOLEAN           ; invalid channel number flag
-        tuning_complete                         = BOOLEAN           ; tuning complete flag
-        ================================================================================
+            dict: A dictionary containing boolean values for various flags, as defined in
+                the TRANSCEIVER_STATUS_FLAGS table in STATE_DB.
         """
         status_flags_dict = dict()
         try:
@@ -2316,26 +2129,20 @@ class CmisApi(XcvrApi):
         except TypeError:
             pass
 
-        fault_types = {
-            'txfault': self.get_tx_fault(),
-            'txlos_hostlane': self.get_tx_los(),
-            'txcdrlol_hostlane': self.get_tx_cdr_lol(),
-            'tx_eq_fault': self.get_tx_adaptive_eq_fail_flag(),
-            'rxlos': self.get_rx_los(),
-            'rxcdrlol': self.get_rx_cdr_lol()
-        }
+        if not self.is_flat_memory():
+            fault_types = {
+                'tx{lane_num}fault': self.get_tx_fault(),
+                'rx{lane_num}los': self.get_rx_los(),
+                'tx{lane_num}los_hostlane': self.get_tx_los(),
+                'tx{lane_num}cdrlol_hostlane': self.get_tx_cdr_lol(),
+                'tx{lane_num}_eq_fault': self.get_tx_adaptive_eq_fail_flag(),
+                'rx{lane_num}cdrlol': self.get_rx_cdr_lol()
+            }
 
-        for fault_type, fault_values in fault_types.items():
-            for lane in range(1, self.NUM_CHANNELS + 1):
-                key = f'{fault_type}{lane}'
-                status_flags_dict[key] = fault_values[lane - 1] if fault_values else "N/A"
-
-        laser_tuning_summary = self.get_laser_tuning_summary()
-        status_flags_dict['target_output_power_oor'] = 'TargetOutputPowerOOR' in laser_tuning_summary
-        status_flags_dict['fine_tuning_oor'] = 'FineTuningOutOfRange' in laser_tuning_summary
-        status_flags_dict['tuning_not_accepted'] = 'TuningNotAccepted' in laser_tuning_summary
-        status_flags_dict['invalid_channel_num'] = 'InvalidChannel' in laser_tuning_summary
-        status_flags_dict['tuning_complete'] = 'TuningComplete' in laser_tuning_summary
+            for fault_type_template, fault_values in fault_types.items():
+                for lane in range(1, self.NUM_CHANNELS + 1):
+                    key = fault_type_template.format(lane_num=lane)
+                    status_flags_dict[key] = fault_values[lane - 1] if fault_values else "N/A"
 
         return status_flags_dict
 

--- a/sonic_platform_base/sonic_xcvr/api/public/sff8436.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/sff8436.py
@@ -69,29 +69,65 @@ class Sff8436Api(XcvrApi):
         return xcvr_info
 
     def get_transceiver_status(self):
-        rx_los = self.get_rx_los()
-        tx_fault = self.get_tx_fault()
+        """
+        Retrieves the current status of the transceiver module.
+
+        Accesses non-latched registers to gather information about the TX output statuses.
+
+        Returns:
+            dict: A dictionary containing boolean values for various status fields, as defined in
+                the TRANSCEIVER_STATUS table in STATE_DB.
+        """
         tx_disable = self.get_tx_disable()
         tx_disabled_channel = self.get_tx_disable_channel()
-        read_failed = rx_los is None or \
-                      tx_fault is None or \
-                      tx_disable is None or \
+        read_failed = tx_disable is None or \
                       tx_disabled_channel is None
         if read_failed:
             return None
 
         trans_status = dict()
-        for lane in range(1, len(rx_los) + 1):
-            trans_status['rxlos%d' % lane] = rx_los[lane - 1]
-        for lane in range(1, len(tx_fault) + 1):
-            trans_status['txfault%d' % lane] = tx_fault[lane - 1]
         for lane in range(1, len(tx_disable) + 1):
             trans_status['tx%ddisable' % lane] = tx_disable[lane - 1]
         trans_status['tx_disabled_channel'] = tx_disabled_channel
 
         return trans_status
 
-    def get_transceiver_bulk_status(self):
+    def get_transceiver_status_flags(self):
+        """
+        Retrieves the current flag status of the transceiver module.
+
+        Accesses latched registers to gather information about TX and RX related flags.
+
+        Returns:
+            dict: A dictionary containing boolean values for various flags, as defined in
+                the TRANSCEIVER_STATUS_FLAGS table in STATE_DB.
+        """
+        rx_los = self.get_rx_los()
+        tx_fault = self.get_tx_fault()
+        read_failed = rx_los is None or \
+                      tx_fault is None
+
+        if read_failed:
+            return None
+
+        trans_status_flags = dict()
+        for lane in range(1, len(rx_los) + 1):
+            trans_status_flags['rx%dlos' % lane] = rx_los[lane - 1]
+        for lane in range(1, len(tx_fault) + 1):
+            trans_status_flags['tx%dfault' % lane] = tx_fault[lane - 1]
+
+        return trans_status_flags
+
+    def get_transceiver_dom_real_value(self):
+        """
+        Retrieves DOM sensor values for this transceiver
+
+        The returned dictionary contains floating-point values corresponding to various
+        DOM sensor readings, as defined in the TRANSCEIVER_DOM_SENSOR table in STATE_DB.
+
+        Returns:
+            Dictionary
+        """
         temp = self.get_module_temperature()
         voltage = self.get_voltage()
         tx_bias = self.get_tx_bias()
@@ -118,6 +154,15 @@ class Sff8436Api(XcvrApi):
         return bulk_status
 
     def get_transceiver_threshold_info(self):
+        """
+        Retrieves threshold info for this xcvr
+
+        The returned dictionary contains floating-point values corresponding to various
+        DOM sensor threshold readings, as defined in the TRANSCEIVER_DOM_THRESHOLD table in STATE_DB.
+
+        Returns:
+            Dictionary
+        """
         threshold_info_keys = ['temphighalarm',    'temphighwarning',
                                'templowalarm',     'templowwarning',
                                'vcchighalarm',     'vcchighwarning',

--- a/sonic_platform_base/sonic_xcvr/api/public/sff8472.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/sff8472.py
@@ -61,29 +61,65 @@ class Sff8472Api(XcvrApi):
         return xcvr_info
 
     def get_transceiver_status(self):
-        rx_los = self.get_rx_los()
-        tx_fault = self.get_tx_fault()
+        """
+        Retrieves the current status of the transceiver module.
+
+        Accesses non-latched registers to gather information about the TX statuses.
+
+        Returns:
+            dict: A dictionary containing boolean values for various status fields, as defined in
+                the TRANSCEIVER_STATUS table in STATE_DB.
+        """
         tx_disable = self.get_tx_disable()
         tx_disabled_channel = self.get_tx_disable_channel()
-        read_failed = rx_los is None or \
-                      tx_fault is None or \
-                      tx_disable is None or \
+        read_failed = tx_disable is None or \
                       tx_disabled_channel is None
         if read_failed:
             return None
 
         trans_status = dict()
-        for lane in range(1, len(rx_los) + 1):
-            trans_status['rxlos%d' % lane] = rx_los[lane - 1]
-        for lane in range(1, len(tx_fault) + 1):
-            trans_status['txfault%d' % lane] = tx_fault[lane - 1]
         for lane in range(1, len(tx_disable) + 1):
             trans_status['tx%ddisable' % lane] = tx_disable[lane - 1]
         trans_status['tx_disabled_channel'] = tx_disabled_channel
 
         return trans_status
 
-    def get_transceiver_bulk_status(self):
+    def get_transceiver_status_flags(self):
+        """
+        Retrieves the current flag status of the transceiver module.
+
+        Accesses non-latched registers to gather TX and RX-related flags. Unlike other
+        module types, SFF-8472 does not support latched registers for these flags.
+
+        Returns:
+            dict: A dictionary containing boolean values for various flags, as defined in
+                the TRANSCEIVER_STATUS_FLAGS table in STATE_DB.
+        """
+        rx_los = self.get_rx_los()
+        tx_fault = self.get_tx_fault()
+        read_failed = rx_los is None or \
+                      tx_fault is None
+        if read_failed:
+            return None
+
+        trans_status_flags = dict()
+        for lane in range(1, len(rx_los) + 1):
+            trans_status_flags['rx%dlos' % lane] = rx_los[lane - 1]
+        for lane in range(1, len(tx_fault) + 1):
+            trans_status_flags['tx%dfault' % lane] = tx_fault[lane - 1]
+
+        return trans_status_flags
+
+    def get_transceiver_dom_real_value(self):
+        """
+        Retrieves DOM sensor values for this transceiver
+
+        The returned dictionary contains floating-point values corresponding to various
+        DOM sensor readings, as defined in the TRANSCEIVER_DOM_SENSOR table in STATE_DB.
+
+        Returns:
+            Dictionary
+        """
         temp = self.get_module_temperature()
         voltage = self.get_voltage()
         tx_bias = self.get_tx_bias()
@@ -116,6 +152,15 @@ class Sff8472Api(XcvrApi):
         return bulk_status
 
     def get_transceiver_threshold_info(self):
+        """
+        Retrieves threshold info for this xcvr
+
+        The returned dictionary contains floating-point values corresponding to various
+        DOM sensor threshold readings, as defined in the TRANSCEIVER_DOM_THRESHOLD table in STATE_DB.
+
+        Returns:
+            Dictionary
+        """
         threshold_info_keys = ['temphighalarm',    'temphighwarning',
                                'templowalarm',     'templowwarning',
                                'vcchighalarm',     'vcchighwarning',

--- a/sonic_platform_base/sonic_xcvr/api/public/sff8636.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/sff8636.py
@@ -76,29 +76,64 @@ class Sff8636Api(XcvrApi):
         return xcvr_info
 
     def get_transceiver_status(self):
-        rx_los = self.get_rx_los()
-        tx_fault = self.get_tx_fault()
+        """
+        Retrieves the current status of the transceiver module.
+
+        Accesses non-latched registers to gather information about the TX statuses.
+
+        Returns:
+            dict: A dictionary containing boolean values for various status fields, as defined in
+                the TRANSCEIVER_STATUS table in STATE_DB.
+        """
         tx_disable = self.get_tx_disable()
         tx_disabled_channel = self.get_tx_disable_channel()
-        read_failed = rx_los is None or \
-                      tx_fault is None or \
-                      tx_disable is None or \
+        read_failed = tx_disable is None or \
                       tx_disabled_channel is None
         if read_failed:
             return None
 
         trans_status = dict()
-        for lane in range(1, len(rx_los) + 1):
-            trans_status['rxlos%d' % lane] = rx_los[lane - 1]
-        for lane in range(1, len(tx_fault) + 1):
-            trans_status['txfault%d' % lane] = tx_fault[lane - 1]
         for lane in range(1, len(tx_disable) + 1):
             trans_status['tx%ddisable' % lane] = tx_disable[lane - 1]
         trans_status['tx_disabled_channel'] = tx_disabled_channel
 
         return trans_status
 
-    def get_transceiver_bulk_status(self):
+    def get_transceiver_status_flags(self):
+        """
+        Retrieves the current flag status of the transceiver module.
+
+        Accesses latched registers to gather information about TX and RX related flags.
+
+        Returns:
+            dict: A dictionary containing boolean values for various flags, as defined in
+                the TRANSCEIVER_STATUS_FLAGS table in STATE_DB.
+        """
+        rx_los = self.get_rx_los()
+        tx_fault = self.get_tx_fault()
+        read_failed = rx_los is None or \
+                      tx_fault is None
+        if read_failed:
+            return None
+
+        trans_status_flags = dict()
+        for lane in range(1, len(rx_los) + 1):
+            trans_status_flags['rx%dlos' % lane] = rx_los[lane - 1]
+        for lane in range(1, len(tx_fault) + 1):
+            trans_status_flags['tx%dfault' % lane] = tx_fault[lane - 1]
+
+        return trans_status_flags
+
+    def get_transceiver_dom_real_value(self):
+        """
+        Retrieves DOM sensor values for this transceiver
+
+        The returned dictionary contains floating-point values corresponding to various
+        DOM sensor readings, as defined in the TRANSCEIVER_DOM_SENSOR table in STATE_DB.
+
+        Returns:
+            Dictionary
+        """
         temp = self.get_module_temperature()
         voltage = self.get_voltage()
         tx_bias = self.get_tx_bias()
@@ -125,6 +160,15 @@ class Sff8636Api(XcvrApi):
         return bulk_status
 
     def get_transceiver_threshold_info(self):
+        """
+        Retrieves threshold info for this xcvr
+
+        The returned dictionary contains floating-point values corresponding to various
+        DOM sensor threshold readings, as defined in the TRANSCEIVER_DOM_THRESHOLD table in STATE_DB.
+
+        Returns:
+            Dictionary
+        """
         threshold_info_keys = ['temphighalarm',    'temphighwarning',
                                'templowalarm',     'templowwarning',
                                'vcchighalarm',     'vcchighwarning',

--- a/sonic_platform_base/sonic_xcvr/api/xcvr_api.py
+++ b/sonic_platform_base/sonic_xcvr/api/xcvr_api.py
@@ -80,9 +80,12 @@ class XcvrApi(object):
         """
         raise NotImplementedError
 
-    def get_transceiver_bulk_status(self):
+    def get_transceiver_dom_real_value(self):
         """
-        Retrieves bulk status info for this xcvr
+        Retrieves DOM sensor values for this transceiver
+
+        The returned dictionary contains floating-point values corresponding to various
+        DOM sensor readings, as defined in the TRANSCEIVER_DOM_SENSOR table in STATE_DB.
 
         Returns:
             A dict containing the following keys/values :
@@ -107,14 +110,21 @@ class XcvrApi(object):
         """
         Retrieves the DOM flags for this xcvr
 
+        The returned dictionary contains boolean values representing various DOM flags.
+        All registers accessed by this function are latched and correspond to the
+        TRANSCEIVER_DOM_FLAG table in the STATE_DB.
+
         Returns:
-            A dict containing dom flags for this xcvr
+            Dictionary
         """
         raise NotImplementedError
 
     def get_transceiver_threshold_info(self):
         """
         Retrieves threshold info for this xcvr
+
+        The returned dictionary contains floating-point values corresponding to various
+        DOM sensor threshold readings, as defined in the TRANSCEIVER_DOM_THRESHOLD table in STATE_DB.
 
         Returns:
             A dict containing the following keys/values :
@@ -149,111 +159,28 @@ class XcvrApi(object):
 
     def get_transceiver_status(self):
         """
-        Retrieves transceiver status of this SFP
+        Retrieves the current status of the transceiver module.
+
+        Accesses non-latched registers to gather information about the module's state,
+        fault causes, and datapath-level statuses, including TX and RX statuses.
 
         Returns:
-            A dict which may contain following keys/values (there could be more for C-CMIS) :
-        ================================================================================
-        key                          = TRANSCEIVER_STATUS|ifname        ; Error information for module on port
-        ; field                      = value
-        module_state                 = 1*255VCHAR                       ; current module state (ModuleLowPwr, ModulePwrUp, ModuleReady, ModulePwrDn, Fault)
-        module_fault_cause           = 1*255VCHAR                       ; reason of entering the module fault state
-        datapath_firmware_fault      = BOOLEAN                          ; datapath (DSP) firmware fault
-        module_firmware_fault        = BOOLEAN                          ; module firmware fault
-        module_state_changed         = BOOLEAN                          ; module state changed
-        datapath_hostlane1           = 1*255VCHAR                       ; data path state indicator on host lane 1
-        datapath_hostlane2           = 1*255VCHAR                       ; data path state indicator on host lane 2
-        datapath_hostlane3           = 1*255VCHAR                       ; data path state indicator on host lane 3
-        datapath_hostlane4           = 1*255VCHAR                       ; data path state indicator on host lane 4
-        datapath_hostlane5           = 1*255VCHAR                       ; data path state indicator on host lane 5
-        datapath_hostlane6           = 1*255VCHAR                       ; data path state indicator on host lane 6
-        datapath_hostlane7           = 1*255VCHAR                       ; data path state indicator on host lane 7
-        datapath_hostlane8           = 1*255VCHAR                       ; data path state indicator on host lane 8
-        txoutput_status              = BOOLEAN                          ; tx output status on media lane
-        rxoutput_status_hostlane1    = BOOLEAN                          ; rx output status on host lane 1
-        rxoutput_status_hostlane2    = BOOLEAN                          ; rx output status on host lane 2
-        rxoutput_status_hostlane3    = BOOLEAN                          ; rx output status on host lane 3
-        rxoutput_status_hostlane4    = BOOLEAN                          ; rx output status on host lane 4
-        rxoutput_status_hostlane5    = BOOLEAN                          ; rx output status on host lane 5
-        rxoutput_status_hostlane6    = BOOLEAN                          ; rx output status on host lane 6
-        rxoutput_status_hostlane7    = BOOLEAN                          ; rx output status on host lane 7
-        rxoutput_status_hostlane8    = BOOLEAN                          ; rx output status on host lane 8
-        txfault                      = BOOLEAN                          ; tx fault flag on media lane
-        txlos_hostlane1              = BOOLEAN                          ; tx loss of signal flag on host lane 1
-        txlos_hostlane2              = BOOLEAN                          ; tx loss of signal flag on host lane 2
-        txlos_hostlane3              = BOOLEAN                          ; tx loss of signal flag on host lane 3
-        txlos_hostlane4              = BOOLEAN                          ; tx loss of signal flag on host lane 4
-        txlos_hostlane5              = BOOLEAN                          ; tx loss of signal flag on host lane 5
-        txlos_hostlane6              = BOOLEAN                          ; tx loss of signal flag on host lane 6
-        txlos_hostlane7              = BOOLEAN                          ; tx loss of signal flag on host lane 7
-        txlos_hostlane8              = BOOLEAN                          ; tx loss of signal flag on host lane 8
-        txcdrlol_hostlane1           = BOOLEAN                          ; tx clock and data recovery loss of lock on host lane 1
-        txcdrlol_hostlane2           = BOOLEAN                          ; tx clock and data recovery loss of lock on host lane 2
-        txcdrlol_hostlane3           = BOOLEAN                          ; tx clock and data recovery loss of lock on host lane 3
-        txcdrlol_hostlane4           = BOOLEAN                          ; tx clock and data recovery loss of lock on host lane 4
-        txcdrlol_hostlane5           = BOOLEAN                          ; tx clock and data recovery loss of lock on host lane 5
-        txcdrlol_hostlane6           = BOOLEAN                          ; tx clock and data recovery loss of lock on host lane 6
-        txcdrlol_hostlane7           = BOOLEAN                          ; tx clock and data recovery loss of lock on host lane 7
-        txcdrlol_hostlane8           = BOOLEAN                          ; tx clock and data recovery loss of lock on host lane 8
-        rxlos                        = BOOLEAN                          ; rx loss of signal flag on media lane
-        rxcdrlol                     = BOOLEAN                          ; rx clock and data recovery loss of lock on media lane
-        config_state_hostlane1       = 1*255VCHAR                       ; configuration status for the data path of host line 1
-        config_state_hostlane2       = 1*255VCHAR                       ; configuration status for the data path of host line 2
-        config_state_hostlane3       = 1*255VCHAR                       ; configuration status for the data path of host line 3
-        config_state_hostlane4       = 1*255VCHAR                       ; configuration status for the data path of host line 4
-        config_state_hostlane5       = 1*255VCHAR                       ; configuration status for the data path of host line 5
-        config_state_hostlane6       = 1*255VCHAR                       ; configuration status for the data path of host line 6
-        config_state_hostlane7       = 1*255VCHAR                       ; configuration status for the data path of host line 7
-        config_state_hostlane8       = 1*255VCHAR                       ; configuration status for the data path of host line 8
-        dpinit_pending_hostlane1     = BOOLEAN                          ; data path configuration updated on host lane 1
-        dpinit_pending_hostlane2     = BOOLEAN                          ; data path configuration updated on host lane 2
-        dpinit_pending_hostlane3     = BOOLEAN                          ; data path configuration updated on host lane 3
-        dpinit_pending_hostlane4     = BOOLEAN                          ; data path configuration updated on host lane 4
-        dpinit_pending_hostlane5     = BOOLEAN                          ; data path configuration updated on host lane 5
-        dpinit_pending_hostlane6     = BOOLEAN                          ; data path configuration updated on host lane 6
-        dpinit_pending_hostlane7     = BOOLEAN                          ; data path configuration updated on host lane 7
-        dpinit_pending_hostlane8     = BOOLEAN                          ; data path configuration updated on host lane 8
-        temphighalarm_flag           = BOOLEAN                          ; temperature high alarm flag
-        temphighwarning_flag         = BOOLEAN                          ; temperature high warning flag
-        templowalarm_flag            = BOOLEAN                          ; temperature low alarm flag
-        templowwarning_flag          = BOOLEAN                          ; temperature low warning flag
-        vcchighalarm_flag            = BOOLEAN                          ; vcc high alarm flag
-        vcchighwarning_flag          = BOOLEAN                          ; vcc high warning flag
-        vcclowalarm_flag             = BOOLEAN                          ; vcc low alarm flag
-        vcclowwarning_flag           = BOOLEAN                          ; vcc low warning flag
-        txpowerhighalarm_flag        = BOOLEAN                          ; tx power high alarm flag
-        txpowerlowalarm_flag         = BOOLEAN                          ; tx power low alarm flag
-        txpowerhighwarning_flag      = BOOLEAN                          ; tx power high warning flag
-        txpowerlowwarning_flag       = BOOLEAN                          ; tx power low alarm flag
-        rxpowerhighalarm_flag        = BOOLEAN                          ; rx power high alarm flag
-        rxpowerlowalarm_flag         = BOOLEAN                          ; rx power low alarm flag
-        rxpowerhighwarning_flag      = BOOLEAN                          ; rx power high warning flag
-        rxpowerlowwarning_flag       = BOOLEAN                          ; rx power low warning flag
-        txbiashighalarm_flag         = BOOLEAN                          ; tx bias high alarm flag
-        txbiaslowalarm_flag          = BOOLEAN                          ; tx bias low alarm flag
-        txbiashighwarning_flag       = BOOLEAN                          ; tx bias high warning flag
-        txbiaslowwarning_flag        = BOOLEAN                          ; tx bias low warning flag
-        lasertemphighalarm_flag      = BOOLEAN                          ; laser temperature high alarm flag
-        lasertemplowalarm_flag       = BOOLEAN                          ; laser temperature low alarm flag
-        lasertemphighwarning_flag    = BOOLEAN                          ; laser temperature high warning flag
-        lasertemplowwarning_flag     = BOOLEAN                          ; laser temperature low warning flag
-        prefecberhighalarm_flag      = BOOLEAN                          ; prefec ber high alarm flag
-        prefecberlowalarm_flag       = BOOLEAN                          ; prefec ber low alarm flag
-        prefecberhighwarning_flag    = BOOLEAN                          ; prefec ber high warning flag
-        prefecberlowwarning_flag     = BOOLEAN                          ; prefec ber low warning flag
-        postfecberhighalarm_flag     = BOOLEAN                          ; postfec ber high alarm flag
-        postfecberlowalarm_flag      = BOOLEAN                          ; postfec ber low alarm flag
-        postfecberhighwarning_flag   = BOOLEAN                          ; postfec ber high warning flag
-        postfecberlowwarning_flag    = BOOLEAN                          ; postfec ber low warning flag
-        ================================================================================
-
+            dict: A dictionary containing boolean values for various status fields, as defined in
+                the TRANSCEIVER_STATUS table in STATE_DB.
         If there is an issue with reading the xcvr, None should be returned.
         """
         raise NotImplementedError
 
     def get_transceiver_status_flags(self):
         """
-        Retrieves status flags of this xcvr
+        Retrieves the current flag status of the transceiver module.
+
+        Accesses latched registers to gather information about both
+        module-level and datapath-level states (including TX/RX related flags).
+
+        Returns:
+            dict: A dictionary containing boolean values for various flags, as defined in
+                the TRANSCEIVER_STATUS_FLAGS table in STATE_DB.
         """
         raise NotImplementedError
 

--- a/sonic_platform_base/sonic_xcvr/sfp_optoe_base.py
+++ b/sonic_platform_base/sonic_xcvr/sfp_optoe_base.py
@@ -31,9 +31,9 @@ class SfpOptoeBase(SfpBase):
         api = self.get_xcvr_api()
         return api.get_transceiver_info_firmware_versions() if api is not None else None
 
-    def get_transceiver_bulk_status(self):
+    def get_transceiver_dom_real_value(self):
         api = self.get_xcvr_api()
-        return api.get_transceiver_bulk_status() if api is not None else None
+        return api.get_transceiver_dom_real_value() if api is not None else None
 
     def get_transceiver_dom_flags(self):
         api = self.get_xcvr_api()

--- a/tests/sonic_xcvr/test_ccmis.py
+++ b/tests/sonic_xcvr/test_ccmis.py
@@ -196,31 +196,6 @@ class TestCCmis(object):
                     'txpower': 0.1,
                     'rxpower': 0.09,
                     'txbias': 70,
-                    'laser_temperature': 40,
-                    'prefec_ber': 0.001,
-                    'postfec_ber': 0,
-                },
-                {
-                    'Pre-FEC BER Average Media Input':{1:[0.001, 0.0125, 0, 0.01, 0, False, False, False, False]},
-                    'Errored Frames Average Media Input':{1:[0, 1, 0, 1, 0, False, False, False, False]},
-                    'Modulator Bias X/I [%]':{1:[50, 90, 10, 85, 15, False, False, False, False]},
-                    'Modulator Bias X/Q [%]':{1:[50, 90, 10, 85, 15, False, False, False, False]},
-                    'Modulator Bias X_Phase [%]':{1:[50, 90, 10, 85, 15, False, False, False, False]},
-                    'Modulator Bias Y/I [%]':{1:[50, 90, 10, 85, 15, False, False, False, False]},
-                    'Modulator Bias Y/Q [%]':{1:[50, 90, 10, 85, 15, False, False, False, False]},
-                    'Modulator Bias Y_Phase [%]':{1:[50, 90, 10, 85, 15, False, False, False, False]},
-                    'CD high granularity, short link [ps/nm]':{1:[1000, 2000, 0, 1800, 0, False, False, False, False]},
-                    'CD low granularity, long link [ps/nm]':{1:[1000, 2000, 0, 1800, 0, False, False, False, False]},
-                    'DGD [ps]':{1:[5, 30, 0, 25, 0, False, False, False, False]},
-                    'SOPMD [ps^2]':{1:[5, 100, 0, 80, 0, False, False, False, False]},
-                    'SOP ROC [krad/s]':{1: [0, 65535, 0, 65535, 0, False, False, False, False]},
-                    'PDL [dB]':{1:[0.5, 3, 0, 2.5, 0, False, False, False, False]},
-                    'OSNR [dB]':{1:[30, 100, 26, 80, 27, False, False, False, False]},
-                    'eSNR [dB]':{1:[16, 100, 13, 80, 14, False, False, False, False]},
-                    'CFO [MHz]':{1:[100, 5000, -5000, 4000, -4000, False, False, False, False]},
-                    'Tx Power [dBm]':{1:[-10, 0, -18, -2, -16, False, False, False, False]},
-                    'Rx Total Power [dBm]':{1:[-10, 3, -18, 0, -15, False, False, False, False]},
-                    'Rx Signal Power [dBm]':{1:[-10, 3, -18, 0, -15, False, False, False, False]}
                 },
                 193100, 193100, -10
             ],
@@ -230,44 +205,22 @@ class TestCCmis(object):
                 'txpower': 0.1,
                 'rxpower': 0.09,
                 'txbias': 70,
-                'laser_temperature': 40,
-                'prefec_ber': 0.001,
-                'postfec_ber': 0,
-                'biasxi': 50,
-                'biasxq': 50,
-                'biasxp': 50,
-                'biasyi': 50,
-                'biasyq': 50,
-                'biasyp': 50,
-                'cdshort': 1000,
-                'cdlong': 1000,
-                'dgd': 5,
-                'sopmd': 5,
-                'soproc': 0,
-                'pdl': 0.5,
-                'osnr': 30,
-                'esnr': 16,
-                'cfo': 100,
-                'txcurrpower': -10,
-                'rxtotpower': -10,
-                'rxsigpower': -10,
                 'laser_config_freq': 193100,
                 'laser_curr_freq': 193100,
                 'tx_config_power': -10
             }
         )
     ])
-    @patch("sonic_platform_base.sonic_xcvr.api.public.cmis.CmisApi.get_transceiver_bulk_status")
-    def test_get_transceiver_bulk_status(self, get_transceiver_bulk_status_func, mock_response, expected):
-        get_transceiver_bulk_status_func.return_value = mock_response[0]
-        self.api.vdm_dict = mock_response[1]
+    @patch("sonic_platform_base.sonic_xcvr.api.public.cmis.CmisApi.get_transceiver_dom_real_value")
+    def test_get_transceiver_dom_real_value(self, get_transceiver_dom_real_value_func, mock_response, expected):
+        get_transceiver_dom_real_value_func.return_value = mock_response[0]
         self.api.get_laser_config_freq = MagicMock()
-        self.api.get_laser_config_freq.return_value = mock_response[2]
+        self.api.get_laser_config_freq.return_value = mock_response[1]
         self.api.get_current_laser_freq = MagicMock()
-        self.api.get_current_laser_freq.return_value = mock_response[3]
+        self.api.get_current_laser_freq.return_value = mock_response[2]
         self.api.get_tx_config_power = MagicMock()
-        self.api.get_tx_config_power.return_value = mock_response[4]
-        result = self.api.get_transceiver_bulk_status()
+        self.api.get_tx_config_power.return_value = mock_response[3]
+        result = self.api.get_transceiver_dom_real_value()
         assert result == expected
 
     @pytest.mark.parametrize("mock_response, expected",[
@@ -278,33 +231,8 @@ class TestCCmis(object):
                     'vcchighalarm': 3.5, 'vcclowalarm': 3.1, 'vcchighwarning': 3.45, 'vcclowwarning': 3.15,
                     'txpowerhighalarm': 1.0, 'txpowerlowalarm': 0.01, 'txpowerhighwarning': 0.7, 'txpowerlowwarning': 0.02,
                     'rxpowerhighalarm': 2.0, 'rxpowerlowalarm': 0.01, 'rxpowerhighwarning': 1.0, 'rxpowerlowwarning': 0.02,
-                    'txbiashighalarm': 90, 'txbiaslowalarm': 10, 'txbiashighwarning': 80, 'txbiaslowwarning': 20,
-                    'lasertemphighalarm': 80, 'lasertemplowalarm': 10, 'lasertemphighwarning': 75, 'lasertemplowwarning': 20,
-                    'prefecberhighalarm': 0.0125, 'prefecberlowalarm': 0, 'prefecberhighwarning': 0.01, 'prefecberlowwarning': 0,
-                    'postfecberhighalarm': 1, 'postfecberlowalarm': 0, 'postfecberhighwarning': 1, 'postfecberlowwarning': 0,
-                    'soprochighalarm' : 65535, 'soproclowalarm' : 0, 'soprochighwarning' : 65535, 'soproclowwarning' : 0,
+                    'txbiashighalarm': 90, 'txbiaslowalarm': 10, 'txbiashighwarning': 80, 'txbiaslowwarning': 20
                 },
-                {
-                    'Pre-FEC BER Average Media Input':{1:[0.001, 0.0125, 0, 0.01, 0, False, False, False, False]},
-                    'Errored Frames Average Media Input':{1:[0, 1, 0, 1, 0, False, False, False, False]},
-                    'Modulator Bias X/I [%]':{1:[50, 90, 10, 85, 15, False, False, False, False]},
-                    'Modulator Bias X/Q [%]':{1:[50, 90, 10, 85, 15, False, False, False, False]},
-                    'Modulator Bias X_Phase [%]':{1:[50, 90, 10, 85, 15, False, False, False, False]},
-                    'Modulator Bias Y/I [%]':{1:[50, 90, 10, 85, 15, False, False, False, False]},
-                    'Modulator Bias Y/Q [%]':{1:[50, 90, 10, 85, 15, False, False, False, False]},
-                    'Modulator Bias Y_Phase [%]':{1:[50, 90, 10, 85, 15, False, False, False, False]},
-                    'CD high granularity, short link [ps/nm]':{1:[1000, 2000, 0, 1800, 0, False, False, False, False]},
-                    'CD low granularity, long link [ps/nm]':{1:[1000, 2000, 0, 1800, 0, False, False, False, False]},
-                    'DGD [ps]':{1:[5, 30, 0, 25, 0, False, False, False, False]},
-                    'SOPMD [ps^2]':{1:[5, 100, 0, 80, 0, False, False, False, False]},
-                    'SOP ROC [krad/s]':{1: [0, 65535, 0, 65535, 0, False, False, False, False]},
-                    'PDL [dB]':{1:[0.5, 3, 0, 2.5, 0, False, False, False, False]},
-                    'OSNR [dB]':{1:[30, 100, 26, 80, 27, False, False, False, False]},
-                    'eSNR [dB]':{1:[16, 100, 13, 80, 14, False, False, False, False]},
-                    'CFO [MHz]':{1:[100, 5000, -5000, 4000, -4000, False, False, False, False]},
-                    'Tx Power [dBm]':{1:[-10, 0, -18, -2, -16, False, False, False, False]},
-                    'Rx Total Power [dBm]':{1:[-10, 3, -18, 0, -15, False, False, False, False]},
-                }
             ],
             {
                 'temphighalarm': 80, 'templowalarm': 0, 'temphighwarning': 75, 'templowwarning': 10,
@@ -312,34 +240,12 @@ class TestCCmis(object):
                 'txpowerhighalarm': 1.0, 'txpowerlowalarm': 0.01, 'txpowerhighwarning': 0.7, 'txpowerlowwarning': 0.02,
                 'rxpowerhighalarm': 2.0, 'rxpowerlowalarm': 0.01, 'rxpowerhighwarning': 1.0, 'rxpowerlowwarning': 0.02,
                 'txbiashighalarm': 90, 'txbiaslowalarm': 10, 'txbiashighwarning': 80, 'txbiaslowwarning': 20,
-                'lasertemphighalarm': 80, 'lasertemplowalarm': 10, 'lasertemphighwarning': 75, 'lasertemplowwarning': 20,
-                'prefecberhighalarm': 0.0125, 'prefecberlowalarm': 0, 'prefecberhighwarning': 0.01, 'prefecberlowwarning': 0,
-                'postfecberhighalarm': 1, 'postfecberlowalarm': 0, 'postfecberhighwarning': 1, 'postfecberlowwarning': 0,
-                'biasxihighalarm': 90, 'biasxilowalarm': 10, 'biasxihighwarning': 85, 'biasxilowwarning': 15,
-                'biasxqhighalarm': 90, 'biasxqlowalarm': 10, 'biasxqhighwarning': 85, 'biasxqlowwarning': 15,
-                'biasxphighalarm': 90, 'biasxplowalarm': 10, 'biasxphighwarning': 85, 'biasxplowwarning': 15,
-                'biasyihighalarm': 90, 'biasyilowalarm': 10, 'biasyihighwarning': 85, 'biasyilowwarning': 15,
-                'biasyqhighalarm': 90, 'biasyqlowalarm': 10, 'biasyqhighwarning': 85, 'biasyqlowwarning': 15,
-                'biasyphighalarm': 90, 'biasyplowalarm': 10, 'biasyphighwarning': 85, 'biasyplowwarning': 15,
-                'cdshorthighalarm': 2000, 'cdshortlowalarm': 0, 'cdshorthighwarning': 1800, 'cdshortlowwarning': 0,
-                'cdlonghighalarm': 2000, 'cdlonglowalarm': 0, 'cdlonghighwarning': 1800, 'cdlonglowwarning': 0,
-                'dgdhighalarm': 30, 'dgdlowalarm': 0, 'dgdhighwarning': 25, 'dgdlowwarning': 0,
-                'sopmdhighalarm': 100, 'sopmdlowalarm': 0, 'sopmdhighwarning': 80, 'sopmdlowwarning': 0,
-                'pdlhighalarm': 3, 'pdllowalarm': 0, 'pdlhighwarning': 2.5, 'pdllowwarning': 0,
-                'osnrhighalarm': 100, 'osnrlowalarm': 26, 'osnrhighwarning': 80, 'osnrlowwarning': 27,
-                'esnrhighalarm': 100, 'esnrlowalarm': 13, 'esnrhighwarning': 80, 'esnrlowwarning': 14,
-                'cfohighalarm': 5000, 'cfolowalarm': -5000, 'cfohighwarning': 4000, 'cfolowwarning': -4000,
-                'txcurrpowerhighalarm': 0, 'txcurrpowerlowalarm': -18, 'txcurrpowerhighwarning': -2, 'txcurrpowerlowwarning': -16,
-                'rxtotpowerhighalarm': 3, 'rxtotpowerlowalarm': -18, 'rxtotpowerhighwarning': 0, 'rxtotpowerlowwarning': -15,
-                'rxsigpowerhighalarm': 'N/A', 'rxsigpowerlowalarm': 'N/A', 'rxsigpowerhighwarning': 'N/A', 'rxsigpowerlowwarning': 'N/A',
-                'soprochighalarm': 65535, 'soproclowalarm': 0, 'soprochighwarning': 65535, 'soproclowwarning': 0
             }
         )
     ])
     @patch("sonic_platform_base.sonic_xcvr.api.public.cmis.CmisApi.get_transceiver_threshold_info")
     def test_get_transceiver_threshold_info(self, get_transceiver_threshold_info_func, mock_response, expected):
         get_transceiver_threshold_info_func.return_value = mock_response[0]
-        self.api.vdm_dict = mock_response[1]
         result = self.api.get_transceiver_threshold_info()
         assert result == expected
 
@@ -369,25 +275,6 @@ class TestCCmis(object):
                     'rxoutput_status_hostlane6': True,
                     'rxoutput_status_hostlane7': True,
                     'rxoutput_status_hostlane8': True,
-                    'txfault': False,
-                    'txlos_hostlane1': False,
-                    'txlos_hostlane2': False,
-                    'txlos_hostlane3': False,
-                    'txlos_hostlane4': False,
-                    'txlos_hostlane5': False,
-                    'txlos_hostlane6': False,
-                    'txlos_hostlane7': False,
-                    'txlos_hostlane8': False,
-                    'txcdrlol_hostlane1': False,
-                    'txcdrlol_hostlane2': False,
-                    'txcdrlol_hostlane3': False,
-                    'txcdrlol_hostlane4': False,
-                    'txcdrlol_hostlane5': False,
-                    'txcdrlol_hostlane6': False,
-                    'txcdrlol_hostlane7': False,
-                    'txcdrlol_hostlane8': False,
-                    'rxlos': False,
-                    'rxcdrlol': False,
                     'config_state_hostlane1': 'ConfigSuccess',
                     'config_state_hostlane2': 'ConfigSuccess',
                     'config_state_hostlane3': 'ConfigSuccess',
@@ -404,48 +291,8 @@ class TestCCmis(object):
                     'dpinit_pending_hostlane6': False,
                     'dpinit_pending_hostlane7': False,
                     'dpinit_pending_hostlane8': False,
-                    'temphighalarm_flag': False, 'templowalarm_flag': False, 
-                    'temphighwarning_flag': False, 'templowwarning_flag': False,
-                    'vcchighalarm_flag': False, 'vcclowalarm_flag': False, 
-                    'vcchighwarning_flag': False, 'vcclowwarning_flag': False,
-                    'lasertemphighalarm_flag': False, 'lasertemplowalarm_flag': False, 
-                    'lasertemphighwarning_flag': False, 'lasertemplowwarning_flag': False,
-                    'txpowerhighalarm_flag': False, 'txpowerlowalarm_flag': False, 
-                    'txpowerhighwarning_flag': False, 'txpowerlowwarning_flag': False,
-                    'rxpowerhighalarm_flag': False, 'rxpowerlowalarm_flag': False, 
-                    'rxpowerhighwarning_flag': False, 'rxpowerlowwarning_flag': False,
-                    'txbiashighalarm_flag': False, 'txbiaslowalarm_flag': False, 
-                    'txbiashighwarning_flag': False, 'txbiaslowwarning_flag': False,
-                    'prefecberhighalarm_flag': False, 'prefecberlowalarm_flag': False, 
-                    'prefecberhighwarning_flag': False, 'prefecberlowwarning_flag': False,
-                    'postfecberhighalarm_flag': False, 'postfecberlowalarm_flag': False, 
-                    'postfecberhighwarning_flag': False, 'postfecberlowwarning_flag': False,
-                    'soprochighalarm_flag' : False, 'soproclowalarm_flag' : False,
-                    'soprochighwarning_flag' : False, 'soproclowwarning_flag' : False,
                 },
-                False, False, ['TuningComplete'],
-                {
-                    'Pre-FEC BER Average Media Input':{1:[0.001, 0.0125, 0, 0.01, 0, False, False, False, False]},
-                    'Errored Frames Average Media Input':{1:[0, 1, 0, 1, 0, False, False, False, False]},
-                    'Modulator Bias X/I [%]':{1:[50, 90, 10, 85, 15, False, False, False, False]},
-                    'Modulator Bias X/Q [%]':{1:[50, 90, 10, 85, 15, False, False, False, False]},
-                    'Modulator Bias X_Phase [%]':{1:[50, 90, 10, 85, 15, False, False, False, False]},
-                    'Modulator Bias Y/I [%]':{1:[50, 90, 10, 85, 15, False, False, False, False]},
-                    'Modulator Bias Y/Q [%]':{1:[50, 90, 10, 85, 15, False, False, False, False]},
-                    'Modulator Bias Y_Phase [%]':{1:[50, 90, 10, 85, 15, False, False, False, False]},
-                    'CD high granularity, short link [ps/nm]':{1:[1000, 2000, 0, 1800, 0, False, False, False, False]},
-                    'CD low granularity, long link [ps/nm]':{1:[1000, 2000, 0, 1800, 0, False, False, False, False]},
-                    'DGD [ps]':{1:[5, 30, 0, 25, 0, False, False, False, False]},
-                    'SOPMD [ps^2]':{1:[5, 100, 0, 80, 0, False, False, False, False]},
-                    'SOP ROC [krad/s]':{1: [0, 65535, 0, 65535, 0, False, False, False, False]},
-                    'PDL [dB]':{1:[0.5, 3, 0, 2.5, 0, False, False, False, False]},
-                    'OSNR [dB]':{1:[30, 100, 26, 80, 27, False, False, False, False]},
-                    'eSNR [dB]':{1:[16, 100, 13, 80, 14, False, False, False, False]},
-                    'CFO [MHz]':{1:[100, 5000, -5000, 4000, -4000, False, False, False, False]},
-                    'Tx Power [dBm]':{1:[-10, 0, -18, -2, -16, False, False, False, False]},
-                    'Rx Total Power [dBm]':{1:[-10, 3, -18, 0, -15, False, False, False, False]},
-                    'Rx Signal Power [dBm]':{1:[-10, 3, -18, 0, -15, False, False, False, False]}
-                }
+                False, False,
             ],
             {
                 'module_state': 'ModuleReady',
@@ -470,25 +317,6 @@ class TestCCmis(object):
                 'rxoutput_status_hostlane6': True,
                 'rxoutput_status_hostlane7': True,
                 'rxoutput_status_hostlane8': True,
-                'txfault': False,
-                'txlos_hostlane1': False,
-                'txlos_hostlane2': False,
-                'txlos_hostlane3': False,
-                'txlos_hostlane4': False,
-                'txlos_hostlane5': False,
-                'txlos_hostlane6': False,
-                'txlos_hostlane7': False,
-                'txlos_hostlane8': False,
-                'txcdrlol_hostlane1': False,
-                'txcdrlol_hostlane2': False,
-                'txcdrlol_hostlane3': False,
-                'txcdrlol_hostlane4': False,
-                'txcdrlol_hostlane5': False,
-                'txcdrlol_hostlane6': False,
-                'txcdrlol_hostlane7': False,
-                'txcdrlol_hostlane8': False,
-                'rxlos': False,
-                'rxcdrlol': False,
                 'config_state_hostlane1': 'ConfigSuccess',
                 'config_state_hostlane2': 'ConfigSuccess',
                 'config_state_hostlane3': 'ConfigSuccess',
@@ -507,63 +335,6 @@ class TestCCmis(object):
                 'dpinit_pending_hostlane8': False,
                 'tuning_in_progress': False,
                 'wavelength_unlock_status': False,
-                'target_output_power_oor': False,
-                'fine_tuning_oor': False,
-                'tuning_not_accepted': False,
-                'invalid_channel_num': False,
-                'tuning_complete': True,
-                'temphighalarm_flag': False, 'templowalarm_flag': False, 
-                'temphighwarning_flag': False, 'templowwarning_flag': False,
-                'vcchighalarm_flag': False, 'vcclowalarm_flag': False, 
-                'vcchighwarning_flag': False, 'vcclowwarning_flag': False,
-                'lasertemphighalarm_flag': False, 'lasertemplowalarm_flag': False, 
-                'lasertemphighwarning_flag': False, 'lasertemplowwarning_flag': False,
-                'txpowerhighalarm_flag': False, 'txpowerlowalarm_flag': False, 
-                'txpowerhighwarning_flag': False, 'txpowerlowwarning_flag': False,
-                'rxpowerhighalarm_flag': False, 'rxpowerlowalarm_flag': False, 
-                'rxpowerhighwarning_flag': False, 'rxpowerlowwarning_flag': False,
-                'txbiashighalarm_flag': False, 'txbiaslowalarm_flag': False, 
-                'txbiashighwarning_flag': False, 'txbiaslowwarning_flag': False,
-                'prefecberhighalarm_flag': False, 'prefecberlowalarm_flag': False, 
-                'prefecberhighwarning_flag': False, 'prefecberlowwarning_flag': False,
-                'postfecberhighalarm_flag': False, 'postfecberlowalarm_flag': False, 
-                'postfecberhighwarning_flag': False, 'postfecberlowwarning_flag': False,
-                'biasxihighalarm_flag': False, 'biasxilowalarm_flag': False, 
-                'biasxihighwarning_flag': False, 'biasxilowwarning_flag': False,
-                'biasxqhighalarm_flag': False, 'biasxqlowalarm_flag': False, 
-                'biasxqhighwarning_flag': False, 'biasxqlowwarning_flag': False,
-                'biasxphighalarm_flag': False, 'biasxplowalarm_flag': False, 
-                'biasxphighwarning_flag': False, 'biasxplowwarning_flag': False,
-                'biasyihighalarm_flag': False, 'biasyilowalarm_flag': False, 
-                'biasyihighwarning_flag': False, 'biasyilowwarning_flag': False,
-                'biasyqhighalarm_flag': False, 'biasyqlowalarm_flag': False, 
-                'biasyqhighwarning_flag': False, 'biasyqlowwarning_flag': False,
-                'biasyphighalarm_flag': False, 'biasyplowalarm_flag': False, 
-                'biasyphighwarning_flag': False, 'biasyplowwarning_flag': False,
-                'cdshorthighalarm_flag': False, 'cdshortlowalarm_flag': False, 
-                'cdshorthighwarning_flag': False, 'cdshortlowwarning_flag': False,
-                'cdlonghighalarm_flag': False, 'cdlonglowalarm_flag': False, 
-                'cdlonghighwarning_flag': False, 'cdlonglowwarning_flag': False,
-                'dgdhighalarm_flag': False, 'dgdlowalarm_flag': False, 
-                'dgdhighwarning_flag': False, 'dgdlowwarning_flag': False,
-                'sopmdhighalarm_flag': False, 'sopmdlowalarm_flag': False, 
-                'sopmdhighwarning_flag': False, 'sopmdlowwarning_flag': False,
-                'pdlhighalarm_flag': False, 'pdllowalarm_flag': False, 
-                'pdlhighwarning_flag': False, 'pdllowwarning_flag': False,
-                'osnrhighalarm_flag': False, 'osnrlowalarm_flag': False, 
-                'osnrhighwarning_flag': False, 'osnrlowwarning_flag': False,
-                'esnrhighalarm_flag': False, 'esnrlowalarm_flag': False, 
-                'esnrhighwarning_flag': False, 'esnrlowwarning_flag': False,
-                'cfohighalarm_flag': False, 'cfolowalarm_flag': False, 
-                'cfohighwarning_flag': False, 'cfolowwarning_flag': False,
-                'txcurrpowerhighalarm_flag': False, 'txcurrpowerlowalarm_flag': False, 
-                'txcurrpowerhighwarning_flag': False, 'txcurrpowerlowwarning_flag': False,
-                'rxtotpowerhighalarm_flag': False, 'rxtotpowerlowalarm_flag': False, 
-                'rxtotpowerhighwarning_flag': False, 'rxtotpowerlowwarning_flag': False,
-                'rxsigpowerhighalarm_flag': False, 'rxsigpowerlowalarm_flag': False, 
-                'rxsigpowerhighwarning_flag': False, 'rxsigpowerlowwarning_flag': False,
-                'soprochighalarm_flag' : False, 'soproclowalarm_flag' : False,
-                'soprochighwarning_flag' : False, 'soproclowwarning_flag' : False
             }
         )
     ])
@@ -574,11 +345,95 @@ class TestCCmis(object):
         self.api.get_tuning_in_progress.return_value = mock_response[1]
         self.api.get_wavelength_unlocked = MagicMock()
         self.api.get_wavelength_unlocked.return_value = mock_response[2]
-        self.api.get_laser_tuning_summary = MagicMock()
-        self.api.get_laser_tuning_summary.return_value = mock_response[3]
-        self.api.vdm_dict = mock_response[4]
         result = self.api.get_transceiver_status()
         assert result == expected
+
+    @pytest.mark.parametrize(
+        "module_faults, tx_fault, tx_los, tx_cdr_lol, tx_eq_fault, rx_los, rx_cdr_lol, laser_tuning_summary, expected_result",
+        [
+            # Test case 1: All flags present for lanes 1 to 8
+            (
+                (True, False, True),
+                [True, False, True, False, True, False, True, False],
+                [False, True, False, True, False, True, False, True],
+                [True, False, True, False, True, False, True, False],
+                [False, True, False, True, False, True, False, True],
+                [True, False, True, False, True, False, True, False],
+                [False, True, False, True, False, True, False, True],
+                ['TargetOutputPowerOOR', 'FineTuningOutOfRange', 'TuningNotAccepted', 'InvalidChannel', 'TuningComplete'],
+                {
+                    'datapath_firmware_fault': True,
+                    'module_firmware_fault': False,
+                    'module_state_changed': True,
+                    'tx1fault': True,
+                    'tx2fault': False,
+                    'tx3fault': True,
+                    'tx4fault': False,
+                    'tx5fault': True,
+                    'tx6fault': False,
+                    'tx7fault': True,
+                    'tx8fault': False,
+                    'rx1los': True,
+                    'rx2los': False,
+                    'rx3los': True,
+                    'rx4los': False,
+                    'rx5los': True,
+                    'rx6los': False,
+                    'rx7los': True,
+                    'rx8los': False,
+                    'tx1los_hostlane': False,
+                    'tx2los_hostlane': True,
+                    'tx3los_hostlane': False,
+                    'tx4los_hostlane': True,
+                    'tx5los_hostlane': False,
+                    'tx6los_hostlane': True,
+                    'tx7los_hostlane': False,
+                    'tx8los_hostlane': True,
+                    'tx1cdrlol_hostlane': True,
+                    'tx2cdrlol_hostlane': False,
+                    'tx3cdrlol_hostlane': True,
+                    'tx4cdrlol_hostlane': False,
+                    'tx5cdrlol_hostlane': True,
+                    'tx6cdrlol_hostlane': False,
+                    'tx7cdrlol_hostlane': True,
+                    'tx8cdrlol_hostlane': False,
+                    'tx1_eq_fault': False,
+                    'tx2_eq_fault': True,
+                    'tx3_eq_fault': False,
+                    'tx4_eq_fault': True,
+                    'tx5_eq_fault': False,
+                    'tx6_eq_fault': True,
+                    'tx7_eq_fault': False,
+                    'tx8_eq_fault': True,
+                    'rx1cdrlol': False,
+                    'rx2cdrlol': True,
+                    'rx3cdrlol': False,
+                    'rx4cdrlol': True,
+                    'rx5cdrlol': False,
+                    'rx6cdrlol': True,
+                    'rx7cdrlol': False,
+                    'rx8cdrlol': True,
+                    'target_output_power_oor': True,
+                    'fine_tuning_oor': True,
+                    'tuning_not_accepted': True,
+                    'invalid_channel_num': True,
+                    'tuning_complete': True,
+                }
+            ),
+        ]
+    )
+    def test_get_transceiver_status_flags(self, module_faults, tx_fault, tx_los, tx_cdr_lol, tx_eq_fault, rx_los, rx_cdr_lol, laser_tuning_summary, expected_result):
+        self.api.get_module_firmware_fault_state_changed = MagicMock(return_value=module_faults)
+        self.api.get_tx_fault = MagicMock(return_value=tx_fault)
+        self.api.get_tx_los = MagicMock(return_value=tx_los)
+        self.api.get_tx_cdr_lol = MagicMock(return_value=tx_cdr_lol)
+        self.api.get_rx_los = MagicMock(return_value=rx_los)
+        self.api.get_rx_cdr_lol = MagicMock(return_value=rx_cdr_lol)
+        self.api.get_laser_tuning_summary = MagicMock(return_value=laser_tuning_summary)
+        with patch.object(self.api, 'get_tx_adaptive_eq_fail_flag', return_value=tx_eq_fault), \
+             patch.object(self.api, 'is_flat_memory', return_value=False):
+            result = self.api.get_transceiver_status_flags()
+            assert result == expected_result
 
     @pytest.mark.parametrize("mock_response, expected", [
         (

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -1498,7 +1498,8 @@ class TestCmis(object):
                 'media_lane_assignment_option': 1,
                 'connector': 'LC',
                 'host_lane_assignment_option': 1,
-                'vendor_date': '21010100'
+                'vendor_date': '21010100',
+                'vdm_supported': False
             }
         )
     ])
@@ -1533,6 +1534,8 @@ class TestCmis(object):
         self.api.get_module_fw_info.return_value = mock_response[14]
         self.api.is_flat_memory = MagicMock()
         self.api.is_flat_memory.return_value = False
+        self.api.is_transceiver_vdm_supported = MagicMock()
+        self.api.is_transceiver_vdm_supported.return_value = False
         result = self.api.get_transceiver_info()
         assert result == expected
         # Test negative path
@@ -1550,15 +1553,7 @@ class TestCmis(object):
                 [0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1],
                 [0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1],
                 True, True, True, True, True, True,
-                {'monitor value': 40},
-                {
-                    'Pre-FEC BER Average Media Input':{1:[0.001, 0.0125, 0, 0.01, 0, False, False, False, False]},
-                    'Errored Frames Minimum Media Input':{1:[0, 1, 0, 1, 0, False, False, False, False]},
-                    'Errored Frames Maximum Media Input':{1:[0, 1, 0, 1, 0, False, False, False, False]},
-                    'Errored Frames Average Media Input':{1:[0, 1, 0, 1, 0, False, False, False, False]},
-                    'Errored Frames Current Value Media Input':{1:[0, 1, 0, 1, 0, False, False, False, False]},
-                    'Pre-FEC BER Current Value Host Input':{1: [2.66e-09, 1e-05, 0.0, 1e-06, 0.0, False, False, False, False], 2: [1.0, 1e-05, 0.0, 1e-06, 0.0, False, False, False, False], 3: [1.0, 1e-05, 0.0, 1e-06, 0.0, False, False, False, False], 4: [1.0, 1e-05, 0.0, 1e-06, 0.0, False, False, False, False]},
-                }
+                {'monitor value': 40}
             ],
             {
                 'temperature': 50,
@@ -1569,16 +1564,7 @@ class TestCmis(object):
                 'rx5power': -10.0, 'rx6power': -10.0, 'rx7power': -10.0, 'rx8power': -10.0,
                 'tx1bias': 70, 'tx2bias': 70, 'tx3bias': 70, 'tx4bias': 70,
                 'tx5bias': 70, 'tx6bias': 70, 'tx7bias': 70, 'tx8bias': 70,
-                'laser_temperature': 40,
-                'prefec_ber_avg_media_input1': 0.001,
-                'errored_frames_min_media_input1': 0,
-                'errored_frames_max_media_input1': 0,
-                'errored_frames_avg_media_input1': 0,
-                'errored_frames_curr_media_input1': 0,
-                'prefec_ber_curr_host_input1': 2.66e-09,
-                'prefec_ber_curr_host_input2': 1.0,
-                'prefec_ber_curr_host_input3': 1.0,
-                'prefec_ber_curr_host_input4': 1.0
+                'laser_temperature': 40
             }
         ),
         (
@@ -1616,7 +1602,7 @@ class TestCmis(object):
             }
         )
     ])
-    def test_get_transceiver_bulk_status(self, mock_response, expected):
+    def test_get_transceiver_dom_real_value(self, mock_response, expected):
         self.api.get_module_temperature = MagicMock()
         self.api.get_module_temperature.return_value = mock_response[0]
         self.api.get_voltage = MagicMock()
@@ -1641,9 +1627,7 @@ class TestCmis(object):
         self.api.get_rx_power_support.return_value = mock_response[10]
         self.api.get_laser_temperature = MagicMock()
         self.api.get_laser_temperature.return_value = mock_response[11]
-        self.api.get_vdm = MagicMock()
-        self.api.get_vdm.return_value = mock_response[12]
-        result = self.api.get_transceiver_bulk_status()
+        result = self.api.get_transceiver_dom_real_value()
         assert result == expected
 
     @pytest.mark.parametrize(
@@ -1697,114 +1681,114 @@ class TestCmis(object):
                 },
                 (0, 1, 0),
                 {
-                    'temphighalarm': True,
-                    'templowalarm': False,
-                    'temphighwarning': True,
-                    'templowwarning': False,
-                    'vcchighalarm': True,
-                    'vcclowalarm': False,
-                    'vcchighwarning': True,
-                    'vcclowwarning': False,
-                    'txpowerhighalarm1': True,
-                    'txpowerlowalarm1': False,
-                    'txpowerhighwarning1': True,
-                    'txpowerlowwarning1': False,
-                    'txpowerhighalarm2': False,
-                    'txpowerlowalarm2': True,
-                    'txpowerhighwarning2': False,
-                    'txpowerlowwarning2': True,
-                    'txpowerhighalarm3': True,
-                    'txpowerlowalarm3': False,
-                    'txpowerhighwarning3': True,
-                    'txpowerlowwarning3': False,
-                    'txpowerhighalarm4': False,
-                    'txpowerlowalarm4': True,
-                    'txpowerhighwarning4': False,
-                    'txpowerlowwarning4': True,
-                    'txpowerhighalarm5': True,
-                    'txpowerlowalarm5': False,
-                    'txpowerhighwarning5': True,
-                    'txpowerlowwarning5': False,
-                    'txpowerhighalarm6': False,
-                    'txpowerlowalarm6': True,
-                    'txpowerhighwarning6': False,
-                    'txpowerlowwarning6': True,
-                    'txpowerhighalarm7': True,
-                    'txpowerlowalarm7': False,
-                    'txpowerhighwarning7': True,
-                    'txpowerlowwarning7': False,
-                    'txpowerhighalarm8': False,
-                    'txpowerlowalarm8': True,
-                    'txpowerhighwarning8': False,
-                    'txpowerlowwarning8': True,
-                    'rxpowerhighalarm1': True,
-                    'rxpowerlowalarm1': False,
-                    'rxpowerhighwarning1': True,
-                    'rxpowerlowwarning1': False,
-                    'rxpowerhighalarm2': False,
-                    'rxpowerlowalarm2': True,
-                    'rxpowerhighwarning2': False,
-                    'rxpowerlowwarning2': True,
-                    'rxpowerhighalarm3': True,
-                    'rxpowerlowalarm3': False,
-                    'rxpowerhighwarning3': True,
-                    'rxpowerlowwarning3': False,
-                    'rxpowerhighalarm4': False,
-                    'rxpowerlowalarm4': True,
-                    'rxpowerhighwarning4': False,
-                    'rxpowerlowwarning4': True,
-                    'rxpowerhighalarm5': True,
-                    'rxpowerlowalarm5': False,
-                    'rxpowerhighwarning5': True,
-                    'rxpowerlowwarning5': False,
-                    'rxpowerhighalarm6': False,
-                    'rxpowerlowalarm6': True,
-                    'rxpowerhighwarning6': False,
-                    'rxpowerlowwarning6': True,
-                    'rxpowerhighalarm7': True,
-                    'rxpowerlowalarm7': False,
-                    'rxpowerhighwarning7': True,
-                    'rxpowerlowwarning7': False,
-                    'rxpowerhighalarm8': False,
-                    'rxpowerlowalarm8': True,
-                    'rxpowerhighwarning8': False,
-                    'rxpowerlowwarning8': True,
-                    'txbiashighalarm1': True,
-                    'txbiaslowalarm1': False,
-                    'txbiashighwarning1': True,
-                    'txbiaslowwarning1': False,
-                    'txbiashighalarm2': False,
-                    'txbiaslowalarm2': True,
-                    'txbiashighwarning2': False,
-                    'txbiaslowwarning2': True,
-                    'txbiashighalarm3': True,
-                    'txbiaslowalarm3': False,
-                    'txbiashighwarning3': True,
-                    'txbiaslowwarning3': False,
-                    'txbiashighalarm4': False,
-                    'txbiaslowalarm4': True,
-                    'txbiashighwarning4': False,
-                    'txbiaslowwarning4': True,
-                    'txbiashighalarm5': True,
-                    'txbiaslowalarm5': False,
-                    'txbiashighwarning5': True,
-                    'txbiaslowwarning5': False,
-                    'txbiashighalarm6': False,
-                    'txbiaslowalarm6': True,
-                    'txbiashighwarning6': False,
-                    'txbiaslowwarning6': True,
-                    'txbiashighalarm7': True,
-                    'txbiaslowalarm7': False,
-                    'txbiashighwarning7': True,
-                    'txbiaslowwarning7': False,
-                    'txbiashighalarm8': False,
-                    'txbiaslowalarm8': True,
-                    'txbiashighwarning8': False,
-                    'txbiaslowwarning8': True,
-                    'lasertemphighalarm': True,
-                    'lasertemplowalarm': False,
-                    'lasertemphighwarning': True,
-                    'lasertemplowwarning': False
+                    'tempHAlarm': True,
+                    'tempLAlarm': False,
+                    'tempHWarn': True,
+                    'tempLWarn': False,
+                    'vccHAlarm': True,
+                    'vccLAlarm': False,
+                    'vccHWarn': True,
+                    'vccLWarn': False,
+                    'tx1powerHAlarm': True,
+                    'tx1powerLAlarm': False,
+                    'tx1powerHWarn': True,
+                    'tx1powerLWarn': False,
+                    'tx2powerHAlarm': False,
+                    'tx2powerLAlarm': True,
+                    'tx2powerHWarn': False,
+                    'tx2powerLWarn': True,
+                    'tx3powerHAlarm': True,
+                    'tx3powerLAlarm': False,
+                    'tx3powerHWarn': True,
+                    'tx3powerLWarn': False,
+                    'tx4powerHAlarm': False,
+                    'tx4powerLAlarm': True,
+                    'tx4powerHWarn': False,
+                    'tx4powerLWarn': True,
+                    'tx5powerHAlarm': True,
+                    'tx5powerLAlarm': False,
+                    'tx5powerHWarn': True,
+                    'tx5powerLWarn': False,
+                    'tx6powerHAlarm': False,
+                    'tx6powerLAlarm': True,
+                    'tx6powerHWarn': False,
+                    'tx6powerLWarn': True,
+                    'tx7powerHAlarm': True,
+                    'tx7powerLAlarm': False,
+                    'tx7powerHWarn': True,
+                    'tx7powerLWarn': False,
+                    'tx8powerHAlarm': False,
+                    'tx8powerLAlarm': True,
+                    'tx8powerHWarn': False,
+                    'tx8powerLWarn': True,
+                    'rx1powerHAlarm': True,
+                    'rx1powerLAlarm': False,
+                    'rx1powerHWarn': True,
+                    'rx1powerLWarn': False,
+                    'rx2powerHAlarm': False,
+                    'rx2powerLAlarm': True,
+                    'rx2powerHWarn': False,
+                    'rx2powerLWarn': True,
+                    'rx3powerHAlarm': True,
+                    'rx3powerLAlarm': False,
+                    'rx3powerHWarn': True,
+                    'rx3powerLWarn': False,
+                    'rx4powerHAlarm': False,
+                    'rx4powerLAlarm': True,
+                    'rx4powerHWarn': False,
+                    'rx4powerLWarn': True,
+                    'rx5powerHAlarm': True,
+                    'rx5powerLAlarm': False,
+                    'rx5powerHWarn': True,
+                    'rx5powerLWarn': False,
+                    'rx6powerHAlarm': False,
+                    'rx6powerLAlarm': True,
+                    'rx6powerHWarn': False,
+                    'rx6powerLWarn': True,
+                    'rx7powerHAlarm': True,
+                    'rx7powerLAlarm': False,
+                    'rx7powerHWarn': True,
+                    'rx7powerLWarn': False,
+                    'rx8powerHAlarm': False,
+                    'rx8powerLAlarm': True,
+                    'rx8powerHWarn': False,
+                    'rx8powerLWarn': True,
+                    'tx1biasHAlarm': True,
+                    'tx1biasLAlarm': False,
+                    'tx1biasHWarn': True,
+                    'tx1biasLWarn': False,
+                    'tx2biasHAlarm': False,
+                    'tx2biasLAlarm': True,
+                    'tx2biasHWarn': False,
+                    'tx2biasLWarn': True,
+                    'tx3biasHAlarm': True,
+                    'tx3biasLAlarm': False,
+                    'tx3biasHWarn': True,
+                    'tx3biasLWarn': False,
+                    'tx4biasHAlarm': False,
+                    'tx4biasLAlarm': True,
+                    'tx4biasHWarn': False,
+                    'tx4biasLWarn': True,
+                    'tx5biasHAlarm': True,
+                    'tx5biasLAlarm': False,
+                    'tx5biasHWarn': True,
+                    'tx5biasLWarn': False,
+                    'tx6biasHAlarm': False,
+                    'tx6biasLAlarm': True,
+                    'tx6biasHWarn': False,
+                    'tx6biasLWarn': True,
+                    'tx7biasHAlarm': True,
+                    'tx7biasLAlarm': False,
+                    'tx7biasHWarn': True,
+                    'tx7biasLWarn': False,
+                    'tx8biasHAlarm': False,
+                    'tx8biasLAlarm': True,
+                    'tx8biasHWarn': False,
+                    'tx8biasLWarn': True,
+                    'lasertempHAlarm': True,
+                    'lasertempLAlarm': False,
+                    'lasertempHWarn': True,
+                    'lasertempLWarn': False
                 }
             ),
         ]
@@ -1815,6 +1799,7 @@ class TestCmis(object):
         self.api.get_rx_power_flag = MagicMock(return_value=rx_power_flag_dict)
         self.api.get_tx_bias_flag = MagicMock(return_value=tx_bias_flag_dict)
         self.api.get_aux_mon_type = MagicMock(return_value=aux_mon_types)
+        self.api.is_flat_memory = MagicMock(return_value=False)
 
         result = self.api.get_transceiver_dom_flags()
         assert result == expected_result
@@ -1832,10 +1817,6 @@ class TestCmis(object):
                 },
                 1,
                 {'high alarm': 80, 'low alarm': 10, 'high warn': 75, 'low warn': 20},
-                {
-                    'Pre-FEC BER Average Media Input':{1:[0.001, 0.0125, 0, 0.01, 0, False, False, False, False]},
-                    'Errored Frames Average Media Input':{1:[0, 1, 0, 1, 0, False, False, False, False]},
-                }
             ],
             {
                 'temphighalarm': 80, 'templowalarm': 0, 'temphighwarning': 75, 'templowwarning': 10,
@@ -1844,8 +1825,6 @@ class TestCmis(object):
                 'rxpowerhighalarm': 0.0, 'rxpowerlowalarm': -20.0, 'rxpowerhighwarning': 0.0, 'rxpowerlowwarning': -20.0,
                 'txbiashighalarm': 180, 'txbiaslowalarm': 20, 'txbiashighwarning': 160, 'txbiaslowwarning': 40,
                 'lasertemphighalarm': 80, 'lasertemplowalarm': 10, 'lasertemphighwarning': 75, 'lasertemplowwarning': 20,
-                'prefecberhighalarm': 0.0125, 'prefecberlowalarm': 0, 'prefecberhighwarning': 0.01, 'prefecberlowwarning': 0,
-                'postfecberhighalarm': 1, 'postfecberlowalarm': 0, 'postfecberhighwarning': 1, 'postfecberlowwarning': 0,
             }
         ),
         ([None, None, None, None, None], None),
@@ -1868,48 +1847,14 @@ class TestCmis(object):
         self.api.xcvr_eeprom.read.side_effect = mock_response[1:3]
         self.api.get_laser_temperature = MagicMock()
         self.api.get_laser_temperature.return_value = mock_response[3]
-        self.api.get_vdm = MagicMock()
-        self.api.get_vdm.return_value = mock_response[4]
         result = self.api.get_transceiver_threshold_info()
         assert result == expected
 
     @pytest.mark.parametrize("mock_response, expected",[
         (
             [
-                'ModuleReady', 'No Fault detected', (False, False, True),
-                {
-                    'case_temp_flags': {
-                        'case_temp_high_alarm_flag': False,
-                        'case_temp_low_alarm_flag': False,
-                        'case_temp_high_warn_flag': False,
-                        'case_temp_low_warn_flag': False,
-                    },
-                    'voltage_flags': {
-                        'voltage_high_alarm_flag': False,
-                        'voltage_low_alarm_flag': False,
-                        'voltage_high_warn_flag': False,
-                        'voltage_low_warn_flag': False,
-                    },
-                    'aux1_flags': {
-                        'aux1_high_alarm_flag': False,
-                        'aux1_low_alarm_flag': False,
-                        'aux1_high_warn_flag': False,
-                        'aux1_low_warn_flag': False,
-                    },
-                    'aux2_flags': {
-                        'aux2_high_alarm_flag': False,
-                        'aux2_low_alarm_flag': False,
-                        'aux2_high_warn_flag': False,
-                        'aux2_low_warn_flag': False,
-                    },
-                    'aux3_flags': {
-                        'aux3_high_alarm_flag': False,
-                        'aux3_low_alarm_flag': False,
-                        'aux3_high_warn_flag': False,
-                        'aux3_low_warn_flag': False,
-                    }
-                },
-                (0, 0, 0), False,
+                'ModuleReady', 'No Fault detected',
+                False,
                 {'DP1State': 'DataPathActivated', 'DP2State': 'DataPathActivated',
                  'DP3State': 'DataPathActivated', 'DP4State': 'DataPathActivated',
                  'DP5State': 'DataPathActivated', 'DP6State': 'DataPathActivated',
@@ -1926,11 +1871,6 @@ class TestCmis(object):
                     'RxOutputStatus5': True, 'RxOutputStatus6': True,
                     'RxOutputStatus7': True, 'RxOutputStatus8': True
                 },
-                [False, False, False, False, False, False, False, False],
-                [False, False, False, False, False, False, False, False],
-                [False, False, False, False, False, False, False, False],
-                [False, False, False, False, False, False, False, False],
-                [False, False, False, False, False, False, False, False],
                 {
                     'ConfigStatusLane1': 'ConfigSuccess', 'ConfigStatusLane2': 'ConfigSuccess',
                     'ConfigStatusLane3': 'ConfigSuccess', 'ConfigStatusLane4': 'ConfigSuccess',
@@ -1943,99 +1883,12 @@ class TestCmis(object):
                     'DPInitPending5': False, 'DPInitPending6': False,
                     'DPInitPending7': False, 'DPInitPending8': False
                 },
-
-                {
-                    'tx_power_high_alarm': {
-                        'TxPowerHighAlarmFlag1': False, 'TxPowerHighAlarmFlag2': False,
-                        'TxPowerHighAlarmFlag3': False, 'TxPowerHighAlarmFlag4': False,
-                        'TxPowerHighAlarmFlag5': False, 'TxPowerHighAlarmFlag6': False,
-                        'TxPowerHighAlarmFlag7': False, 'TxPowerHighAlarmFlag8': False,
-                    },
-                    'tx_power_low_alarm': {
-                        'TxPowerLowAlarmFlag1': False, 'TxPowerLowAlarmFlag2': False,
-                        'TxPowerLowAlarmFlag3': False, 'TxPowerLowAlarmFlag4': False,
-                        'TxPowerLowAlarmFlag5': False, 'TxPowerLowAlarmFlag6': False,
-                        'TxPowerLowAlarmFlag7': False, 'TxPowerLowAlarmFlag8': False,
-                    },
-                    'tx_power_high_warn': {
-                        'TxPowerHighWarnFlag1': False, 'TxPowerHighWarnFlag2': False,
-                        'TxPowerHighWarnFlag3': False, 'TxPowerHighWarnFlag4': False,
-                        'TxPowerHighWarnFlag5': False, 'TxPowerHighWarnFlag6': False,
-                        'TxPowerHighWarnFlag7': False, 'TxPowerHighWarnFlag8': False,
-                    },
-                    'tx_power_low_warn': {
-                        'TxPowerLowWarnFlag1': False, 'TxPowerLowWarnFlag2': False,
-                        'TxPowerLowWarnFlag3': False, 'TxPowerLowWarnFlag4': False,
-                        'TxPowerLowWarnFlag5': False, 'TxPowerLowWarnFlag6': False,
-                        'TxPowerLowWarnFlag7': False, 'TxPowerLowWarnFlag8': False,
-                    },
-                },
-                {
-                    'rx_power_high_alarm': {
-                        'RxPowerHighAlarmFlag1': False, 'RxPowerHighAlarmFlag2': False,
-                        'RxPowerHighAlarmFlag3': False, 'RxPowerHighAlarmFlag4': False,
-                        'RxPowerHighAlarmFlag5': False, 'RxPowerHighAlarmFlag6': False,
-                        'RxPowerHighAlarmFlag7': False, 'RxPowerHighAlarmFlag8': False,
-                    },
-                    'rx_power_low_alarm': {
-                        'RxPowerLowAlarmFlag1': False, 'RxPowerLowAlarmFlag2': False,
-                        'RxPowerLowAlarmFlag3': False, 'RxPowerLowAlarmFlag4': False,
-                        'RxPowerLowAlarmFlag5': False, 'RxPowerLowAlarmFlag6': False,
-                        'RxPowerLowAlarmFlag7': False, 'RxPowerLowAlarmFlag8': False,
-                    },
-                    'rx_power_high_warn': {
-                        'RxPowerHighWarnFlag1': False, 'RxPowerHighWarnFlag2': False,
-                        'RxPowerHighWarnFlag3': False, 'RxPowerHighWarnFlag4': False,
-                        'RxPowerHighWarnFlag5': False, 'RxPowerHighWarnFlag6': False,
-                        'RxPowerHighWarnFlag7': False, 'RxPowerHighWarnFlag8': False,
-                    },
-                    'rx_power_low_warn': {
-                        'RxPowerLowWarnFlag1': False, 'RxPowerLowWarnFlag2': False,
-                        'RxPowerLowWarnFlag3': False, 'RxPowerLowWarnFlag4': False,
-                        'RxPowerLowWarnFlag5': False, 'RxPowerLowWarnFlag6': False,
-                        'RxPowerLowWarnFlag7': False, 'RxPowerLowWarnFlag8': False,
-                    },
-                },
-                {
-                    'tx_bias_high_alarm': {
-                        'TxBiasHighAlarmFlag1': False, 'TxBiasHighAlarmFlag2': False,
-                        'TxBiasHighAlarmFlag3': False, 'TxBiasHighAlarmFlag4': False,
-                        'TxBiasHighAlarmFlag5': False, 'TxBiasHighAlarmFlag6': False,
-                        'TxBiasHighAlarmFlag7': False, 'TxBiasHighAlarmFlag8': False,
-                    },
-                    'tx_bias_low_alarm': {
-                        'TxBiasLowAlarmFlag1': False, 'TxBiasLowAlarmFlag2': False,
-                        'TxBiasLowAlarmFlag3': False, 'TxBiasLowAlarmFlag4': False,
-                        'TxBiasLowAlarmFlag5': False, 'TxBiasLowAlarmFlag6': False,
-                        'TxBiasLowAlarmFlag7': False, 'TxBiasLowAlarmFlag8': False,
-                    },
-                    'tx_bias_high_warn': {
-                        'TxBiasHighWarnFlag1': False, 'TxBiasHighWarnFlag2': False,
-                        'TxBiasHighWarnFlag3': False, 'TxBiasHighWarnFlag4': False,
-                        'TxBiasHighWarnFlag5': False, 'TxBiasHighWarnFlag6': False,
-                        'TxBiasHighWarnFlag7': False, 'TxBiasHighWarnFlag8': False,
-                    },
-                    'tx_bias_low_warn': {
-                        'TxBiasLowWarnFlag1': False, 'TxBiasLowWarnFlag2': False,
-                        'TxBiasLowWarnFlag3': False, 'TxBiasLowWarnFlag4': False,
-                        'TxBiasLowWarnFlag5': False, 'TxBiasLowWarnFlag6': False,
-                        'TxBiasLowWarnFlag7': False, 'TxBiasLowWarnFlag8': False,
-                    },
-                },
-                {
-                    'Pre-FEC BER Average Media Input':{1:[0.001, 0.0125, 0, 0.01, 0, False, False, False, False]},
-                    'Errored Frames Average Media Input':{1:[0, 1, 0, 1, 0, False, False, False, False]},
-                },
                 0, [False, False, False, False, False, False, False, False],
                 [False, True, False, False, False, False, False, False],
-                [False, False, False, False, False, False, False, False]
             ],
             {
                 'module_state': 'ModuleReady',
                 'module_fault_cause': 'No Fault detected',
-                'datapath_firmware_fault': False,
-                'module_firmware_fault': False,
-                'module_state_changed': True,
                 'DP1State': 'DataPathActivated',
                 'DP2State': 'DataPathActivated',
                 'DP3State': 'DataPathActivated',
@@ -2044,22 +1897,22 @@ class TestCmis(object):
                 'DP6State': 'DataPathActivated',
                 'DP7State': 'DataPathActivated',
                 'DP8State': 'DataPathActivated',
-                'txoutput_status1': True,
-                'txoutput_status2': True,
-                'txoutput_status3': True,
-                'txoutput_status4': True,
-                'txoutput_status5': True,
-                'txoutput_status6': True,
-                'txoutput_status7': True,
-                'txoutput_status8': True,
-                'rxoutput_status_hostlane1': True,
-                'rxoutput_status_hostlane2': True,
-                'rxoutput_status_hostlane3': True,
-                'rxoutput_status_hostlane4': True,
-                'rxoutput_status_hostlane5': True,
-                'rxoutput_status_hostlane6': True,
-                'rxoutput_status_hostlane7': True,
-                'rxoutput_status_hostlane8': True,
+                'tx1OutputStatus': True,
+                'tx2OutputStatus': True,
+                'tx3OutputStatus': True,
+                'tx4OutputStatus': True,
+                'tx5OutputStatus': True,
+                'tx6OutputStatus': True,
+                'tx7OutputStatus': True,
+                'tx8OutputStatus': True,
+                'rx1OutputStatusHostlane': True,
+                'rx2OutputStatusHostlane': True,
+                'rx3OutputStatusHostlane': True,
+                'rx4OutputStatusHostlane': True,
+                'rx5OutputStatusHostlane': True,
+                'rx6OutputStatusHostlane': True,
+                'rx7OutputStatusHostlane': True,
+                'rx8OutputStatusHostlane': True,
                 "tx_disabled_channel": 0,
                 "tx1disable": False,
                 "tx2disable": False,
@@ -2069,54 +1922,6 @@ class TestCmis(object):
                 "tx6disable": False,
                 "tx7disable": False,
                 "tx8disable": False,
-                'txfault1': False,
-                'txfault2': False,
-                'txfault3': False,
-                'txfault4': False,
-                'txfault5': False,
-                'txfault6': False,
-                'txfault7': False,
-                'txfault8': False,
-                'txlos_hostlane1': False,
-                'txlos_hostlane2': False,
-                'txlos_hostlane3': False,
-                'txlos_hostlane4': False,
-                'txlos_hostlane5': False,
-                'txlos_hostlane6': False,
-                'txlos_hostlane7': False,
-                'txlos_hostlane8': False,
-                'txcdrlol_hostlane1': False,
-                'txcdrlol_hostlane2': False,
-                'txcdrlol_hostlane3': False,
-                'txcdrlol_hostlane4': False,
-                'txcdrlol_hostlane5': False,
-                'txcdrlol_hostlane6': False,
-                'txcdrlol_hostlane7': False,
-                'txcdrlol_hostlane8': False,
-                'rxlos1': False,
-                'rxlos2': False,
-                'rxlos3': False,
-                'rxlos4': False,
-                'rxlos5': False,
-                'rxlos6': False,
-                'rxlos7': False,
-                'rxlos8': False,
-                'rxcdrlol1': False,
-                'rxcdrlol2': False,
-                'rxcdrlol3': False,
-                'rxcdrlol4': False,
-                'rxcdrlol5': False,
-                'rxcdrlol6': False,
-                'rxcdrlol7': False,
-                'rxcdrlol8': False,
-                'tx_eq_fault1': False,
-                'tx_eq_fault2': False,
-                'tx_eq_fault3': False,
-                'tx_eq_fault4': False,
-                'tx_eq_fault5': False,
-                'tx_eq_fault6': False,
-                'tx_eq_fault7': False,
-                'tx_eq_fault8': False,
                 'config_state_hostlane1': 'ConfigSuccess',
                 'config_state_hostlane2': 'ConfigSuccess',
                 'config_state_hostlane3': 'ConfigSuccess',
@@ -2141,102 +1946,12 @@ class TestCmis(object):
                 'dpinit_pending_hostlane6': False,
                 'dpinit_pending_hostlane7': False,
                 'dpinit_pending_hostlane8': False,
-                'temphighalarm_flag': False, 'templowalarm_flag': False,
-                'temphighwarning_flag': False, 'templowwarning_flag': False,
-                'vcchighalarm_flag': False, 'vcclowalarm_flag': False,
-                'vcchighwarning_flag': False, 'vcclowwarning_flag': False,
-                'lasertemphighalarm_flag': False, 'lasertemplowalarm_flag': False,
-                'lasertemphighwarning_flag': False, 'lasertemplowwarning_flag': False,
-                'txpowerhighalarm_flag1': False, 'txpowerlowalarm_flag1': False,
-                'txpowerhighwarning_flag1': False, 'txpowerlowwarning_flag1': False,
-                'txpowerhighalarm_flag2': False, 'txpowerlowalarm_flag2': False,
-                'txpowerhighwarning_flag2': False, 'txpowerlowwarning_flag2': False,
-                'txpowerhighalarm_flag3': False, 'txpowerlowalarm_flag3': False,
-                'txpowerhighwarning_flag3': False, 'txpowerlowwarning_flag3': False,
-                'txpowerhighalarm_flag4': False, 'txpowerlowalarm_flag4': False,
-                'txpowerhighwarning_flag4': False, 'txpowerlowwarning_flag4': False,
-                'txpowerhighalarm_flag5': False, 'txpowerlowalarm_flag5': False,
-                'txpowerhighwarning_flag5': False, 'txpowerlowwarning_flag5': False,
-                'txpowerhighalarm_flag6': False, 'txpowerlowalarm_flag6': False,
-                'txpowerhighwarning_flag6': False, 'txpowerlowwarning_flag6': False,
-                'txpowerhighalarm_flag7': False, 'txpowerlowalarm_flag7': False,
-                'txpowerhighwarning_flag7': False, 'txpowerlowwarning_flag7': False,
-                'txpowerhighalarm_flag8': False, 'txpowerlowalarm_flag8': False,
-                'txpowerhighwarning_flag8': False, 'txpowerlowwarning_flag8': False,
-                'rxpowerhighalarm_flag1': False, 'rxpowerlowalarm_flag1': False,
-                'rxpowerhighwarning_flag1': False, 'rxpowerlowwarning_flag1': False,
-                'rxpowerhighalarm_flag2': False, 'rxpowerlowalarm_flag2': False,
-                'rxpowerhighwarning_flag2': False, 'rxpowerlowwarning_flag2': False,
-                'rxpowerhighalarm_flag3': False, 'rxpowerlowalarm_flag3': False,
-                'rxpowerhighwarning_flag3': False, 'rxpowerlowwarning_flag3': False,
-                'rxpowerhighalarm_flag4': False, 'rxpowerlowalarm_flag4': False,
-                'rxpowerhighwarning_flag4': False, 'rxpowerlowwarning_flag4': False,
-                'rxpowerhighalarm_flag5': False, 'rxpowerlowalarm_flag5': False,
-                'rxpowerhighwarning_flag5': False, 'rxpowerlowwarning_flag5': False,
-                'rxpowerhighalarm_flag6': False, 'rxpowerlowalarm_flag6': False,
-                'rxpowerhighwarning_flag6': False, 'rxpowerlowwarning_flag6': False,
-                'rxpowerhighalarm_flag7': False, 'rxpowerlowalarm_flag7': False,
-                'rxpowerhighwarning_flag7': False, 'rxpowerlowwarning_flag7': False,
-                'rxpowerhighalarm_flag8': False, 'rxpowerlowalarm_flag8': False,
-                'rxpowerhighwarning_flag8': False, 'rxpowerlowwarning_flag8': False,
-                'txbiashighalarm_flag1': False, 'txbiaslowalarm_flag1': False,
-                'txbiashighwarning_flag1': False, 'txbiaslowwarning_flag1': False,
-                'txbiashighalarm_flag2': False, 'txbiaslowalarm_flag2': False,
-                'txbiashighwarning_flag2': False, 'txbiaslowwarning_flag2': False,
-                'txbiashighalarm_flag3': False, 'txbiaslowalarm_flag3': False,
-                'txbiashighwarning_flag3': False, 'txbiaslowwarning_flag3': False,
-                'txbiashighalarm_flag4': False, 'txbiaslowalarm_flag4': False,
-                'txbiashighwarning_flag4': False, 'txbiaslowwarning_flag4': False,
-                'txbiashighalarm_flag5': False, 'txbiaslowalarm_flag5': False,
-                'txbiashighwarning_flag5': False, 'txbiaslowwarning_flag5': False,
-                'txbiashighalarm_flag6': False, 'txbiaslowalarm_flag6': False,
-                'txbiashighwarning_flag6': False, 'txbiaslowwarning_flag6': False,
-                'txbiashighalarm_flag7': False, 'txbiaslowalarm_flag7': False,
-                'txbiashighwarning_flag7': False, 'txbiaslowwarning_flag7': False,
-                'txbiashighalarm_flag8': False, 'txbiaslowalarm_flag8': False,
-                'txbiashighwarning_flag8': False, 'txbiaslowwarning_flag8': False,
-                'prefecberhighalarm_flag': False, 'prefecberlowalarm_flag': False,
-                'prefecberhighwarning_flag': False, 'prefecberlowwarning_flag': False,
-                'postfecberhighalarm_flag': False, 'postfecberlowalarm_flag': False,
-                'postfecberhighwarning_flag': False, 'postfecberlowwarning_flag': False,
             }
         ),
         (
             [
-                'ModuleReady', 'No Fault detected', (False, False, True),
-                {
-                    'case_temp_flags': {
-                        'case_temp_high_alarm_flag': False,
-                        'case_temp_low_alarm_flag': False,
-                        'case_temp_high_warn_flag': False,
-                        'case_temp_low_warn_flag': False,
-                    },
-                    'voltage_flags': {
-                        'voltage_high_alarm_flag': False,
-                        'voltage_low_alarm_flag': False,
-                        'voltage_high_warn_flag': False,
-                        'voltage_low_warn_flag': False,
-                    },
-                    'aux1_flags': {
-                        'aux1_high_alarm_flag': False,
-                        'aux1_low_alarm_flag': False,
-                        'aux1_high_warn_flag': False,
-                        'aux1_low_warn_flag': False,
-                    },
-                    'aux2_flags': {
-                        'aux2_high_alarm_flag': False,
-                        'aux2_low_alarm_flag': False,
-                        'aux2_high_warn_flag': False,
-                        'aux2_low_warn_flag': False,
-                    },
-                    'aux3_flags': {
-                        'aux3_high_alarm_flag': False,
-                        'aux3_low_alarm_flag': False,
-                        'aux3_high_warn_flag': False,
-                        'aux3_low_warn_flag': False,
-                    }
-                },
-                (0, 0, 0), True,
+                'ModuleReady', 'No Fault detected',
+                True,
                 {'DP1State': 'DataPathActivated', 'DP2State': 'DataPathActivated',
                  'DP3State': 'DataPathActivated', 'DP4State': 'DataPathActivated',
                  'DP5State': 'DataPathActivated', 'DP6State': 'DataPathActivated',
@@ -2248,11 +1963,6 @@ class TestCmis(object):
                     'RxOutputStatus5': True, 'RxOutputStatus6': True,
                     'RxOutputStatus7': True, 'RxOutputStatus8': True
                 },
-                [False],
-                [False, False, False, False, False, False, False, False],
-                [False, False, False, False, False, False, False, False],
-                [False],
-                [False],
                 {
                     'ConfigStatusLane1': 'ConfigSuccess', 'ConfigStatusLane2': 'ConfigSuccess',
                     'ConfigStatusLane3': 'ConfigSuccess', 'ConfigStatusLane4': 'ConfigSuccess',
@@ -2266,42 +1976,11 @@ class TestCmis(object):
                     'DPInitPending7': False, 'DPInitPending8': False
                 },
 
-                {
-                    'tx_power_high_alarm': {'TxPowerHighAlarmFlag1': False},
-                    'tx_power_low_alarm': {'TxPowerLowAlarmFlag1': False},
-                    'tx_power_high_warn': {'TxPowerHighWarnFlag1': False},
-                    'tx_power_low_warn': {'TxPowerLowWarnFlag1': False},
-                },
-                {
-                    'rx_power_high_alarm': {'RxPowerHighAlarmFlag1': False},
-                    'rx_power_low_alarm': {'RxPowerLowAlarmFlag1': False},
-                    'rx_power_high_warn': {'RxPowerHighWarnFlag1': False},
-                    'rx_power_low_warn': {'RxPowerLowWarnFlag1': False},
-                },
-                {
-                    'tx_bias_high_alarm': {'TxBiasHighAlarmFlag1': False},
-                    'tx_bias_low_alarm': {'TxBiasLowAlarmFlag1': False},
-                    'tx_bias_high_warn': {'TxBiasHighWarnFlag1': False},
-                    'tx_bias_low_warn': {'TxBiasLowWarnFlag1': False},
-                },
-                {
-                    'Pre-FEC BER Average Media Input':{1:[0.001, 0.0125, 0, 0.01, 0, False, False, False, False]},
-                    'Errored Frames Average Media Input':{1:[0, 1, 0, 1, 0, False, False, False, False]},
-                },
-                None, None, None, None
+                None, None, None
             ],
             {
                 'module_state': 'ModuleReady',
                 'module_fault_cause': 'No Fault detected',
-                'datapath_firmware_fault': False,
-                'module_firmware_fault': False,
-                'module_state_changed': True,
-                'temphighalarm_flag': False, 'templowalarm_flag': False,
-                'temphighwarning_flag': False, 'templowwarning_flag': False,
-                'vcchighalarm_flag': False, 'vcclowalarm_flag': False,
-                'vcchighwarning_flag': False, 'vcclowwarning_flag': False,
-                'lasertemphighalarm_flag': False, 'lasertemplowalarm_flag': False,
-                'lasertemphighwarning_flag': False, 'lasertemplowwarning_flag': False,
             }
         )
     ])
@@ -2310,57 +1989,29 @@ class TestCmis(object):
         self.api.get_module_state.return_value = mock_response[0]
         self.api.get_module_fault_cause = MagicMock()
         self.api.get_module_fault_cause.return_value = mock_response[1]
-        self.api.get_module_firmware_fault_state_changed = MagicMock()
-        self.api.get_module_firmware_fault_state_changed.return_value = mock_response[2]
-        self.api.get_module_level_flag = MagicMock()
-        self.api.get_module_level_flag.return_value = mock_response[3]
-        self.api.get_aux_mon_type = MagicMock()
-        self.api.get_aux_mon_type.return_value = mock_response[4]
         self.api.is_flat_memory = MagicMock()
-        self.api.is_flat_memory.return_value = mock_response[5]
+        self.api.is_flat_memory.return_value = mock_response[2]
         self.api.get_datapath_state = MagicMock()
-        self.api.get_datapath_state.return_value = mock_response[6]
+        self.api.get_datapath_state.return_value = mock_response[3]
         self.api.get_tx_output_status = MagicMock()
-        self.api.get_tx_output_status.return_value = mock_response[7]
+        self.api.get_tx_output_status.return_value = mock_response[4]
         self.api.get_rx_output_status = MagicMock()
-        self.api.get_rx_output_status.return_value = mock_response[8]
-        self.api.get_tx_fault = MagicMock()
-        self.api.get_tx_fault.return_value = mock_response[9]
-        self.api.get_tx_los = MagicMock()
-        self.api.get_tx_los.return_value = mock_response[10]
-        self.api.get_tx_cdr_lol = MagicMock()
-        self.api.get_tx_cdr_lol.return_value = mock_response[11]
-        self.api.get_rx_los = MagicMock()
-        self.api.get_rx_los.return_value = mock_response[12]
-        self.api.get_rx_cdr_lol = MagicMock()
-        self.api.get_rx_cdr_lol.return_value = mock_response[13]
+        self.api.get_rx_output_status.return_value = mock_response[5]
         self.api.get_config_datapath_hostlane_status = MagicMock()
-        self.api.get_config_datapath_hostlane_status.return_value = mock_response[14]
+        self.api.get_config_datapath_hostlane_status.return_value = mock_response[6]
         self.api.get_dpinit_pending = MagicMock()
-        self.api.get_dpinit_pending.return_value = mock_response[15]
+        self.api.get_dpinit_pending.return_value = mock_response[7]
 
-        self.api.get_tx_power_flag = MagicMock()
-        self.api.get_tx_power_flag.return_value = mock_response[16]
-        self.api.get_rx_power_flag = MagicMock()
-        self.api.get_rx_power_flag.return_value = mock_response[17]
-        self.api.get_tx_bias_flag = MagicMock()
-        self.api.get_tx_bias_flag.return_value = mock_response[18]
-        self.api.get_vdm = MagicMock()
-        self.api.get_vdm.return_value = mock_response[19]
         self.api.get_tx_disable_channel = MagicMock()
-        self.api.get_tx_disable_channel.return_value = mock_response[20]
+        self.api.get_tx_disable_channel.return_value = mock_response[8]
         self.api.get_tx_disable = MagicMock()
-        self.api.get_tx_disable.return_value = mock_response[21]
-        with patch.object(self.api, 'get_datapath_deinit', return_value=mock_response[22]), \
-             patch.object(self.api, 'get_tx_adaptive_eq_fail_flag', return_value=mock_response[23]):
-            self.api.vdm = MagicMock()
-            self.api.vdm.return_value.VDM_FLAG = 'mocked_value'
-
+        self.api.get_tx_disable.return_value = mock_response[9]
+        with patch.object(self.api, 'get_datapath_deinit', return_value=mock_response[10]):
             result = self.api.get_transceiver_status()
             assert result == expected
 
     @pytest.mark.parametrize(
-        "module_faults, tx_fault, tx_los, tx_cdr_lol, tx_eq_fault, rx_los, rx_cdr_lol, laser_tuning_summary, expected_result",
+        "module_faults, tx_fault, tx_los, tx_cdr_lol, tx_eq_fault, rx_los, rx_cdr_lol, expected_result",
         [
             # Test case 1: All flags present for lanes 1 to 8
             (
@@ -2371,77 +2022,71 @@ class TestCmis(object):
                 [False, True, False, True, False, True, False, True],
                 [True, False, True, False, True, False, True, False],
                 [False, True, False, True, False, True, False, True],
-                ['TargetOutputPowerOOR', 'FineTuningOutOfRange', 'TuningNotAccepted', 'InvalidChannel', 'TuningComplete'],
                 {
                     'datapath_firmware_fault': True,
                     'module_firmware_fault': False,
                     'module_state_changed': True,
-                    'txfault1': True,
-                    'txfault2': False,
-                    'txfault3': True,
-                    'txfault4': False,
-                    'txfault5': True,
-                    'txfault6': False,
-                    'txfault7': True,
-                    'txfault8': False,
-                    'txlos_hostlane1': False,
-                    'txlos_hostlane2': True,
-                    'txlos_hostlane3': False,
-                    'txlos_hostlane4': True,
-                    'txlos_hostlane5': False,
-                    'txlos_hostlane6': True,
-                    'txlos_hostlane7': False,
-                    'txlos_hostlane8': True,
-                    'txcdrlol_hostlane1': True,
-                    'txcdrlol_hostlane2': False,
-                    'txcdrlol_hostlane3': True,
-                    'txcdrlol_hostlane4': False,
-                    'txcdrlol_hostlane5': True,
-                    'txcdrlol_hostlane6': False,
-                    'txcdrlol_hostlane7': True,
-                    'txcdrlol_hostlane8': False,
-                    'tx_eq_fault1': False,
-                    'tx_eq_fault2': True,
-                    'tx_eq_fault3': False,
-                    'tx_eq_fault4': True,
-                    'tx_eq_fault5': False,
-                    'tx_eq_fault6': True,
-                    'tx_eq_fault7': False,
-                    'tx_eq_fault8': True,
-                    'rxlos1': True,
-                    'rxlos2': False,
-                    'rxlos3': True,
-                    'rxlos4': False,
-                    'rxlos5': True,
-                    'rxlos6': False,
-                    'rxlos7': True,
-                    'rxlos8': False,
-                    'rxcdrlol1': False,
-                    'rxcdrlol2': True,
-                    'rxcdrlol3': False,
-                    'rxcdrlol4': True,
-                    'rxcdrlol5': False,
-                    'rxcdrlol6': True,
-                    'rxcdrlol7': False,
-                    'rxcdrlol8': True,
-                    'target_output_power_oor': True,
-                    'fine_tuning_oor': True,
-                    'tuning_not_accepted': True,
-                    'invalid_channel_num': True,
-                    'tuning_complete': True
+                    'tx1fault': True,
+                    'tx2fault': False,
+                    'tx3fault': True,
+                    'tx4fault': False,
+                    'tx5fault': True,
+                    'tx6fault': False,
+                    'tx7fault': True,
+                    'tx8fault': False,
+                    'rx1los': True,
+                    'rx2los': False,
+                    'rx3los': True,
+                    'rx4los': False,
+                    'rx5los': True,
+                    'rx6los': False,
+                    'rx7los': True,
+                    'rx8los': False,
+                    'tx1los_hostlane': False,
+                    'tx2los_hostlane': True,
+                    'tx3los_hostlane': False,
+                    'tx4los_hostlane': True,
+                    'tx5los_hostlane': False,
+                    'tx6los_hostlane': True,
+                    'tx7los_hostlane': False,
+                    'tx8los_hostlane': True,
+                    'tx1cdrlol_hostlane': True,
+                    'tx2cdrlol_hostlane': False,
+                    'tx3cdrlol_hostlane': True,
+                    'tx4cdrlol_hostlane': False,
+                    'tx5cdrlol_hostlane': True,
+                    'tx6cdrlol_hostlane': False,
+                    'tx7cdrlol_hostlane': True,
+                    'tx8cdrlol_hostlane': False,
+                    'tx1_eq_fault': False,
+                    'tx2_eq_fault': True,
+                    'tx3_eq_fault': False,
+                    'tx4_eq_fault': True,
+                    'tx5_eq_fault': False,
+                    'tx6_eq_fault': True,
+                    'tx7_eq_fault': False,
+                    'tx8_eq_fault': True,
+                    'rx1cdrlol': False,
+                    'rx2cdrlol': True,
+                    'rx3cdrlol': False,
+                    'rx4cdrlol': True,
+                    'rx5cdrlol': False,
+                    'rx6cdrlol': True,
+                    'rx7cdrlol': False,
+                    'rx8cdrlol': True
                 }
             ),
         ]
     )
-    def test_get_transceiver_status_flags(self, module_faults, tx_fault, tx_los, tx_cdr_lol, tx_eq_fault, rx_los, rx_cdr_lol, laser_tuning_summary, expected_result):
+    def test_get_transceiver_status_flags(self, module_faults, tx_fault, tx_los, tx_cdr_lol, tx_eq_fault, rx_los, rx_cdr_lol, expected_result):
         self.api.get_module_firmware_fault_state_changed = MagicMock(return_value=module_faults)
         self.api.get_tx_fault = MagicMock(return_value=tx_fault)
         self.api.get_tx_los = MagicMock(return_value=tx_los)
         self.api.get_tx_cdr_lol = MagicMock(return_value=tx_cdr_lol)
         self.api.get_rx_los = MagicMock(return_value=rx_los)
         self.api.get_rx_cdr_lol = MagicMock(return_value=rx_cdr_lol)
-        self.api.get_laser_tuning_summary = MagicMock(return_value=laser_tuning_summary)
-        with patch.object(self.api, 'get_tx_adaptive_eq_fail_flag', return_value=tx_eq_fault):
+        with patch.object(self.api, 'get_tx_adaptive_eq_fail_flag', return_value=tx_eq_fault), \
+             patch.object(self.api, 'is_flat_memory', return_value=False):
             result = self.api.get_transceiver_status_flags()
             assert result == expected_result
 
@@ -3123,7 +2768,7 @@ class TestCmis(object):
         run_num = 5
         while run_num > 0:
             try:
-                self.api.get_transceiver_bulk_status()
+                self.api.get_transceiver_dom_real_value()
                 self.api.get_transceiver_info()
                 self.api.get_transceiver_threshold_info()
                 self.api.get_transceiver_status()

--- a/tests/sonic_xcvr/test_sff8436.py
+++ b/tests/sonic_xcvr/test_sff8436.py
@@ -25,7 +25,7 @@ class TestSff8436(object):
         self.api.get_model()
         self.api.get_serial()
         self.api.get_transceiver_info()
-        self.api.get_transceiver_bulk_status()
+        self.api.get_transceiver_dom_real_value()
         self.api.get_transceiver_threshold_info()
         self.api.get_transceiver_status()
         self.api.get_rx_los()
@@ -119,7 +119,7 @@ class TestSff8436(object):
         run_num = 5
         while run_num > 0:
             try:
-                self.api.get_transceiver_bulk_status()
+                self.api.get_transceiver_dom_real_value()
                 self.api.get_transceiver_info()
                 self.api.get_transceiver_threshold_info()
             except:
@@ -159,8 +159,6 @@ class TestSff8436(object):
     @pytest.mark.parametrize("mock_response, expected",[
         (
             [
-                [False, False, False, False],
-                [False, False, False, False],
                 0,
                 [False, False, False, False]
             ],
@@ -170,20 +168,10 @@ class TestSff8436(object):
                 "tx2disable": False,
                 "tx3disable": False,
                 "tx4disable": False,
-                'txfault1': False,
-                'txfault2': False,
-                'txfault3': False,
-                'txfault4': False,
-                'rxlos1': False,
-                'rxlos2': False,
-                'rxlos3': False,
-                'rxlos4': False,
             }
         ),
         (
             [
-                None,
-                None,
                 None,
                 None
             ],
@@ -191,15 +179,44 @@ class TestSff8436(object):
         )
     ])
     def test_get_transceiver_status(self, mock_response, expected):
+        self.api.get_tx_disable_channel = MagicMock()
+        self.api.get_tx_disable_channel.return_value = mock_response[0]
+        self.api.get_tx_disable = MagicMock()
+        self.api.get_tx_disable.return_value = mock_response[1]
+        result = self.api.get_transceiver_status()
+        assert result == expected
+
+    @pytest.mark.parametrize("mock_response, expected",[
+        (
+            [
+                [False, False, False, False],
+                [False, False, False, False],
+            ],
+            {
+                'tx1fault': False,
+                'tx2fault': False,
+                'tx3fault': False,
+                'tx4fault': False,
+                'rx1los': False,
+                'rx2los': False,
+                'rx3los': False,
+                'rx4los': False,
+            }
+        ),
+        (
+            [
+                None,
+                None
+            ],
+            None
+        )
+    ])
+    def test_get_transceiver_status_flags(self, mock_response, expected):
         self.api.get_rx_los = MagicMock()
         self.api.get_rx_los.return_value = mock_response[0]
         self.api.get_tx_fault = MagicMock()
         self.api.get_tx_fault.return_value = mock_response[1]
-        self.api.get_tx_disable_channel = MagicMock()
-        self.api.get_tx_disable_channel.return_value = mock_response[2]
-        self.api.get_tx_disable = MagicMock()
-        self.api.get_tx_disable.return_value = mock_response[3]
-        result = self.api.get_transceiver_status()
+        result = self.api.get_transceiver_status_flags()
         assert result == expected
 
     @pytest.mark.parametrize("mock_response, expected",[
@@ -221,7 +238,7 @@ class TestSff8436(object):
             }
         )
     ])
-    def test_get_transceiver_bulk_status(self, mock_response, expected):
+    def test_get_transceiver_dom_real_value(self, mock_response, expected):
         self.api.get_module_temperature = MagicMock()
         self.api.get_module_temperature.return_value = mock_response[0]
         self.api.get_voltage = MagicMock()
@@ -244,7 +261,7 @@ class TestSff8436(object):
         self.api.get_tx_power_support.return_value = mock_response[9]
         self.api.get_rx_power_support = MagicMock()
         self.api.get_rx_power_support.return_value = mock_response[10]
-        result = self.api.get_transceiver_bulk_status()
+        result = self.api.get_transceiver_dom_real_value()
         assert result == expected
 
 

--- a/tests/sonic_xcvr/test_sff8472.py
+++ b/tests/sonic_xcvr/test_sff8472.py
@@ -27,7 +27,7 @@ class TestSff8472(object):
         self.api.get_model()
         self.api.get_serial()
         self.api.get_transceiver_info()
-        self.api.get_transceiver_bulk_status()
+        self.api.get_transceiver_dom_real_value()
         self.api.get_transceiver_threshold_info()
         self.api.get_transceiver_status()
         self.api.get_rx_los()
@@ -201,7 +201,7 @@ class TestSff8472(object):
         run_num = 5
         while run_num > 0:
             try:
-                self.api.get_transceiver_bulk_status()
+                self.api.get_transceiver_dom_real_value()
                 self.api.get_transceiver_info()
                 self.api.get_transceiver_threshold_info()
             except:
@@ -211,22 +211,16 @@ class TestSff8472(object):
     @pytest.mark.parametrize("mock_response, expected",[
         (
             [
-                [False],
-                [False],
                 0,
                 [False]
             ],
             {
                 "tx_disabled_channel": 0,
                 "tx1disable": False,
-                'txfault1': False,
-                'rxlos1': False,
             }
         ),
         (
             [
-                None,
-                None,
                 None,
                 None
             ],
@@ -234,15 +228,38 @@ class TestSff8472(object):
         )
     ])
     def test_get_transceiver_status(self, mock_response, expected):
+        self.api.get_tx_disable_channel = MagicMock()
+        self.api.get_tx_disable_channel.return_value = mock_response[0]
+        self.api.get_tx_disable = MagicMock()
+        self.api.get_tx_disable.return_value = mock_response[1]
+        result = self.api.get_transceiver_status()
+        assert result == expected
+
+    @pytest.mark.parametrize("mock_response, expected",[
+        (
+            [
+                [False],
+                [False],
+            ],
+            {
+                'tx1fault': False,
+                'rx1los': False,
+            }
+        ),
+        (
+            [
+                None,
+                None,
+            ],
+            None
+        )
+    ])
+    def test_get_transceiver_status_flags(self, mock_response, expected):
         self.api.get_rx_los = MagicMock()
         self.api.get_rx_los.return_value = mock_response[0]
         self.api.get_tx_fault = MagicMock()
         self.api.get_tx_fault.return_value = mock_response[1]
-        self.api.get_tx_disable_channel = MagicMock()
-        self.api.get_tx_disable_channel.return_value = mock_response[2]
-        self.api.get_tx_disable = MagicMock()
-        self.api.get_tx_disable.return_value = mock_response[3]
-        result = self.api.get_transceiver_status()
+        result = self.api.get_transceiver_status_flags()
         assert result == expected
 
     @pytest.mark.parametrize("mock_response, expected",[
@@ -264,7 +281,7 @@ class TestSff8472(object):
             }
         )
     ])
-    def test_get_transceiver_bulk_status(self, mock_response, expected):
+    def test_get_transceiver_dom_real_value(self, mock_response, expected):
         self.api.get_module_temperature = MagicMock()
         self.api.get_module_temperature.return_value = mock_response[0]
         self.api.get_voltage = MagicMock()
@@ -287,7 +304,7 @@ class TestSff8472(object):
         self.api.get_tx_power_support.return_value = mock_response[9]
         self.api.get_rx_power_support = MagicMock()
         self.api.get_rx_power_support.return_value = mock_response[10]
-        result = self.api.get_transceiver_bulk_status()
+        result = self.api.get_transceiver_dom_real_value()
         assert result == expected
 
     def test_get_lpmode(self):

--- a/tests/sonic_xcvr/test_sff8636.py
+++ b/tests/sonic_xcvr/test_sff8636.py
@@ -24,7 +24,7 @@ class TestSff8636(object):
         self.api.get_model()
         self.api.get_serial()
         self.api.get_transceiver_info()
-        self.api.get_transceiver_bulk_status()
+        self.api.get_transceiver_dom_real_value()
         self.api.get_transceiver_threshold_info()
         self.api.get_transceiver_status()
         self.api.get_rx_los()
@@ -119,7 +119,7 @@ class TestSff8636(object):
         run_num = 5
         while run_num > 0:
             try:
-                self.api.get_transceiver_bulk_status()
+                self.api.get_transceiver_dom_real_value()
                 self.api.get_transceiver_info()
                 self.api.get_transceiver_threshold_info()
             except:
@@ -159,8 +159,6 @@ class TestSff8636(object):
     @pytest.mark.parametrize("mock_response, expected",[
         (
             [
-                [False, False, False, False],
-                [False, False, False, False],
                 0,
                 [False, False, False, False]
             ],
@@ -170,20 +168,10 @@ class TestSff8636(object):
                 "tx2disable": False,
                 "tx3disable": False,
                 "tx4disable": False,
-                'txfault1': False,
-                'txfault2': False,
-                'txfault3': False,
-                'txfault4': False,
-                'rxlos1': False,
-                'rxlos2': False,
-                'rxlos3': False,
-                'rxlos4': False,
             }
         ),
         (
             [
-                None,
-                None,
                 None,
                 None
             ],
@@ -191,15 +179,44 @@ class TestSff8636(object):
         )
     ])
     def test_get_transceiver_status(self, mock_response, expected):
+        self.api.get_tx_disable_channel = MagicMock()
+        self.api.get_tx_disable_channel.return_value = mock_response[0]
+        self.api.get_tx_disable = MagicMock()
+        self.api.get_tx_disable.return_value = mock_response[1]
+        result = self.api.get_transceiver_status()
+        assert result == expected
+
+    @pytest.mark.parametrize("mock_response, expected",[
+        (
+            [
+                [False, False, False, False],
+                [False, False, False, False],
+            ],
+            {
+                'tx1fault': False,
+                'tx2fault': False,
+                'tx3fault': False,
+                'tx4fault': False,
+                'rx1los': False,
+                'rx2los': False,
+                'rx3los': False,
+                'rx4los': False,
+            }
+        ),
+        (
+            [
+                None,
+                None
+            ],
+            None
+        )
+    ])
+    def test_get_transceiver_status_flags(self, mock_response, expected):
         self.api.get_rx_los = MagicMock()
         self.api.get_rx_los.return_value = mock_response[0]
         self.api.get_tx_fault = MagicMock()
         self.api.get_tx_fault.return_value = mock_response[1]
-        self.api.get_tx_disable_channel = MagicMock()
-        self.api.get_tx_disable_channel.return_value = mock_response[2]
-        self.api.get_tx_disable = MagicMock()
-        self.api.get_tx_disable.return_value = mock_response[3]
-        result = self.api.get_transceiver_status()
+        result = self.api.get_transceiver_status_flags()
         assert result == expected
 
     @pytest.mark.parametrize("mock_response, expected",[
@@ -221,7 +238,7 @@ class TestSff8636(object):
             }
         )
     ])
-    def test_get_transceiver_bulk_status(self, mock_response, expected):
+    def test_get_transceiver_dom_real_value(self, mock_response, expected):
         self.api.get_module_temperature = MagicMock()
         self.api.get_module_temperature.return_value = mock_response[0]
         self.api.get_voltage = MagicMock()
@@ -244,6 +261,6 @@ class TestSff8636(object):
         self.api.get_tx_power_support.return_value = mock_response[9]
         self.api.get_rx_power_support = MagicMock()
         self.api.get_rx_power_support.return_value = mock_response[10]
-        result = self.api.get_transceiver_bulk_status()
+        result = self.api.get_transceiver_dom_real_value()
         assert result == expected
 


### PR DESCRIPTION
* [cmis] Separate Flag-Specific Fields for DOM and Status APIs



* Moved tx fault and rx los to get_transceiver_status_flags for non-CMIS modules

* Added comment for status and status flag function

* Correct typo for specifying latched fields as non-latched fields

* Renamed API for DOM sensor read and added redis-db table names for DOM and Status related APIs

* Moved lane num from suffix to after tx/rx for txfault and rxlos for non-CMIS transceivers

* Removed EEPROM read for active_apsel_hostlane field in get_transceiver_info function

* Reverted Removed EEPROM read for active_apsel_hostlane field in get_transceiver_info function

---------

<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)

