### PR TITLE
Add abbreviation identifier for Custom Amphenol backplane cartridge

### DIFF
--- a/sonic_platform_base/sonic_xcvr/codes/public/sff8024.py
+++ b/sonic_platform_base/sonic_xcvr/codes/public/sff8024.py
@@ -73,7 +73,8 @@ class Sff8024(XcvrCodes):
         27: 'DSFP',
         28: 'Link-x4',
         29: 'Link-x8',
-        30: 'QSFP+C'
+        30: 'QSFP+C',
+        126: 'BP',  # Backplane Cartridge
     }
 
     CONNECTORS = {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
We need to add XCVR_IDENTIFIER_ABBRV code for Custom Amphenol Backplane Cartridge
https://github.com/sonic-net/sonic-platform-common/blob/4af4791f602e1684ea2aa940b73a50d9c8910f86/sonic_platform_base/sonic_xcvr/codes/public/sff8024.py#L45-L76
```
>>> print("Module type is {}".format(platform_chassis.get_sfp(port_num).get_xcvr_api().get_module_type_abbreviation()))
Module type is Unknown
>>> 
```
#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
```
>>> print("Module type is {}".format(platform_chassis.get_sfp(port_num).get_xcvr_api().get_module_type_abbreviation()))
Module type is BP
>>> 
```
#### Additional Information (Optional)
MSFT ADO - 34111221