### PR TITLE
Update MODULE_FAULT_CAUSE with additional codes (4-6)

### DIFF
--- a/sonic_platform_base/sonic_xcvr/codes/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/codes/public/cmis.py
@@ -46,6 +46,9 @@ class CmisCodes(Sff8024):
         1: 'TEC runawawy',
         2: 'Data memory corrupted',
         3: 'Program memory corrupted',
+        4: "Transmitter fault",
+        5: "Receiver fault",
+        6: "Temperature related fault",
     }
 
     DATAPATH_STATE = {


### PR DESCRIPTION
#### Description

Add missing module fault cause codes

#### Motivation and Context

`MODULE_FAULT_CAUSE` misses values from cmis standard.

#### How Has This Been Tested?

#### Additional Information (Optional)


