### PR TITLE
Add 1.6t/200G SerDes SFF support

### DIFF
--- a/sonic_platform_base/sonic_xcvr/codes/public/sff8024.py
+++ b/sonic_platform_base/sonic_xcvr/codes/public/sff8024.py
@@ -314,8 +314,6 @@ class Sff8024(XcvrCodes):
         32: '800G-VR8 (Placeholder)',
         33: '800G-VR4.2',
         34: '800G-SR4.2',
-        35: '1.6T-VR8.2 ',
-        36: '1.6T-SR8.2',
     }
 
     # SMF media interface IDs


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
Add new SFF codes for 1.6T/200G SerDes rate support
<!--
     Describe your changes in detail
-->

#### Motivation and Context
SFF8024 has added new codes for 1.6T and 200G SerDes rate support:
##### Host Electrical Interface

| |  |  |  |  |  |
| :---- | :---- | :---- | :---- | :---- | :---- |
| **ID** | **Host Electrical Interface (Specification Reference)** | **Application Bit Rate (Gb/s)** | **Lane Count** | **Lane Signaling Rate (GBd)** | **Modulation** |
| 30 | 200GBASE-CR1 (Clause179) | 212.5 | 1 | 106.25 | PAM4 |
| 31 | 400GBASE-CR2 (Clause179) | 425 | 2 | 106.25 | PAM4 |
| 87 | 800GBASE-CR4 (Clause179) | 850 | 4 | 106.25 | PAM4 |
| 88 | 1.6TBASE-CR8 (Clause179) | 1700 | 8 | 106.25 | PAM4 |
| 128 | 200GAUI-1 (Annex176E) | 212.5 | 1 | 106.25 | PAM4 |
| 129 | 400GAUI-2 (Annex176E) | 425 | 2 | 106.25 | PAM4 |
| 130 | 800GAUI-4 (Annex176E) | 850 | 4 | 106.25 | PAM4 |
| 131 | 1.6TAUI-8 (Annex176E) | 1700 | 8 | 106.25 | PAM4 |

##### MMF Media Interface
| |  |  |  |  |  |
| :---- | :---- | :---- | :---- | :---- | :---- |
| **ID** | **MM Media Interface (Specification Reference)** | **Application Rate** | **Lane Count** | **Lane Signaling Rate (GBd)** | **Modulation** |
| 33 | 800G-VR4.2 | 850 | 8 | 53.125 | PAM4 |
| 34 | 800G-SR4.2 | 850 | 8 | 53.125 | PAM4 |

##### SMF Media Interface
| |  |  |  |  |  |
| :---- | :---- | :---- | :---- | :---- | :---- |
| **ID** | **SM Media Interface (Specification Reference)** | **Application Bit Rate (Gb/s)** | **Lane Count** | **Lane Signaling Rate (GBd)** | **Modulation** |
| 115 | 200GBASE-DR1 (Clause 180\) | 212.5 | 1 | 106.25 | PAM4 |
| 116 | 200GBASE-DR1-2 (Clause 181\) | 212.5 | 1 | 113.4375 | PAM4 |
| 117 | 400GBASE-DR2 (Clause 180\) | 425 | 2 | 106.25 | PAM4 |
| 118 | 400GBASE-DR2-2 (Clause 181\) | 425 | 2 | 113.4375 | PAM4 |
| 119 | 800GBASE-DR4 (Clause 180\) | 850 | 4 | 106.25 | PAM4 |
| 120 | 800GBASE-DR4-2 (Clause 181\) | 850 | 4 | 113.4375 | PAM4 |
| 121 | 800GBASE-FR4-500 (Clause 183\) | 850 | 4 | 106.25 | PAM4 |
| 122 | 800GBASE-FR4 (Clause 183\) | 850 | 4 | 113.4375 | PAM4 |
| 123 | 800GBASE-LR4 (Clause 183\) | 850 | 4 | 113.4375 | PAM4 |
| 127 | 1.6TBASE-DR8 (Clause 180\) | 1700 | 8 | 106.25 | PAM4 |
| 128 | 1.6TBASE-DR8-2 (Clause 181\) | 1700 | 8 | 113.4375 | PAM4 |
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
It has not yet.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202411

#### Additional Information (Optional)

