### PR TITLE
Fix UnicodeDecodeError in xcvr API for corrupted EEPROM vendor fields

### DIFF
--- a/sonic_platform_base/sonic_xcvr/xcvr_api_factory.py
+++ b/sonic_platform_base/sonic_xcvr/xcvr_api_factory.py
@@ -65,14 +65,14 @@ class XcvrApiFactory(object):
        name_data = self.reader(VENDOR_NAME_OFFSET, VENDOR_NAME_LENGTH)
        if name_data is None:
            return None
-       vendor_name = name_data.decode()
+       vendor_name = name_data.decode('utf-8', errors='ignore')
        return vendor_name.strip()
 
     def _get_vendor_part_num(self):
        part_num = self.reader(VENDOR_PART_NUM_OFFSET, VENDOR_PART_NUM_LENGTH)
        if part_num is None:
            return None
-       vendor_pn = part_num.decode()
+       vendor_pn = part_num.decode('utf-8', errors='ignore')
        return vendor_pn.strip()
 
     def _create_cmis_api(self):


### PR DESCRIPTION

#### Description
<!--
     Describe your changes in detail
-->
Modified `_get_vendor_name()` and `_get_vendor_part_num()` in `xcvr_api_factory.py` to use `decode('utf-8', errors='ignore')` instead of `decode()`. This allows the transceiver API to initialize successfully even when EEPROM vendor fields contain invalid UTF-8 bytes.

Invalid bytes are skipped during decode, and the API falls back to generic `CmisApi` if vendor-specific matching fails.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
Transceivers with corrupted EEPROM data (e.g., byte `0xbe` in vendor name field) fail API initialization with `UnicodeDecodeError`. This causes xcvrd to treat the module as "EEPROM not ready" and enter an infinite 60-second retry loop, preventing the transceiver from ever becoming operational.

The fix allows modules with manufacturing defects or EEPROM corruption to function with degraded metadata rather than completely failing.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Changes will not impact any transceiver with correct EEPROM for vendor_name and vendor_pn

If non utf-8 characters are present in these fields, they will be skipped
Tested on a device with the following EEPROM dump:

```
admin@str5-nh5010-ut2-5:~$ sudo sfputil show eeprom-hexdump -p Ethernet24
EEPROM hexdump for port Ethernet24 page 0h
        Lower page 0h
        00000000 18 30 80 03 00 00 00 00  00 00 00 00 00 00 00 00 |.0..............|
        00000010 00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 |................|
        00000020 00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 |................|
        00000030 00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 |................|
        00000040 00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 |................|
        00000050 00 00 00 00 00 03 1d 01  88 01 16 01 11 ff 18 01 |................|
        00000060 11 ff ff 00 00 00 00 00  00 00 00 00 00 00 00 00 |................|
        00000070 00 00 00 00 00 00 00 00  00 00 cf 45 4d 20 00 00 |...........EM ..|

        Upper page 0h
        00000080 00 41 00 00 00 be 00 00  4e 65 74 77 6f 72 6b 73 |.A......Networks|
        00000090 20 a8 b0 ae 43 41 42 2d  44 2d 44 2d 34 30 30 47 | ...CAB-D-D-400G|
        000000a0 2d 32 4d 20 30 30 5a 5a  32 34 30 39 31 33 30 36 |-2M 00ZZ24091306|
        000000b0 33 32 20 20 20 20 32 34  30 39 31 31 20 20 00 00 |32    240911  ..|
        000000c0 00 00 00 00 00 00 00 00  00 01 42 23 04 05 08 10 |..........B#....|
        000000d0 00 00 00 02 0a 00 00 00  00 00 00 00 00 00 31 00 |..............1.|
        000000e0 00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 |................|
        000000f0 00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 |................|
```

Before this change the CmisApi itself was not initialized, so the command gave the following error:

```
admin@str5-nh5010-ut2-5:~$ sudo sfputil show eeprom-hexdump -p Ethernet24
Error creating API: 'utf-8' codec can't decode byte 0xbe in position 4: invalid start byte
Error: Failed to read EEPROM for offset 0!
admin@str5-nh5010-ut2-5:~$
```

#### Additional Information (Optional)


