### PR TITLE
Add new PDB base object and corresponding functions to chassis base object

### DIFF
--- a/sonic_platform_base/chassis_base.py
+++ b/sonic_platform_base/chassis_base.py
@@ -51,6 +51,10 @@ class ChassisBase(device_base.DeviceBase):
         # available on the chassis
         self._psu_list = []
 
+        # List of PdbBase-derived objects representing all power distribution boards
+        # available on the chassis
+        self._pdb_list = []
+
         # List of ThermalBase-derived objects representing all thermals
         # available on the chassis
         self._thermal_list = []
@@ -482,6 +486,52 @@ class ChassisBase(device_base.DeviceBase):
                              index, len(self._psu_list)-1))
 
         return psu
+
+    ##############################################
+    # PDB methods
+    ##############################################
+
+    def get_num_pdbs(self):
+        """
+        Retrieves the number of power distribution boards available on this chassis
+
+        Returns:
+            An integer, the number of power distribution boards available on this
+            chassis
+        """
+        return len(self._pdb_list)
+
+    def get_all_pdbs(self):
+        """
+        Retrieves all power distribution boards available on this chassis
+
+        Returns:
+            A list of objects derived from PdbBase representing all power
+            distribution boards available on this chassis
+        """
+        return self._pdb_list
+
+    def get_pdb(self, index):
+        """
+        Retrieves power distribution board object represented by (0-based) index <index>
+
+        Args:
+            index: An integer, the index (0-based) of the power distribution board object to
+            retrieve
+
+        Returns:
+            An object dervied from PdbBase representing the specified power
+            distribution board object
+        """
+        pdb = None
+
+        try:
+            pdb = self._pdb_list[index]
+        except IndexError:
+            sys.stderr.write("PDB index {} out of range (0-{})\n".format(
+                             index, len(self._pdb_list)-1))
+
+        return pdb
 
     ##############################################
     # THERMAL methods

--- a/sonic_platform_base/pdb_base.py
+++ b/sonic_platform_base/pdb_base.py
@@ -1,0 +1,89 @@
+"""
+    pdb_base.py
+
+    Abstract base class for implementing a platform-specific class with which
+    to interact with a power distribution board (PDB) in SONiC. PDB is used on
+    direct-current platforms and replaces PSU. This class inherits from PsuBase
+    to allow reuse of PSU daemon and CLI for a consistent power monitoring experience.
+"""
+
+from . import psu_base
+
+
+class PdbBase(psu_base.PsuBase):
+    """
+    Abstract base class for interfacing with a power distribution board (PDB).
+    Inherits from PsuBase so that PSU daemon and CLI can operate on PDB objects
+    with a consistent user experience. PDB is generally not replaceable and has
+    thermals but no fans.
+    """
+    # Device type definition. Note, this is a constant.
+    DEVICE_TYPE = "pdb"
+
+    def __init__(self):
+        super(PdbBase, self).__init__()
+        # PDB has no fans; _fan_list remains empty from parent.
+        # _thermal_list is used for PDB thermals.
+
+    def get_output_current(self):
+        """
+        Retrieves the output current reading.
+
+        Returns:
+            A float representing the output current in Amperes, or 'N/A' if not available.
+        """
+        raise NotImplementedError
+
+    def get_output_power(self):
+        """
+        Retrieves the output power reading.
+
+        Returns:
+            A float representing the output power in Watts, or 'N/A' if not available.
+        """
+        raise NotImplementedError
+
+    def get_output_voltage(self):
+        """
+        Retrieves the output voltage reading.
+
+        Returns:
+            A float representing the output voltage in Volts, or 'N/A' if not available.
+        """
+        raise NotImplementedError
+
+    def get_input_power(self):
+        """
+        Retrieves the input power reading.
+
+        Returns:
+            A float representing the input power in Watts, or 'N/A' if not available.
+        """
+        raise NotImplementedError
+
+    def get_voltage(self):
+        """
+        Retrieves the output voltage reading.
+
+        Returns:
+            A float representing the output voltage in Volts, or 'N/A' if not available.
+        """
+        return self.get_output_voltage()
+
+    def get_current(self):
+        """
+        Retrieves the output current reading.
+
+        Returns:
+            A float representing the output current in Amperes, or 'N/A' if not available.
+        """
+        return self.get_output_current()
+
+    def get_power(self):
+        """
+        Retrieves the output power reading.
+
+        Returns:
+            A float representing the output power in Watts, or 'N/A' if not available.
+        """
+        return self.get_output_power()

--- a/tests/chassis_base_test.py
+++ b/tests/chassis_base_test.py
@@ -96,3 +96,46 @@ class TestChassisBase:
         assert chassis.get_num_modules() == 1
         assert chassis.get_all_modules() == [switch_host]
         assert chassis.get_module(0) is switch_host
+
+    def test_pdbs(self, capsys):
+        chassis = ChassisBase()
+        assert chassis.get_num_pdbs() == 0
+        assert chassis.get_all_pdbs() == []
+        assert chassis.get_pdb(0) is None
+        err = capsys.readouterr().err
+        assert "PDB index 0 out of range" in err
+
+        pdb0 = object()
+        chassis._pdb_list = [pdb0]
+        assert chassis.get_num_pdbs() == 1
+        assert chassis.get_all_pdbs() == [pdb0]
+        assert chassis.get_pdb(0) is pdb0
+
+        assert chassis.get_pdb(1) is None
+        err_oob = capsys.readouterr().err
+        assert "PDB index 1 out of range (0-0)" in err_oob
+
+    def test_pdbs_multiple_and_negative_index(self, capsys):
+        """Several PDB entries: success paths, high index error, valid negative index."""
+        chassis = ChassisBase()
+        pdb0, pdb1, pdb2 = object(), object(), object()
+        chassis._pdb_list = [pdb0, pdb1, pdb2]
+
+        assert chassis.get_num_pdbs() == 3
+        assert chassis.get_all_pdbs() == [pdb0, pdb1, pdb2]
+        assert chassis.get_pdb(0) is pdb0
+        assert chassis.get_pdb(1) is pdb1
+        assert chassis.get_pdb(2) is pdb2
+        capsys.readouterr()
+
+        assert chassis.get_pdb(3) is None
+        err_high = capsys.readouterr().err
+        assert "PDB index 3 out of range (0-2)" in err_high
+
+        assert chassis.get_pdb(-1) is pdb2
+        assert chassis.get_pdb(-2) is pdb1
+        assert chassis.get_pdb(-3) is pdb0
+
+        assert chassis.get_pdb(-4) is None
+        err_neg = capsys.readouterr().err
+        assert "PDB index -4 out of range (0-2)" in err_neg

--- a/tests/pdb_base_test.py
+++ b/tests/pdb_base_test.py
@@ -1,0 +1,85 @@
+"""
+Unit tests for PdbBase class.
+
+Validates the PDB base object API: default is_replaceable is False,
+and platform-specific methods raise NotImplementedError. Ensures
+PDB can be used where PSU is expected (voltage/current/power delegation).
+"""
+
+from unittest.mock import patch
+
+from sonic_platform_base.pdb_base import PdbBase
+
+
+class _PdbForDelegation(PdbBase):
+    """Concrete PDB with output readings for delegation tests."""
+
+    def get_output_voltage(self):
+        return 48.0
+
+    def get_output_current(self):
+        return 2.25
+
+    def get_output_power(self):
+        return 108.0
+
+
+class TestPdbBase:
+
+    def test_pdb_base_device_type(self):
+        """PDB device type constant."""
+        assert PdbBase.DEVICE_TYPE == "pdb"
+
+    def test_pdb_base_not_implemented_methods(self):
+        """Platform must implement these; base raises NotImplementedError."""
+        pdb = PdbBase()
+        not_implemented_methods = [
+            pdb.get_name,
+            pdb.get_presence,
+            pdb.get_status,
+            pdb.get_model,
+            pdb.get_serial,
+            pdb.get_revision,
+            pdb.get_temperature,
+            pdb.get_output_current,
+            pdb.get_output_power,
+            pdb.get_output_voltage,
+            pdb.get_input_current,
+            pdb.get_input_power,
+            pdb.get_input_voltage,
+            pdb.get_maximum_supplied_power,
+        ]
+        for method in not_implemented_methods:
+            exception_raised = False
+            try:
+                method()
+            except NotImplementedError:
+                exception_raised = True
+            assert exception_raised, "Expected NotImplementedError from {}".format(method.__name__)
+
+    def test_pdb_base_thermal_inherited(self):
+        """PDB inherits thermal list from PsuBase; empty by default."""
+        pdb = PdbBase()
+        assert pdb.get_num_thermals() == 0
+        assert pdb.get_all_thermals() == []
+        assert pdb.get_thermal(0) is None
+
+    def test_pdb_get_voltage_current_power_delegate(self):
+        """get_voltage/get_current/get_power forward to output* methods."""
+        pdb = _PdbForDelegation()
+        assert pdb.get_voltage() == 48.0
+        assert pdb.get_current() == 2.25
+        assert pdb.get_power() == 108.0
+
+    def test_pdb_get_voltage_current_power_delegate_on_base_instance(self):
+        """
+        Exercise delegation return paths on a plain PdbBase instance by
+        stubbing get_output_* (the abstract implementations raise otherwise).
+        """
+        pdb = PdbBase()
+        with patch.object(pdb, "get_output_voltage", return_value=12.5):
+            assert pdb.get_voltage() == 12.5
+        with patch.object(pdb, "get_output_current", return_value=3.0):
+            assert pdb.get_current() == 3.0
+        with patch.object(pdb, "get_output_power", return_value=37.5):
+            assert pdb.get_power() == 37.5


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

This pr is part of the design [Support PDB flows](https://github.com/sonic-net/SONiC/pull/2219)
- Added a new PdbBase abstraction (derived from PsuBase) for DC platforms where PDB replaces PSU, while keeping PSU daemon/CLI compatibility.
- Extended ChassisBase with PDB inventory APIs (_pdb_list, get_num_pdbs, get_all_pdbs, get_pdb) to expose PDB objects consistently.
- Added unit tests validating PDB base behavior (device type, required unimplemented platform methods, and inherited thermal handling).

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
add new pdb base object to reflect new hardware type, the power distribute board, as well as the corresponding functions inside of chassis base object


#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

unit test had been extended to cover the new object and functions

#### Additional Information (Optional)

