### PR TITLE
Add tx bias support check before getting tx bias of sff8436 and sff8636

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/sff8436.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/sff8436.py
@@ -347,7 +347,7 @@ class Sff8436Api(XcvrApi):
         return True
 
     def get_tx_bias_support(self):
-        return True
+        return not self.is_copper()
 
     def get_tx_fault_support(self):
         return self.xcvr_eeprom.read(consts.TX_FAULT_SUPPORT_FIELD)

--- a/sonic_platform_base/sonic_xcvr/api/public/sff8436.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/sff8436.py
@@ -269,6 +269,8 @@ class Sff8436Api(XcvrApi):
         return float("{:.3f}".format(voltage))
 
     def get_tx_bias(self):
+        if not self.get_tx_bias_support():
+            return ["N/A" for _ in range(self.NUM_CHANNELS)]
         tx_bias = self.xcvr_eeprom.read(consts.TX_BIAS_FIELD)
         if tx_bias is None:
             return None

--- a/sonic_platform_base/sonic_xcvr/api/public/sff8436.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/sff8436.py
@@ -217,6 +217,8 @@ class Sff8436Api(XcvrApi):
         }
 
     def get_rx_los(self):
+        if not self.get_rx_los_support():
+            return ["N/A" for _ in range(self.NUM_CHANNELS)]
         rx_los = self.xcvr_eeprom.read(consts.RX_LOS_FIELD)
         if rx_los is None:
             return None
@@ -344,7 +346,7 @@ class Sff8436Api(XcvrApi):
         return not self.is_copper()
 
     def get_rx_los_support(self):
-        return True
+        return not self.is_copper()
 
     def get_tx_bias_support(self):
         return not self.is_copper()

--- a/sonic_platform_base/sonic_xcvr/api/public/sff8636.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/sff8636.py
@@ -287,6 +287,8 @@ class Sff8636Api(XcvrApi):
         return float("{:.3f}".format(voltage))
 
     def get_tx_bias(self):
+        if not self.get_tx_bias_support():
+            return ["N/A" for _ in range(self.NUM_CHANNELS)]
         tx_bias = self.xcvr_eeprom.read(consts.TX_BIAS_FIELD)
         if tx_bias is None:
             return None

--- a/sonic_platform_base/sonic_xcvr/api/public/sff8636.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/sff8636.py
@@ -400,7 +400,7 @@ class Sff8636Api(XcvrApi):
         return True
 
     def get_tx_bias_support(self):
-        return True
+        return not self.is_copper()
 
     def get_tx_fault_support(self):
         return self.xcvr_eeprom.read(consts.TX_FAULT_SUPPORT_FIELD)

--- a/sonic_platform_base/sonic_xcvr/api/public/sff8636.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/sff8636.py
@@ -235,6 +235,8 @@ class Sff8636Api(XcvrApi):
         }
 
     def get_rx_los(self):
+        if not self.get_rx_los_support():
+            return ["N/A" for _ in range(self.NUM_CHANNELS)]
         rx_los = self.xcvr_eeprom.read(consts.RX_LOS_FIELD)
         if rx_los is None:
             return None
@@ -397,7 +399,7 @@ class Sff8636Api(XcvrApi):
         return self._voltage_support
 
     def get_rx_los_support(self):
-        return True
+        return not self.is_copper()
 
     def get_tx_bias_support(self):
         return not self.is_copper()

--- a/tests/sonic_xcvr/test_sff8436.py
+++ b/tests/sonic_xcvr/test_sff8436.py
@@ -100,6 +100,7 @@ class TestSff8436(object):
 
     def test_simulate_copper(self):
         with patch.object(self.api, 'is_copper', return_value=True):
+            assert self.api.get_tx_power() == ['N/A'] * self.api.NUM_CHANNELS
             assert self.api.get_rx_power() == ['N/A'] * self.api.NUM_CHANNELS
             assert self.api.get_module_temperature() == 'N/A'
             assert self.api.get_voltage() == 'N/A'
@@ -263,11 +264,3 @@ class TestSff8436(object):
         self.api.get_rx_power_support.return_value = mock_response[10]
         result = self.api.get_transceiver_dom_real_value()
         assert result == expected
-
-        # Test when tx_bias_support is False
-        self.api.get_tx_bias_support.return_value = False
-        result = self.api.get_transceiver_dom_real_value()
-        assert result['tx1bias'] == 'N/A'
-        assert result['tx2bias'] == 'N/A'
-        assert result['tx3bias'] == 'N/A'
-        assert result['tx4bias'] == 'N/A'

--- a/tests/sonic_xcvr/test_sff8436.py
+++ b/tests/sonic_xcvr/test_sff8436.py
@@ -264,3 +264,4 @@ class TestSff8436(object):
         self.api.get_rx_power_support.return_value = mock_response[10]
         result = self.api.get_transceiver_dom_real_value()
         assert result == expected
+

--- a/tests/sonic_xcvr/test_sff8436.py
+++ b/tests/sonic_xcvr/test_sff8436.py
@@ -264,4 +264,10 @@ class TestSff8436(object):
         result = self.api.get_transceiver_dom_real_value()
         assert result == expected
 
-
+        # Test when tx_bias_support is False
+        self.api.get_tx_bias_support.return_value = False
+        result = self.api.get_transceiver_dom_real_value()
+        assert result['tx1bias'] == 'N/A'
+        assert result['tx2bias'] == 'N/A'
+        assert result['tx3bias'] == 'N/A'
+        assert result['tx4bias'] == 'N/A'

--- a/tests/sonic_xcvr/test_sff8436.py
+++ b/tests/sonic_xcvr/test_sff8436.py
@@ -267,3 +267,4 @@ class TestSff8436(object):
         result = self.api.get_transceiver_dom_real_value()
         assert result == expected
 
+

--- a/tests/sonic_xcvr/test_sff8436.py
+++ b/tests/sonic_xcvr/test_sff8436.py
@@ -100,8 +100,8 @@ class TestSff8436(object):
 
     def test_simulate_copper(self):
         with patch.object(self.api, 'is_copper', return_value=True):
-            assert self.api.get_tx_power() == ['N/A'] * self.api.NUM_CHANNELS
             assert self.api.get_rx_power() == ['N/A'] * self.api.NUM_CHANNELS
+            assert self.api.get_tx_bias() == ['N/A'] * self.api.NUM_CHANNELS
             assert self.api.get_module_temperature() == 'N/A'
             assert self.api.get_voltage() == 'N/A'
             assert not self.api.get_tx_power_support()

--- a/tests/sonic_xcvr/test_sff8436.py
+++ b/tests/sonic_xcvr/test_sff8436.py
@@ -102,11 +102,13 @@ class TestSff8436(object):
         with patch.object(self.api, 'is_copper', return_value=True):
             assert self.api.get_rx_power() == ['N/A'] * self.api.NUM_CHANNELS
             assert self.api.get_tx_bias() == ['N/A'] * self.api.NUM_CHANNELS
+            assert self.api.get_rx_los() == ['N/A'] * self.api.NUM_CHANNELS
             assert self.api.get_module_temperature() == 'N/A'
             assert self.api.get_voltage() == 'N/A'
             assert not self.api.get_tx_power_support()
             assert not self.api.get_rx_power_support()
-            assert not self.api.get_rx_power_support()
+            assert not self.api.get_tx_bias_support()
+            assert not self.api.get_rx_los_support()
             assert not self.api.get_temperature_support()
             assert not self.api.get_voltage_support()
 

--- a/tests/sonic_xcvr/test_sff8636.py
+++ b/tests/sonic_xcvr/test_sff8636.py
@@ -299,11 +299,3 @@ class TestSff8636(object):
         self.api.get_rx_power_support.return_value = mock_response[10]
         result = self.api.get_transceiver_dom_real_value()
         assert result == expected
-
-        # Test when tx_bias_support is False
-        # self.api.get_tx_bias_support.return_value = False
-        # result = self.api.get_transceiver_dom_real_value()
-        # assert result['tx1bias'] == 'N/A'
-        # assert result['tx2bias'] == 'N/A'
-        # assert result['tx3bias'] == 'N/A'
-        # assert result['tx4bias'] == 'N/A'

--- a/tests/sonic_xcvr/test_sff8636.py
+++ b/tests/sonic_xcvr/test_sff8636.py
@@ -299,3 +299,10 @@ class TestSff8636(object):
         result = self.api.get_transceiver_dom_real_value()
         assert result == expected
 
+        # Test when tx_bias_support is False
+        self.api.get_tx_bias_support.return_value = False
+        result = self.api.get_transceiver_dom_real_value()
+        assert result['tx1bias'] == 'N/A'
+        assert result['tx2bias'] == 'N/A'
+        assert result['tx3bias'] == 'N/A'
+        assert result['tx4bias'] == 'N/A'

--- a/tests/sonic_xcvr/test_sff8636.py
+++ b/tests/sonic_xcvr/test_sff8636.py
@@ -102,8 +102,8 @@ class TestSff8636(object):
 
     def test_simulate_copper(self):
         with patch.object(self.api, 'is_copper', return_value=True):
-            assert self.api.get_tx_power() == ['N/A'] * self.api.NUM_CHANNELS
             assert self.api.get_rx_power() == ['N/A'] * self.api.NUM_CHANNELS
+            assert self.api.get_tx_bias() == ['N/A'] * self.api.NUM_CHANNELS
             assert not self.api.get_tx_power_support()
             assert not self.api.get_rx_power_support()
             assert not self.api.get_rx_power_support()

--- a/tests/sonic_xcvr/test_sff8636.py
+++ b/tests/sonic_xcvr/test_sff8636.py
@@ -104,9 +104,11 @@ class TestSff8636(object):
         with patch.object(self.api, 'is_copper', return_value=True):
             assert self.api.get_rx_power() == ['N/A'] * self.api.NUM_CHANNELS
             assert self.api.get_tx_bias() == ['N/A'] * self.api.NUM_CHANNELS
+            assert self.api.get_rx_los() == ['N/A'] * self.api.NUM_CHANNELS
             assert not self.api.get_tx_power_support()
             assert not self.api.get_rx_power_support()
-            assert not self.api.get_rx_power_support()
+            assert not self.api.get_tx_bias_support()
+            assert not self.api.get_rx_los_support()
             assert not self.api.get_temperature_support()
             assert not self.api.get_voltage_support()
 

--- a/tests/sonic_xcvr/test_sff8636.py
+++ b/tests/sonic_xcvr/test_sff8636.py
@@ -299,3 +299,4 @@ class TestSff8636(object):
         self.api.get_rx_power_support.return_value = mock_response[10]
         result = self.api.get_transceiver_dom_real_value()
         assert result == expected
+

--- a/tests/sonic_xcvr/test_sff8636.py
+++ b/tests/sonic_xcvr/test_sff8636.py
@@ -102,6 +102,7 @@ class TestSff8636(object):
 
     def test_simulate_copper(self):
         with patch.object(self.api, 'is_copper', return_value=True):
+            assert self.api.get_tx_power() == ['N/A'] * self.api.NUM_CHANNELS
             assert self.api.get_rx_power() == ['N/A'] * self.api.NUM_CHANNELS
             assert not self.api.get_tx_power_support()
             assert not self.api.get_rx_power_support()
@@ -270,23 +271,6 @@ class TestSff8636(object):
                 'tx1power': -10.0, 'tx2power': -10.0, 'tx3power': -10.0, 'tx4power': -10.0,
                 'rx1power': -10.0, 'rx2power': -10.0, 'rx3power': -10.0, 'rx4power': -10.0,
                 'tx1bias': 70, 'tx2bias': 70, 'tx3bias': 70, 'tx4bias': 70,
-            }
-        ),
-        (
-            [
-                50,
-                3.3,
-                [70, 70, 70, 70],
-                [0.1, 0.1, 0.1, 0.1],
-                [0.1, 0.1, 0.1, 0.1],
-                True, True, True, False, True, True
-            ],
-            {
-                'temperature': 50,
-                'voltage': 3.3,
-                'tx1power': -10.0, 'tx2power': -10.0, 'tx3power': -10.0, 'tx4power': -10.0,
-                'rx1power': -10.0, 'rx2power': -10.0, 'rx3power': -10.0, 'rx4power': -10.0,
-                'tx1bias': 'N/A', 'tx2bias': 'N/A', 'tx3bias': 'N/A', 'tx4bias': 'N/A',
             }
         )
     ])

--- a/tests/sonic_xcvr/test_sff8636.py
+++ b/tests/sonic_xcvr/test_sff8636.py
@@ -271,6 +271,23 @@ class TestSff8636(object):
                 'rx1power': -10.0, 'rx2power': -10.0, 'rx3power': -10.0, 'rx4power': -10.0,
                 'tx1bias': 70, 'tx2bias': 70, 'tx3bias': 70, 'tx4bias': 70,
             }
+        ),
+        (
+            [
+                50,
+                3.3,
+                [70, 70, 70, 70],
+                [0.1, 0.1, 0.1, 0.1],
+                [0.1, 0.1, 0.1, 0.1],
+                True, True, True, False, True, True
+            ],
+            {
+                'temperature': 50,
+                'voltage': 3.3,
+                'tx1power': -10.0, 'tx2power': -10.0, 'tx3power': -10.0, 'tx4power': -10.0,
+                'rx1power': -10.0, 'rx2power': -10.0, 'rx3power': -10.0, 'rx4power': -10.0,
+                'tx1bias': 'N/A', 'tx2bias': 'N/A', 'tx3bias': 'N/A', 'tx4bias': 'N/A',
+            }
         )
     ])
     def test_get_transceiver_dom_real_value(self, mock_response, expected):
@@ -300,9 +317,9 @@ class TestSff8636(object):
         assert result == expected
 
         # Test when tx_bias_support is False
-        self.api.get_tx_bias_support.return_value = False
-        result = self.api.get_transceiver_dom_real_value()
-        assert result['tx1bias'] == 'N/A'
-        assert result['tx2bias'] == 'N/A'
-        assert result['tx3bias'] == 'N/A'
-        assert result['tx4bias'] == 'N/A'
+        # self.api.get_tx_bias_support.return_value = False
+        # result = self.api.get_transceiver_dom_real_value()
+        # assert result['tx1bias'] == 'N/A'
+        # assert result['tx2bias'] == 'N/A'
+        # assert result['tx3bias'] == 'N/A'
+        # assert result['tx4bias'] == 'N/A'


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
 Fix the tx bias response for sff8436 and sff8636 copper interfaces. 

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
Tx bias of sff8436 and sff8636 interfaces would return as 0 even for copper interfaces. As copper interfaces don't support txbias, we change the return to 'N/A' for them. It keeps the behavior consistent with other DOM values.
#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
I looked at the output of the following commands on a sonic device:
1. `sudo sfputil show eeprom` : The output remained unchanged.
2. `show interface transce eeprom` : The output remained unchanged.
3. 
```python
# In the python shell of pmon container
from sonic_platform.platform import Platform
p = Platform()
platform_chassis = p.get_chassis()
a = platform_chassis.get_all_sfps()
apis = [i.get_xcvr_api() for i in a if i]
{i.get_transceiver_info()['serial'].strip():i.get_tx_bias() for i in apis if i}
{i.get_transceiver_info()['serial'].strip():(i.is_copper(), i.get_tx_bias_support()) for i in apis if i}
{(i.get_transceiver_info()['type'].strip(),i.is_copper(), i.get_tx_bias_support(), i.is_flat_memory()) for i in apis if i}
```
After the change, the tx_bias of sff8436 and sff8636 copper interfaces returned as 'N/A'. The output for other interfaces remained unchanged. It was tested on a testbed with following types of txvrs:
```python
>>>{(i.get_transceiver_info()['type'].strip(),i.is_copper(), i.get_tx_bias_support(), i.is_flat_memory()) for i in apis if i}
{('QSFP28 or later', False, True, False), ('QSFP28 or later', True, False, True), ('QSFP+ or later with SFF-8636 or SFF-8436', True, False, False), ('QSFP-DD Double Density 8X Pluggable Transceiver', True, False, True), ('QSFP+ or later with SFF-8636 or SFF-8436', False, True, False), ('QSFP-DD Double Density 8X Pluggable Transceiver', False, True, False), ('SFP/SFP+/SFP28', False, True, True)}
```

Before the rx_los_support change:
```python
 [print(i.get_transceiver_info()['type'].strip(),i.is_copper(), i.get_rx_los_support(), i.get_rx_los()) for i in apis if i]
QSFP-DD Double Density 8X Pluggable Transceiver False True [True, False, False, False, False, False, False, False]
QSFP-DD Double Density 8X Pluggable Transceiver False True [False, False, False, False, False, False, False, False]
QSFP-DD Double Density 8X Pluggable Transceiver False True [False, False, False, False, False, False, False, False]
QSFP-DD Double Density 8X Pluggable Transceiver False True [False, False, False, False, False, False, False, False]
QSFP-DD Double Density 8X Pluggable Transceiver False True [False, False, False, False, False, False, False, False]
QSFP-DD Double Density 8X Pluggable Transceiver False True [False, False, False, False, False, False, False, False]
QSFP-DD Double Density 8X Pluggable Transceiver False True [False, False, False, False, False, False, False, False]
QSFP-DD Double Density 8X Pluggable Transceiver True False ['N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A']
QSFP-DD Double Density 8X Pluggable Transceiver True False ['N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A']
QSFP-DD Double Density 8X Pluggable Transceiver False True [False, False, False, False, False, False, False, False]
QSFP-DD Double Density 8X Pluggable Transceiver False True [False, False, False, False, False, False, False, False]
QSFP28 or later False True [True, True, True, True]
QSFP28 or later False True [True, True, True, True]
QSFP28 or later True True [False, False, False, False]
QSFP28 or later True True [False, False, False, False]
QSFP+ or later with SFF-8636 or SFF-8436 False True [False, False, False, False]
QSFP+ or later with SFF-8636 or SFF-8436 False True [False, False, False, False]
QSFP+ or later with SFF-8636 or SFF-8436 True True [False, False, False, False]
QSFP+ or later with SFF-8636 or SFF-8436 True True [False, False, False, False]
SFP/SFP+/SFP28 False True [False]
SFP/SFP+/SFP28 False True [False]
```

After making the rx_los_support change:
```python
>>> [print(i.get_transceiver_info()['type'].strip(),i.is_copper(), i.get_rx_los_support(), i.get_rx_los()) for i in apis if i]
QSFP-DD Double Density 8X Pluggable Transceiver False True [True, False, False, False, False, False, False, False]
QSFP-DD Double Density 8X Pluggable Transceiver False True [False, False, False, False, False, False, False, False]
QSFP-DD Double Density 8X Pluggable Transceiver False True [False, False, False, False, False, False, False, False]
QSFP-DD Double Density 8X Pluggable Transceiver False True [False, False, False, False, False, False, False, False]
QSFP-DD Double Density 8X Pluggable Transceiver False True [False, False, False, False, False, False, False, False]
QSFP-DD Double Density 8X Pluggable Transceiver False True [False, False, False, False, False, False, False, False]
QSFP-DD Double Density 8X Pluggable Transceiver False True [False, False, False, False, False, False, False, False]
QSFP-DD Double Density 8X Pluggable Transceiver True False ['N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A']
QSFP-DD Double Density 8X Pluggable Transceiver True False ['N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A']
QSFP-DD Double Density 8X Pluggable Transceiver False True [False, False, False, False, False, False, False, False]
QSFP-DD Double Density 8X Pluggable Transceiver False True [False, False, False, False, False, False, False, False]
QSFP28 or later False True [True, True, True, True]
QSFP28 or later False True [True, True, True, True]
QSFP28 or later True False ['N/A', 'N/A', 'N/A', 'N/A']
QSFP28 or later True False ['N/A', 'N/A', 'N/A', 'N/A']
QSFP+ or later with SFF-8636 or SFF-8436 False True [False, False, False, False]
QSFP+ or later with SFF-8636 or SFF-8436 False True [False, False, False, False]
QSFP+ or later with SFF-8636 or SFF-8436 True False ['N/A', 'N/A', 'N/A', 'N/A']
QSFP+ or later with SFF-8636 or SFF-8436 True False ['N/A', 'N/A', 'N/A', 'N/A']
SFP/SFP+/SFP28 False True [False]
SFP/SFP+/SFP28 False True [False]
```

#### Additional Information (Optional)

