### PR TITLE
Re-add leakage_sensors_num to LiquidCoolingBase init

### DIFF
--- a/sonic_platform_base/liquid_cooling_base.py
+++ b/sonic_platform_base/liquid_cooling_base.py
@@ -129,6 +129,7 @@ class LiquidCoolingBase(device_base.DeviceBase):
     """
 
     def __init__(self,
+                 leakage_sensors_num: int = 0,
                  leakage_sensors_list: List[LeakageSensorBase] = [],
                  *,
                  profiles: List[LeakSensorProfileBase] = []):

--- a/tests/liquid_cooling_base_test.py
+++ b/tests/liquid_cooling_base_test.py
@@ -277,7 +277,8 @@ class TestLiquidCoolingBase():
         '''
         common = {"type": "rope", "location": "chassis",
                        "severity": LeakSeverity.MINOR}
-        liquid_cooling = LiquidCoolingBase([LeakageSensorBase("Sensor1", **common), 
+        liquid_cooling = LiquidCoolingBase(0,
+                                           [LeakageSensorBase("Sensor1", **common),
                                             LeakageSensorBase("Sensor2", **common), 
                                             LeakageSensorBase("Sensor3", **common)])
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

It's not used for anything but needs to be temporarily re-added for build/integration reasons. Once the updates to the tests that depend on it have been merged, this change should be reverted.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

The common API for liquid cooling (https://github.com/sonic-net/sonic-platform-common/pull/637) removed a redundant parameter from the LiquidCoolingBase constructor. Tests in the sonic-platform-daemons submodule made use of this parameter, so integration of the previous PR is failing as it breaks those tests.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)

