### PR TITLE
[agent][ssd] Fix NameError: nand_endurance undefined in parse_micron_info()

### DIFF
--- a/sonic_platform_base/sonic_storage/ssd.py
+++ b/sonic_platform_base/sonic_storage/ssd.py
@@ -338,9 +338,9 @@ class SsdUtil(StorageCommon):
 
             if health_raw == NOT_AVAILABLE:
                 average_erase_count = self.parse_id_number(MICRON_AVG_ERASE_COUNT_ID, self.vendor_ssd_info)
-                erase_fail_count = self.parse_id_number(MICRON_ERASE_FAIL_COUNT_ID, self.vendor_ssd_info)
+                nand_endurance = self._parse_re(r'NAND_Endurance\s*\d*\s*(\d+?)\s+', self.vendor_ssd_info)
 
-                if average_erase_count != NOT_AVAILABLE and erase_fail_count != NOT_AVAILABLE:
+                if average_erase_count != NOT_AVAILABLE and nand_endurance != NOT_AVAILABLE:
                     try:
                         self.health = 100 - (float(average_erase_count) * 100 / float(nand_endurance))
                     except (ValueError, ZeroDivisionError) as ex:

--- a/sonic_platform_base/sonic_storage/ssd.py
+++ b/sonic_platform_base/sonic_storage/ssd.py
@@ -275,8 +275,8 @@ class SsdUtil(StorageCommon):
                 health_raw = self.parse_id_number(VIRTIUM_HEALTH_ID, self.vendor_ssd_info)
                 self.health = float(health_raw.split()[2]) if health_raw != NOT_AVAILABLE else NOT_AVAILABLE
             else :
-                nand_endurance = self._parse_re(r'(?m)NAND_Endurance.*?(\d+)\s*$', self.vendor_ssd_info)
-                avg_erase_count = self._parse_re(r'(?m)Average_Erase_Count.*?(\d+)\s*$', self.vendor_ssd_info)
+                nand_endurance = self._parse_re(r'NAND_Endurance\s*\d*\s*(\d+?)\s+', self.vendor_ssd_info)
+                avg_erase_count = self._parse_re(r'Average_Erase_Count\s*\d*\s*(\d+?)\s+', self.vendor_ssd_info)
                 if nand_endurance != NOT_AVAILABLE and avg_erase_count != NOT_AVAILABLE:
                     try:
                         self.health = 100 - (float(avg_erase_count) * 100 / float(nand_endurance))
@@ -342,7 +342,7 @@ class SsdUtil(StorageCommon):
 
                 if average_erase_count != NOT_AVAILABLE and nand_endurance != NOT_AVAILABLE:
                     try:
-                        self.health = 100 - (float(average_erase_count.split()[-1]) * 100 / float(nand_endurance.split()[-1]))
+                        self.health = 100 - (float(average_erase_count.split()[-1]) * 100 / float(nand_endurance))
                     except (ValueError, ZeroDivisionError) as ex:
                         self.log.log_info("SsdUtil parse_micron_info exception: {}".format(ex))
                         pass

--- a/sonic_platform_base/sonic_storage/ssd.py
+++ b/sonic_platform_base/sonic_storage/ssd.py
@@ -342,7 +342,7 @@ class SsdUtil(StorageCommon):
 
                 if average_erase_count != NOT_AVAILABLE and nand_endurance != NOT_AVAILABLE:
                     try:
-                        self.health = 100 - (float(average_erase_count) * 100 / float(nand_endurance))
+                        self.health = 100 - (float(average_erase_count.split()[-1]) * 100 / float(nand_endurance.split()[-1]))
                     except (ValueError, ZeroDivisionError) as ex:
                         self.log.log_info("SsdUtil parse_micron_info exception: {}".format(ex))
                         pass

--- a/sonic_platform_base/sonic_storage/ssd.py
+++ b/sonic_platform_base/sonic_storage/ssd.py
@@ -275,8 +275,8 @@ class SsdUtil(StorageCommon):
                 health_raw = self.parse_id_number(VIRTIUM_HEALTH_ID, self.vendor_ssd_info)
                 self.health = float(health_raw.split()[2]) if health_raw != NOT_AVAILABLE else NOT_AVAILABLE
             else :
-                nand_endurance = self._parse_re(r'NAND_Endurance\s*\d*\s*(\d+?)\s+', self.vendor_ssd_info)
-                avg_erase_count = self._parse_re(r'Average_Erase_Count\s*\d*\s*(\d+?)\s+', self.vendor_ssd_info)
+                nand_endurance = self._parse_re(r'(?m)NAND_Endurance.*?(\d+)\s*$', self.vendor_ssd_info)
+                avg_erase_count = self._parse_re(r'(?m)Average_Erase_Count.*?(\d+)\s*$', self.vendor_ssd_info)
                 if nand_endurance != NOT_AVAILABLE and avg_erase_count != NOT_AVAILABLE:
                     try:
                         self.health = 100 - (float(avg_erase_count) * 100 / float(nand_endurance))
@@ -338,7 +338,7 @@ class SsdUtil(StorageCommon):
 
             if health_raw == NOT_AVAILABLE:
                 average_erase_count = self.parse_id_number(MICRON_AVG_ERASE_COUNT_ID, self.vendor_ssd_info)
-                nand_endurance = self._parse_re(r'NAND_Endurance\s*\d*\s*(\d+?)\s+', self.vendor_ssd_info)
+                nand_endurance = self._parse_re(r'(?m)NAND_Endurance.*?(\d+)\s*$', self.vendor_ssd_info)
 
                 if average_erase_count != NOT_AVAILABLE and nand_endurance != NOT_AVAILABLE:
                     try:

--- a/tests/test_ssd.py
+++ b/tests/test_ssd.py
@@ -1951,6 +1951,19 @@ class TestSsd:
         assert(micron_ssd.get_disk_io_writes() == '9607694422')
         assert(micron_ssd.get_reserved_blocks() == '475')
 
+    def test_micron_ssd_health_from_nand_endurance(self):
+        micron_output = output_micron_ssd.replace(
+            "202 Percent_Lifetime_Used   0x0031   075   075   000    Pre-fail  Offline      -       25\n",
+            "202 Unknown_Attribute       0x0031   075   075   000    Pre-fail  Offline      -       25\n"
+            "999 NAND_Endurance          0x0032   100   100   000    Old_age   Always       -       3028\n"
+        )
+
+        with mock.patch('sonic_platform_base.sonic_storage.ssd.SsdUtil._execute_shell',
+                        mock.MagicMock(return_value=micron_output)):
+            micron_ssd = SsdUtil('/dev/sda')
+
+        assert micron_ssd.get_health() == 75.0
+
 
     @mock.patch('sonic_platform_base.sonic_storage.ssd.SsdUtil._execute_shell', mock.MagicMock(return_value=output_intel_ssd))
     def test_intel_ssd(self):


### PR DESCRIPTION
#### What I did
Fix `NameError` in `parse_micron_info()` where `nand_endurance` is referenced but never defined.

#### How I did it
- Parse `nand_endurance` from SMART attributes using `_parse_re()` with the same `NAND_Endurance` regex pattern used in `parse_virtium_info()`
- Guard the health calculation with `nand_endurance != NOT_AVAILABLE` check
- Remove unused `erase_fail_count` variable (was fetched but never used in the calculation)

#### How to verify it
Run on a Micron SSD where `Percent_Lifetime_Used` and `Percent_Lifetime_Remain` are both unavailable — should no longer crash with `NameError`.

#### Which release branch to backport
master

#### Description for the changelog
Fix NameError crash in Micron SSD health parsing due to undefined nand_endurance variable.

Fixes: #644