### PR TITLE
Fix invalid escape sequence warnings in ssd.py

### DIFF
--- a/sonic_platform_base/sonic_storage/ssd.py
+++ b/sonic_platform_base/sonic_storage/ssd.py
@@ -153,32 +153,32 @@ class SsdUtil(StorageCommon):
         self.ssd_info = self._execute_shell(self.vendor_ssd_utility["Generic"]["utility"].format(diskdev))
 
     def parse_nvme_ssd_info(self):
-        self.model = self._parse_re('Model Number:\s*(.+?)\n', self.ssd_info)
+        self.model = self._parse_re(r'Model Number:\s*(.+?)\n', self.ssd_info)
 
-        health_raw = self._parse_re('Percentage Used\s*(.+?)\n', self.ssd_info)
+        health_raw = self._parse_re(r'Percentage Used\s*(.+?)\n', self.ssd_info)
         if health_raw == NOT_AVAILABLE:
             self.health = NOT_AVAILABLE
         else:
             health_raw = health_raw.split()[-1]
             self.health = 100 - float(health_raw.strip('%'))
 
-        temp_raw = self._parse_re('Temperature\s*(.+?)\n', self.ssd_info)
+        temp_raw = self._parse_re(r'Temperature\s*(.+?)\n', self.ssd_info)
         if temp_raw == NOT_AVAILABLE:
             self.temperature = NOT_AVAILABLE
         else:
             temp_raw = temp_raw.split()[-2]
             self.temperature = float(temp_raw)
 
-        spare_blocks_raw = self._parse_re('Available Spare\s*(.+?)\n', self.ssd_info)
+        spare_blocks_raw = self._parse_re(r'Available Spare\s*(.+?)\n', self.ssd_info)
         if spare_blocks_raw != NOT_AVAILABLE:
             spare_blocks_raw = spare_blocks_raw.split()[-1]
             self.reserved_blocks = float(spare_blocks_raw.strip('%'))
 
-        disk_io_reads_raw = self._parse_re('Data Units Read\s*(.+?)\n', self.ssd_info)
+        disk_io_reads_raw = self._parse_re(r'Data Units Read\s*(.+?)\n', self.ssd_info)
         if disk_io_reads_raw != NOT_AVAILABLE:
             self.disk_io_reads = disk_io_reads_raw.split(':')[-1].strip()
 
-        disk_io_writes_raw = self._parse_re('Data Units Written\s*(.+?)\n', self.ssd_info)
+        disk_io_writes_raw = self._parse_re(r'Data Units Written\s*(.+?)\n', self.ssd_info)
         if disk_io_writes_raw != NOT_AVAILABLE:
             self.disk_io_writes = disk_io_writes_raw.split(':')[-1].strip()
 
@@ -188,9 +188,9 @@ class SsdUtil(StorageCommon):
         if "nvme" in self.dev:
             self.parse_nvme_ssd_info()
         else:
-            self.model = self._parse_re('Device Model:\s*(.+?)\n', self.ssd_info)
+            self.model = self._parse_re(r'Device Model:\s*(.+?)\n', self.ssd_info)
 
-            health_raw = self._parse_re('Remaining_Lifetime_Perc\s*(.+?)\n', self.ssd_info)
+            health_raw = self._parse_re(r'Remaining_Lifetime_Perc\s*(.+?)\n', self.ssd_info)
             if health_raw == NOT_AVAILABLE:
                 for health_id in GENERIC_HEALTH_ID:
                     health_raw = self.parse_id_number(health_id, self.ssd_info)
@@ -200,7 +200,7 @@ class SsdUtil(StorageCommon):
             else:
                 self.health = health_raw.split()[-1]
 
-            temp_raw = self._parse_re('Temperature_Celsius\s*(.+?)\n', self.ssd_info)
+            temp_raw = self._parse_re(r'Temperature_Celsius\s*(.+?)\n', self.ssd_info)
             if temp_raw == NOT_AVAILABLE:
                 self.temperature = NOT_AVAILABLE
             else:
@@ -219,15 +219,15 @@ class SsdUtil(StorageCommon):
                     self.reserved_blocks = rbc_raw.split()[-1]
                     break
 
-        self.serial = self._parse_re('Serial Number:\s*(.+?)\n', self.ssd_info)
-        self.firmware = self._parse_re('Firmware Version:\s*(.+?)\n', self.ssd_info)
+        self.serial = self._parse_re(r'Serial Number:\s*(.+?)\n', self.ssd_info)
+        self.firmware = self._parse_re(r'Firmware Version:\s*(.+?)\n', self.ssd_info)
 
     def parse_innodisk_info(self):
         if self.vendor_ssd_info:
-            if self.health == NOT_AVAILABLE: self.health = self._parse_re('Health:\s*(.+?)%', self.vendor_ssd_info)
-            if self.temperature == NOT_AVAILABLE: self.temperature = self._parse_re('Temperature\s*\[\s*(.+?)\]', self.vendor_ssd_info)
-            if self.firmware == NOT_AVAILABLE: self.firmware = (self._parse_re('.*FW.*', self.vendor_ssd_info)).split()[-1]
-            if self.serial == NOT_AVAILABLE: self.serial = (self._parse_re('.*Serial.*', self.vendor_ssd_info)).split()[-1]
+            if self.health == NOT_AVAILABLE: self.health = self._parse_re(r'Health:\s*(.+?)%', self.vendor_ssd_info)
+            if self.temperature == NOT_AVAILABLE: self.temperature = self._parse_re(r'Temperature\s*\[\s*(.+?)\]', self.vendor_ssd_info)
+            if self.firmware == NOT_AVAILABLE: self.firmware = (self._parse_re(r'.*FW.*', self.vendor_ssd_info)).split()[-1]
+            if self.serial == NOT_AVAILABLE: self.serial = (self._parse_re(r'.*Serial.*', self.vendor_ssd_info)).split()[-1]
 
         if self.health == NOT_AVAILABLE:
             health_raw = self.parse_id_number("[{}]".format(hex(INNODISK_HEALTH_ID)[2:]).upper(), self.vendor_ssd_info)
@@ -262,7 +262,7 @@ class SsdUtil(StorageCommon):
 
     def parse_virtium_info(self):
         if self.vendor_ssd_info:
-            vendor_temp = self._parse_re('Temperature_Celsius\s*\d*\s*(\d+?)\s+', self.vendor_ssd_info)
+            vendor_temp = self._parse_re(r'Temperature_Celsius\s*\d*\s*(\d+?)\s+', self.vendor_ssd_info)
             if vendor_temp != NOT_AVAILABLE:
                 self.temperature = vendor_temp
 
@@ -275,8 +275,8 @@ class SsdUtil(StorageCommon):
                 health_raw = self.parse_id_number(VIRTIUM_HEALTH_ID, self.vendor_ssd_info)
                 self.health = float(health_raw.split()[2]) if health_raw != NOT_AVAILABLE else NOT_AVAILABLE
             else :
-                nand_endurance = self._parse_re('NAND_Endurance\s*\d*\s*(\d+?)\s+', self.vendor_ssd_info)
-                avg_erase_count = self._parse_re('Average_Erase_Count\s*\d*\s*(\d+?)\s+', self.vendor_ssd_info)
+                nand_endurance = self._parse_re(r'NAND_Endurance\s*\d*\s*(\d+?)\s+', self.vendor_ssd_info)
+                avg_erase_count = self._parse_re(r'Average_Erase_Count\s*\d*\s*(\d+?)\s+', self.vendor_ssd_info)
                 if nand_endurance != NOT_AVAILABLE and avg_erase_count != NOT_AVAILABLE:
                     try:
                         self.health = 100 - (float(avg_erase_count) * 100 / float(nand_endurance))
@@ -286,7 +286,7 @@ class SsdUtil(StorageCommon):
                 else:
                     health_raw = NOT_AVAILABLE
                     try:
-                        pattern = 'Remaining_Life_Left\s*\d*\s*(\d+?)\s+'
+                        pattern = r'Remaining_Life_Left\s*\d*\s*(\d+?)\s+'
                         health_raw = self._parse_re(pattern, self.vendor_ssd_info)
                         self.health = float(health_raw.split()[-1]) if health_raw != NOT_AVAILABLE else NOT_AVAILABLE
                     except ValueError as ex:
@@ -329,9 +329,9 @@ class SsdUtil(StorageCommon):
 
     def parse_micron_info(self):
         if self.vendor_ssd_info:
-            health_raw = self._parse_re('{}\s*(.+?)\n'.format('Percent_Lifetime_Used'), self.vendor_ssd_info)
+            health_raw = self._parse_re(r'{}\s*(.+?)\n'.format('Percent_Lifetime_Used'), self.vendor_ssd_info)
             if health_raw == NOT_AVAILABLE:
-                health_raw = self._parse_re('{}\s*(.+?)\n'.format('Percent_Lifetime_Remain'), self.vendor_ssd_info)
+                health_raw = self._parse_re(r'{}\s*(.+?)\n'.format('Percent_Lifetime_Remain'), self.vendor_ssd_info)
                 self.health = health_raw.split()[-1]
             else:
                 self.health = str(100 - int(health_raw.split()[-1]))


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

Use raw string literals (r'...') for all regex patterns passed to _parse_re() to avoid SyntaxWarning for \s, \d etc. in non-raw strings.
Fixes tjpse pattern and all other _parse_re call sites.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

There are warnings when the first time these Python files are called for the first time

```
admin@sonic:/usr/local/lib/python3.13/dist-packages/sonic_platform_base/sonic_storage/__pycache__$ show platform ssd                                                                              
/usr/local/lib/python3.13/dist-packages/sonic_platform_base/sonic_storage/ssd.py:156: SyntaxWarning: invalid escape sequence '\s'                                                                           
  self.model = self._parse_re('Model Number:\s*(.+?)\n', self.ssd_info)                                                                                                                                     
/usr/local/lib/python3.13/dist-packages/sonic_platform_base/sonic_storage/ssd.py:158: SyntaxWarning: invalid escape sequence '\s'                                                                           
  health_raw = self._parse_re('Percentage Used\s*(.+?)\n', self.ssd_info)                                                                                                                                   
/usr/local/lib/python3.13/dist-packages/sonic_platform_base/sonic_storage/ssd.py:165: SyntaxWarning: invalid escape sequence '\s'                                                                           
  temp_raw = self._parse_re('Temperature\s*(.+?)\n', self.ssd_info)                                                                                                                                         
/usr/local/lib/python3.13/dist-packages/sonic_platform_base/sonic_storage/ssd.py:172: SyntaxWarning: invalid escape sequence '\s'                                                                           
  spare_blocks_raw = self._parse_re('Available Spare\s*(.+?)\n', self.ssd_info)                                                                                                                             
/usr/local/lib/python3.13/dist-packages/sonic_platform_base/sonic_storage/ssd.py:177: SyntaxWarning: invalid escape sequence '\s'                                                                           
  disk_io_reads_raw = self._parse_re('Data Units Read\s*(.+?)\n', self.ssd_info)                                                                                                                            
/usr/local/lib/python3.13/dist-packages/sonic_platform_base/sonic_storage/ssd.py:181: SyntaxWarning: invalid escape sequence '\s'                                                                           
  disk_io_writes_raw = self._parse_re('Data Units Written\s*(.+?)\n', self.ssd_info)                                                                                                                        
/usr/local/lib/python3.13/dist-packages/sonic_platform_base/sonic_storage/ssd.py:191: SyntaxWarning: invalid escape sequence '\s'                                                                           
  self.model = self._parse_re('Device Model:\s*(.+?)\n', self.ssd_info)                                                                                                                                     
/usr/local/lib/python3.13/dist-packages/sonic_platform_base/sonic_storage/ssd.py:193: SyntaxWarning: invalid escape sequence '\s'                                                                           
  health_raw = self._parse_re('Remaining_Lifetime_Perc\s*(.+?)\n', self.ssd_info)                                                                                                                           
/usr/local/lib/python3.13/dist-packages/sonic_platform_base/sonic_storage/ssd.py:203: SyntaxWarning: invalid escape sequence '\s'                                                                           
  temp_raw = self._parse_re('Temperature_Celsius\s*(.+?)\n', self.ssd_info)                                                                                                                                 
/usr/local/lib/python3.13/dist-packages/sonic_platform_base/sonic_storage/ssd.py:222: SyntaxWarning: invalid escape sequence '\s'                                                                           
  self.serial = self._parse_re('Serial Number:\s*(.+?)\n', self.ssd_info)                                                                                                                                   
/usr/local/lib/python3.13/dist-packages/sonic_platform_base/sonic_storage/ssd.py:223: SyntaxWarning: invalid escape sequence '\s'                                                                           
  self.firmware = self._parse_re('Firmware Version:\s*(.+?)\n', self.ssd_info)                                                                                                                              
/usr/local/lib/python3.13/dist-packages/sonic_platform_base/sonic_storage/ssd.py:227: SyntaxWarning: invalid escape sequence '\s'                                                                           
  if self.health == NOT_AVAILABLE: self.health = self._parse_re('Health:\s*(.+?)%', self.vendor_ssd_info)                                                                                                   
/usr/local/lib/python3.13/dist-packages/sonic_platform_base/sonic_storage/ssd.py:228: SyntaxWarning: invalid escape sequence '\s'                                                                           
  if self.temperature == NOT_AVAILABLE: self.temperature = self._parse_re('Temperature\s*\[\s*(.+?)\]', self.vendor_ssd_info)                                                                               
/usr/local/lib/python3.13/dist-packages/sonic_platform_base/sonic_storage/ssd.py:265: SyntaxWarning: invalid escape sequence '\s'                                                                           
  vendor_temp = self._parse_re('Temperature_Celsius\s*\d*\s*(\d+?)\s+', self.vendor_ssd_info)                                                                                                               
/usr/local/lib/python3.13/dist-packages/sonic_platform_base/sonic_storage/ssd.py:278: SyntaxWarning: invalid escape sequence '\s'                                                                           
  nand_endurance = self._parse_re('NAND_Endurance\s*\d*\s*(\d+?)\s+', self.vendor_ssd_info)                                                                                                                 
/usr/local/lib/python3.13/dist-packages/sonic_platform_base/sonic_storage/ssd.py:279: SyntaxWarning: invalid escape sequence '\s'                                                                           
  avg_erase_count = self._parse_re('Average_Erase_Count\s*\d*\s*(\d+?)\s+', self.vendor_ssd_info)                                                                                                           
/usr/local/lib/python3.13/dist-packages/sonic_platform_base/sonic_storage/ssd.py:289: SyntaxWarning: invalid escape sequence '\s'                                                                           
  pattern = 'Remaining_Life_Left\s*\d*\s*(\d+?)\s+'                                                                                                                                                         
/usr/local/lib/python3.13/dist-packages/sonic_platform_base/sonic_storage/ssd.py:332: SyntaxWarning: invalid escape sequence '\s'                                                                           
  health_raw = self._parse_re('{}\s*(.+?)\n'.format('Percent_Lifetime_Used'), self.vendor_ssd_info)                                                                                                         
/usr/local/lib/python3.13/dist-packages/sonic_platform_base/sonic_storage/ssd.py:334: SyntaxWarning: invalid escape sequence '\s'                                                                           
  health_raw = self._parse_re('{}\s*(.+?)\n'.format('Percent_Lifetime_Remain'), self.vendor_ssd_info)                                                                                                       
Disk Type    : NVME                                                                                                                                                                                         
Device Model : MD681GEGBC82                                                                                                                                                                                 
Health       : 100.0%                                                                                                                                                                                       
Temperature  : 40.0C                                                                                                                                                                                        
admin@sonic:/usr/local/lib/python3.13/dist-packages/sonic_platform_base/sonic_storage/__pycache__$ show platform ssd                                                                              
Disk Type    : NVME                                                                                                                                                                                         
Device Model : MD681GEGBC82                                                                                                                                                                                 
Health       : 100.0%                                                                                                                                                                                       
Temperature  : 40.0C                                                                                                                                                                                        
admin@sonic:/usr/local/lib/python3.13/dist-packages/sonic_platform_base/sonic_storage/__pycache__$                 
```

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)

