### PR TITLE
[module_base]: Add states and platform API for provisioning modules

### DIFF
--- a/sonic_platform_base/module_base.py
+++ b/sonic_platform_base/module_base.py
@@ -50,6 +50,16 @@ class ModuleBase(device_base.DeviceBase):
     # Module state is Present when it is powered up, but entered a fault state.
     # Module is not able to go Online.
     MODULE_STATUS_FAULT   = "Fault"
+    # Module state when module is detected, is able to run SONiC, but is not yet running SONiC.
+    # Modules in this state will be attempted to be converted to SONiC via calls to module.provision_module()
+    # This state does not make much sense if provision_module() is not implemented. 
+    MODULE_STATUS_PROVISION_READY = "ProvisionReady"
+    # Module state if module is currently undergoing provisioning.
+    # Module is not expected to be contactable in this state.
+    MODULE_STATUS_PROVISION_PENDING = "ProvisionPending"
+    # Module state once module has been provisioned successfully,
+    # but the chassis requires a reboot to fully incorporate the module. 
+    MODULE_STATUS_PROVISIONED = "Provisioned"
     # Module state is Online when fully operational
     MODULE_STATUS_ONLINE  = "Online"
 
@@ -221,7 +231,9 @@ class ModuleBase(device_base.DeviceBase):
         Returns:
             A string, the operational status of the module from one of the
             predefined status values: MODULE_STATUS_EMPTY, MODULE_STATUS_OFFLINE,
-            MODULE_STATUS_FAULT, MODULE_STATUS_PRESENT or MODULE_STATUS_ONLINE
+            MODULE_STATUS_FAULT, MODULE_STATUS_PRESENT, MODULE_STATUS_PROVISION_READY,
+            MODULE_STATUS_PROVISION_PENDING, MODULE_STATUS_PROVISIONED,
+            or MODULE_STATUS_ONLINE
         """
         raise NotImplementedError
 
@@ -267,6 +279,17 @@ class ModuleBase(device_base.DeviceBase):
         Returns:
             A float, with value of the maximum consumable power of the
             module.
+        """
+        raise NotImplementedError
+
+    def provision_module(self):
+        """
+        Request to provision the module.
+        This method should be implemented if the module supports
+        MODULE_STATUS_PROVISION_READY state.
+
+        Returns:
+            bool: True if the request has been issued successfully, False if not
         """
         raise NotImplementedError
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
HLD: https://github.com/sonic-net/SONiC/pull/2252

#### Motivation and Context
Add new module states and API to facilitate module auto-provisioning (eg. for linecard insertion / RMA)

#### How Has This Been Tested?
N/A - API spec changes only - backwards compatible / opt in only. Requires vendor code changes to introduce functionality

#### Additional Information (Optional)

