### PR TITLE
[SED] Change/Reset SED password CLI

### DIFF
--- a/sonic_platform_base/chassis_base.py
+++ b/sonic_platform_base/chassis_base.py
@@ -73,6 +73,8 @@ class ChassisBase(device_base.DeviceBase):
         # BMC
         self._bmc = None
 
+        # SED (Self-Encrypting Drive) password management
+        self._sed_mgmt = None
 
     def get_base_mac(self):
         """
@@ -813,23 +815,11 @@ class ChassisBase(device_base.DeviceBase):
         """
         return self._bmc
 
-    def change_sed_password(self, new_password):
+    def get_sed_mgmt(self):
         """
-        Change the SED (Self-Encrypting Drive) password for the platform.
-
-        Args:
-            new_password (str): The new password to set for the SED
+        Get SED (Self-Encrypting Drive) password management object for the platform.
 
         Returns:
-            bool: True if the password change process completed successfully, False otherwise
+            An object derived from SedMgmtBase, or None if SED management is not supported.
         """
-        raise NotImplementedError
-
-    def reset_sed_password(self):
-        """
-        Reset the SED (Self-Encrypting Drive) password to default for the platform.
-
-        Returns:
-            bool: True if the password reset process completed successfully, False otherwise
-        """
-        raise NotImplementedError
+        return self._sed_mgmt

--- a/sonic_platform_base/chassis_base.py
+++ b/sonic_platform_base/chassis_base.py
@@ -813,3 +813,23 @@ class ChassisBase(device_base.DeviceBase):
         """
         return self._bmc
 
+    def change_sed_password(self, new_password):
+        """
+        Change the SED (Self-Encrypting Drive) password for the platform.
+
+        Args:
+            new_password (str): The new password to set for the SED
+
+        Returns:
+            bool: True if the password change process completed successfully, False otherwise
+        """
+        raise NotImplementedError
+
+    def reset_sed_password(self):
+        """
+        Reset the SED (Self-Encrypting Drive) password to default for the platform.
+
+        Returns:
+            bool: True if the password reset process completed successfully, False otherwise
+        """
+        raise NotImplementedError

--- a/sonic_platform_base/sed_mgmt_base.py
+++ b/sonic_platform_base/sed_mgmt_base.py
@@ -1,0 +1,144 @@
+"""
+    sed_mgmt_base.py
+
+    Base class for SED (Self-Encrypting Drive) password management.
+    Platform-specific SedMgmt implementations override the abstract getters.
+"""
+
+
+import subprocess
+from sonic_py_common.logger import Logger
+
+
+logger = Logger('sed_mgmt_base')
+
+
+SED_CONFIG_PATH = '/etc/sonic/sed_config.conf'
+
+
+def _read_sed_config_value(key):
+    """Read a key=value from SED config file. Returns value or None."""
+    try:
+        with open(SED_CONFIG_PATH) as f:
+            for line in f:
+                line = line.strip()
+                if line.startswith(key + '='):
+                    return line.split('=', 1)[1].strip() or None
+    except Exception:
+        pass
+    return None
+
+
+class SedMgmtBase:
+    """
+    Base class for SED password management.
+    Implements change_sed_password and reset_sed_password using abstract getters.
+    """
+
+    SED_PW_CHANGE_SCRIPT = '/usr/local/bin/sed_pw_change.sh'
+    SED_PW_RESET_SCRIPT = '/usr/local/bin/sed_pw_reset.sh'
+
+    def get_min_sed_password_len(self):
+        """
+        Return minimum allowed SED password length.
+
+        Returns:
+            int: Minimum length (e.g. 8).
+        """
+        raise NotImplementedError
+
+    def get_max_sed_password_len(self):
+        """
+        Return maximum allowed SED password length.
+
+        Returns:
+            int: Maximum length (e.g. 124).
+        """
+        raise NotImplementedError
+
+    def get_default_sed_password(self):
+        """
+        Return the platform default SED password.
+
+        Returns:
+            str: Default password, or None on failure.
+        """
+        raise NotImplementedError
+
+    def get_tpm_bank_a_address(self):
+        """
+        Return TPM bank A persistent handle for SED password (e.g. 0x81010001).
+
+        Returns:
+            str: TPM bank A address.
+        """
+        return _read_sed_config_value('tpm_bank_a')
+
+    def get_tpm_bank_b_address(self):
+        """
+        Return TPM bank B persistent handle for SED password (e.g. 0x81010002).
+
+        Returns:
+            str: TPM bank B address.
+        """
+        return _read_sed_config_value('tpm_bank_b')
+
+    def change_sed_password(self, new_password):
+        """
+        Change the SED password. Validates length and runs the common script.
+
+        Args:
+            new_password (str): The new password to set.
+
+        Returns:
+            bool: True if successful, False otherwise.
+        """
+        try:
+            min_len = self.get_min_sed_password_len()
+            max_len = self.get_max_sed_password_len()
+            if len(new_password) < min_len or len(new_password) > max_len:
+                logger.log_error(f"SED password length is not valid: {len(new_password)}. min_len: {min_len}, max_len: {max_len}")
+                return False
+            bank_a = self.get_tpm_bank_a_address()
+            bank_b = self.get_tpm_bank_b_address()
+            if not bank_a or not bank_b:
+                logger.log_error(f"TPM bank address is not valid: bank_a: {bank_a}, bank_b: {bank_b}. Check {SED_CONFIG_PATH}.")
+                return False
+            subprocess.check_call(
+                [self.SED_PW_CHANGE_SCRIPT, '-a', bank_a, '-b', bank_b, '-p', new_password],
+                universal_newlines=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.PIPE
+            )
+            return True
+        except Exception as e:
+            logger.log_error(f"Failed to change SED password: {e}")
+            return False
+
+    def reset_sed_password(self):
+        """
+        Reset the SED password to the platform default.
+
+        Returns:
+            bool: True if successful, False otherwise.
+        """
+        try:
+            default_pw = self.get_default_sed_password()
+            if not default_pw:
+                logger.log_error("Failed to get default SED password.")
+                return False
+            bank_a = self.get_tpm_bank_a_address()
+            bank_b = self.get_tpm_bank_b_address()
+            if not bank_a or not bank_b:
+                logger.log_error(f"TPM bank address is not valid: bank_a: {bank_a}, bank_b: {bank_b}. Check {SED_CONFIG_PATH}.")
+                return False
+            subprocess.check_call(
+                [self.SED_PW_RESET_SCRIPT, '-a', bank_a, '-b', bank_b, '-p', default_pw],
+                universal_newlines=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.PIPE
+            )
+            return True
+        except Exception as e:
+            logger.log_error(f"Failed to reset SED password: {e}")
+            return False

--- a/tests/chassis_base_test.py
+++ b/tests/chassis_base_test.py
@@ -25,6 +25,8 @@ class TestChassisBase:
                 [chassis.get_dpu_id, [], {"name": "DPU0"}],
                 [chassis.get_dataplane_state, [], {}],
                 [chassis.get_controlplane_state, [], {}],
+                [chassis.change_sed_password, ["new_password"], {}],
+                [chassis.reset_sed_password, [], {}],
             ]
 
         for method in not_implemented_methods:

--- a/tests/chassis_base_test.py
+++ b/tests/chassis_base_test.py
@@ -25,8 +25,6 @@ class TestChassisBase:
                 [chassis.get_dpu_id, [], {"name": "DPU0"}],
                 [chassis.get_dataplane_state, [], {}],
                 [chassis.get_controlplane_state, [], {}],
-                [chassis.change_sed_password, ["new_password"], {}],
-                [chassis.reset_sed_password, [], {}],
             ]
 
         for method in not_implemented_methods:
@@ -67,6 +65,13 @@ class TestChassisBase:
         mock_bmc = "mock_bmc_instance"
         chassis._bmc = mock_bmc
         assert(chassis.get_bmc() == mock_bmc)
+
+    def test_get_sed_mgmt(self):
+        chassis = ChassisBase()
+        assert(chassis.get_sed_mgmt() == None)
+        mock_sed_mgmt = "mock_sed_mgmt_instance"
+        chassis._sed_mgmt = mock_sed_mgmt
+        assert(chassis.get_sed_mgmt() == mock_sed_mgmt)
 
     def test_is_bmc(self):
         chassis = ChassisBase()

--- a/tests/sed_mgmt_base_test.py
+++ b/tests/sed_mgmt_base_test.py
@@ -1,0 +1,179 @@
+"""
+    sed_mgmt_base_test.py
+
+    Unit tests for SedMgmtBase class.
+"""
+
+import sys
+import pytest
+if sys.version_info.major == 3:
+    from unittest import mock
+else:
+    import mock
+
+try:
+    from sonic_py_common import logger
+except ImportError:
+    sys.modules['sonic_py_common'] = mock.MagicMock()
+    sys.modules['sonic_py_common.logger'] = mock.MagicMock()
+
+from sonic_platform_base.sed_mgmt_base import (
+    SedMgmtBase,
+    _read_sed_config_value,
+)
+
+
+class TestSedMgmtBase:
+    """Test class for SedMgmtBase."""
+
+    def test_abstract_methods_raise_not_implemented(self):
+        """Test that abstract getters raise NotImplementedError."""
+        class IncompleteSedMgmt(SedMgmtBase):
+            pass
+
+        sed = IncompleteSedMgmt()
+        not_implemented_methods = [
+            [sed.get_min_sed_password_len],
+            [sed.get_max_sed_password_len],
+            [sed.get_default_sed_password],
+        ]
+        for method_list in not_implemented_methods:
+            with pytest.raises(NotImplementedError):
+                method_list[0]()
+
+    @mock.patch('sonic_platform_base.sed_mgmt_base._read_sed_config_value')
+    def test_get_tpm_bank_addresses_from_config(self, mock_read):
+        """Test that base get_tpm_bank_a/b use config reader."""
+        mock_read.side_effect = lambda k: {'tpm_bank_a': '0x81010001', 'tpm_bank_b': '0x81010002'}.get(k)
+        class IncompleteSedMgmt(SedMgmtBase):
+            def get_min_sed_password_len(self):
+                return 8
+            def get_max_sed_password_len(self):
+                return 124
+            def get_default_sed_password(self):
+                return None
+
+        sed = IncompleteSedMgmt()
+        assert sed.get_tpm_bank_a_address() == '0x81010001'
+        assert sed.get_tpm_bank_b_address() == '0x81010002'
+        assert mock_read.call_count == 2
+
+
+class ConcreteSedMgmt(SedMgmtBase):
+    """Concrete implementation of SedMgmtBase for testing."""
+
+    def get_min_sed_password_len(self):
+        return 8
+
+    def get_max_sed_password_len(self):
+        return 124
+
+    def get_default_sed_password(self):
+        return 'default_secret'
+
+    def get_tpm_bank_a_address(self):
+        return '0x81010001'
+
+    def get_tpm_bank_b_address(self):
+        return '0x81010002'
+
+
+class TestSedMgmtBaseWithConcrete:
+    """Test SedMgmtBase methods that require concrete implementation."""
+
+    def test_change_sed_password_length_too_short(self):
+        """Test change_sed_password returns False when password too short."""
+        sed = ConcreteSedMgmt()
+        assert sed.change_sed_password('short') is False
+
+    def test_change_sed_password_length_too_long(self):
+        """Test change_sed_password returns False when password too long."""
+        sed = ConcreteSedMgmt()
+        long_pw = 'a' * 125
+        assert sed.change_sed_password(long_pw) is False
+
+    def test_change_sed_password_missing_bank_a(self):
+        """Test change_sed_password returns False when bank_a is missing."""
+        sed = ConcreteSedMgmt()
+        with mock.patch.object(sed, 'get_tpm_bank_a_address', return_value=None):
+            assert sed.change_sed_password('validpassword123') is False
+
+    def test_change_sed_password_missing_bank_b(self):
+        """Test change_sed_password returns False when bank_b is missing."""
+        sed = ConcreteSedMgmt()
+        with mock.patch.object(sed, 'get_tpm_bank_b_address', return_value=''):
+            assert sed.change_sed_password('validpassword123') is False
+
+    @mock.patch('subprocess.check_call')
+    def test_change_sed_password_success(self, mock_check_call):
+        """Test change_sed_password succeeds and calls script with correct args."""
+        sed = ConcreteSedMgmt()
+        result = sed.change_sed_password('validpassword123')
+        assert result is True
+        mock_check_call.assert_called_once()
+        call_args = mock_check_call.call_args[0][0]
+        assert call_args[0] == SedMgmtBase.SED_PW_CHANGE_SCRIPT
+        assert '-a' in call_args and '0x81010001' in call_args
+        assert '-b' in call_args and '0x81010002' in call_args
+        assert '-p' in call_args and 'validpassword123' in call_args
+
+    @mock.patch('subprocess.check_call')
+    def test_change_sed_password_script_fails(self, mock_check_call):
+        """Test change_sed_password returns False when script raises."""
+        import subprocess
+        mock_check_call.side_effect = subprocess.CalledProcessError(1, 'sed_pw_change.sh')
+        sed = ConcreteSedMgmt()
+        assert sed.change_sed_password('validpassword123') is False
+
+    def test_reset_sed_password_no_default(self):
+        """Test reset_sed_password returns False when default password is None."""
+        sed = ConcreteSedMgmt()
+        with mock.patch.object(sed, 'get_default_sed_password', return_value=None):
+            assert sed.reset_sed_password() is False
+
+    def test_reset_sed_password_missing_bank_a(self):
+        """Test reset_sed_password returns False when bank_a is missing."""
+        sed = ConcreteSedMgmt()
+        with mock.patch.object(sed, 'get_tpm_bank_a_address', return_value=None):
+            assert sed.reset_sed_password() is False
+
+    @mock.patch('subprocess.check_call')
+    def test_reset_sed_password_success(self, mock_check_call):
+        """Test reset_sed_password succeeds and calls script with default password."""
+        sed = ConcreteSedMgmt()
+        result = sed.reset_sed_password()
+        assert result is True
+        mock_check_call.assert_called_once()
+        call_args = mock_check_call.call_args[0][0]
+        assert call_args[0] == SedMgmtBase.SED_PW_RESET_SCRIPT
+        assert '-a' in call_args and '0x81010001' in call_args
+        assert '-b' in call_args and '0x81010002' in call_args
+        assert '-p' in call_args and 'default_secret' in call_args
+
+    @mock.patch('subprocess.check_call')
+    def test_reset_sed_password_script_fails(self, mock_check_call):
+        """Test reset_sed_password returns False when script raises."""
+        import subprocess
+        mock_check_call.side_effect = subprocess.CalledProcessError(1, 'sed_pw_reset.sh')
+        sed = ConcreteSedMgmt()
+        assert sed.reset_sed_password() is False
+
+
+class TestReadSedConfigValue:
+    """Test _read_sed_config_value helper."""
+
+    def test_read_sed_config_value_missing_file(self):
+        """Test _read_sed_config_value returns None when file is missing."""
+        with mock.patch('builtins.open', side_effect=OSError(2, 'No such file')):
+            assert _read_sed_config_value('tpm_bank_a') is None
+
+    def test_read_sed_config_value_found(self):
+        """Test _read_sed_config_value returns value when key present."""
+        with mock.patch('builtins.open', mock.mock_open(read_data='tpm_bank_a=0x81010001\ntpm_bank_b=0x81010002\n')):
+            assert _read_sed_config_value('tpm_bank_a') == '0x81010001'
+            assert _read_sed_config_value('tpm_bank_b') == '0x81010002'
+
+    def test_read_sed_config_value_key_missing(self):
+        """Test _read_sed_config_value returns None when key not in file."""
+        with mock.patch('builtins.open', mock.mock_open(read_data='other=value\n')):
+            assert _read_sed_config_value('tpm_bank_a') is None


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

HLD: https://github.com/sonic-net/SONiC/pull/2171

#### Description
<!--
     Describe your changes in detail
-->
I added BaseSedMgmt to provide support for changing/resetting the SED password.
It will be used by the new relevant CLIs.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
We want to be able to change and reset the SED password via SONiC CLI.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
config sed change-password
config sed reset-password

#### Additional Information (Optional)

