### PR TITLE
Add API to check if module is Linear Pluggable Optics (LPO)

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -111,6 +111,20 @@ class CmisApi(XcvrApi):
     LowPwrRequestSW = 4
     LowPwrAllowRequestHW = 6
 
+    LPO_HOST_ELECTRICAL_INTERFACE_IDS = [
+        Sff8024.HOST_ELECTRICAL_INTERFACE[32],
+        Sff8024.HOST_ELECTRICAL_INTERFACE[33],
+        Sff8024.HOST_ELECTRICAL_INTERFACE[34],
+        Sff8024.HOST_ELECTRICAL_INTERFACE[35]
+    ]
+
+    LPO_SM_MEDIA_INTERFACE_IDS = [
+        Sff8024.SM_MEDIA_INTERFACE[151],
+        Sff8024.SM_MEDIA_INTERFACE[152],
+        Sff8024.SM_MEDIA_INTERFACE[153],
+        Sff8024.SM_MEDIA_INTERFACE[154]
+    ]
+
     # Default caching enabled; control via classmethod
     cache_enabled = True
 
@@ -591,6 +605,25 @@ class CmisApi(XcvrApi):
         '''
         media_intf = self.get_module_media_type()
         return media_intf == "passive_copper_media_interface" if media_intf else None
+
+    def is_lpo(self):
+        '''
+        Returns True if the module is LPO, False otherwise
+        '''
+        appl_advt = self.get_application_advertisement()
+        if not appl_advt:
+            return False
+
+        for appl_dict in appl_advt.values():
+            host_intf = appl_dict.get('host_electrical_interface_id')
+            media_intf = appl_dict.get('module_media_interface_id')
+            if (
+                host_intf in self.LPO_HOST_ELECTRICAL_INTERFACE_IDS or
+                media_intf in self.LPO_SM_MEDIA_INTERFACE_IDS
+            ):
+                return True
+
+        return False
 
     @read_only_cached_api_return
     def is_flat_memory(self):

--- a/sonic_platform_base/sonic_xcvr/api/xcvr_api.py
+++ b/sonic_platform_base/sonic_xcvr/api/xcvr_api.py
@@ -685,3 +685,12 @@ class XcvrApi(object):
             bool: True if the provision succeeds, False if it fails
         """
         raise NotImplementedError
+
+    def is_lpo(self):
+        """
+        Check if the module is Linear Pluggable Optics (LPO)
+
+        Returns:
+            A Boolean, True if the module is LPO, False otherwise
+        """
+        raise NotImplementedError


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

Add `is_lpo` API to check if the module is Linear Pluggable Optics (LPO)

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
This API will be consumed by https://github.com/sonic-net/sonic-platform-daemons/pull/687

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)

