### PR TITLE
Add support for get_power_override_support in sfp API

### DIFF
--- a/sonic_platform_base/sfp_base.py
+++ b/sonic_platform_base/sfp_base.py
@@ -290,6 +290,16 @@ class SfpBase(device_base.DeviceBase, EepromReadWriteMixin):
         """
         raise NotImplementedError
 
+    def get_power_override_support(self):
+        """
+        Retrieves whether power override is supported by this SFP
+
+        Returns:
+            bool: True if power override is supported, False if not supported
+            None: if not implemented or xcvr_api is not available
+        """
+        return None
+
     def get_temperature(self):
         """
         Retrieves the temperature of this SFP

--- a/sonic_platform_base/sonic_xcvr/sfp_optoe_base.py
+++ b/sonic_platform_base/sonic_xcvr/sfp_optoe_base.py
@@ -258,6 +258,16 @@ class SfpOptoeBase(SfpBase, OptoeEepromReadWriteMixin):
         api = self.get_xcvr_api()
         return api.rx_disable_channel(channel, disable) if api is not None else None
 
+    def get_power_override_support(self):
+        """
+        Retrieves whether power override is supported by this SFP
+
+        Returns:
+            bool: True if power override is supported, False if not supported
+            None: if xcvr_api is not available
+        """
+        api = self.get_xcvr_api()
+        return api.get_power_override_support() if api is not None else None
 
     def get_power_override(self):
         api = self.get_xcvr_api()

--- a/tests/sonic_xcvr/test_sfp_base.py
+++ b/tests/sonic_xcvr/test_sfp_base.py
@@ -2,6 +2,11 @@ import pytest
 from sonic_platform_base.sfp_base import SfpBase
 from unittest.mock import MagicMock
 
+def test_get_power_override_support_default():
+    sfp = SfpBase()
+
+    assert sfp.get_power_override_support() is None
+
 def test_remove_xcvr_api_and_refresh():
     """
     Test that remove_xcvr_api clears the cached API and that get_xcvr_api
@@ -62,4 +67,4 @@ def test_old_api_handle_survives_remove_xcvr_api():
     # Thread 1 still uses old handle without crashing
     assert t1_api.get_transceiver_bulk_status() == "bulk1"
     # New handle returns its own result
-    assert t2_api.get_transceiver_bulk_status() == "bulk2" 
+    assert t2_api.get_transceiver_bulk_status() == "bulk2"

--- a/tests/sonic_xcvr/test_sfp_optoe_base.py
+++ b/tests/sonic_xcvr/test_sfp_optoe_base.py
@@ -90,6 +90,22 @@ class TestSfpOptoeBase(object):
         result = self.sfp_optoe_api.get_rx_disable_channel()
         assert result == expected
 
+    @pytest.mark.parametrize("mock_response1, mock_response2, expected", [
+        (True, cmis_api, True),
+        (False, cmis_api, False),
+        (None, None, None),
+    ])
+    def test_get_power_override_support(self, mock_response1, mock_response2, expected):
+        self.sfp_optoe_api.get_xcvr_api = MagicMock()
+        self.sfp_optoe_api.get_xcvr_api.return_value = mock_response2
+        self.cmis_api.get_power_override_support = MagicMock()
+        self.cmis_api.get_power_override_support.return_value = mock_response1
+
+        result = self.sfp_optoe_api.get_power_override_support()
+        assert result == expected
+        if mock_response2 is not None:
+            self.cmis_api.get_power_override_support.assert_called_once()
+
 
     @pytest.mark.parametrize("mock_response1, mock_response2, expected", [
         (0, cmis_api, 0),


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
This PR introduces the get_power_override_support method to the SFP API within sonic-platform-common. Needed to address: https://github.com/sonic-net/sonic-buildimage/issues/26372

sfp_base.py: Added the abstract method definition to the SfpBase class to define the interface.

sfp_optoe_base.py: Provided an implementation in SfpOptoeBase that delegates the call to the underlying transceiver API (xcvr_api).

This allows platform-specific implementations and upper-layer applications to query whether a specific SFP module supports power override capabilities before attempting to get or set override values.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

Currently, while get_power_override and set_power_override exist, there isn't a standardized way to check for feature support across different hardware modules. This change improves the robustness of the SFP interface by allowing callers to verify support programmatically, preventing unnecessary errors or invalid calls on modules that do not support this feature.

This will help us move away from hardcoded functions like these that need constant maintenance: https://github.com/sonic-net/sonic-mgmt/blob/a1d1fd8717c4525055a3a4a9e3250232ee3b0d86/tests/platform_tests/api/test_sfp.py#L374-L378

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Verified by running the test_sfp sonic-mgmt tests to use this API

#### Additional Information (Optional)
NA
