### PR TITLE
Add via pin lpmode methods to sfputil optoe base

### DIFF
--- a/sonic_platform_base/sonic_xcvr/sfp_optoe_base.py
+++ b/sonic_platform_base/sonic_xcvr/sfp_optoe_base.py
@@ -291,6 +291,31 @@ class SfpOptoeBase(SfpBase):
         api = self.get_xcvr_api()
         return api.set_lpmode(lpmode) if api is not None else None
 
+    def get_lpmode_via_pin(self):
+        """
+        Retrieves the lpmode (low power mode) status of this SFP via the
+        hardware LPMode pin. Platform vendors must implement this if they
+        want to control lpmode via the hardware pin instead of EEPROM.
+
+        Returns:
+            A Boolean, True if lpmode is enabled, False if disabled
+        """
+        raise NotImplementedError
+
+    def set_lpmode_via_pin(self, lpmode):
+        """
+        Sets the lpmode (low power mode) of this SFP via the hardware
+        LPMode pin. Platform vendors must implement this if they want to
+        control lpmode via the hardware pin instead of EEPROM.
+
+        Args:
+            lpmode: A Boolean, True to enable lpmode, False to disable it
+
+        Returns:
+            A boolean, True if lpmode is set successfully, False if not
+        """
+        raise NotImplementedError
+
     def set_power(self, mode):
         raise NotImplementedError
 

--- a/tests/sonic_xcvr/test_sfp_optoe_base.py
+++ b/tests/sonic_xcvr/test_sfp_optoe_base.py
@@ -199,6 +199,14 @@ class TestSfpOptoeBase(object):
         mode = 1
         with pytest.raises(NotImplementedError):
             self.sfp_optoe_api.set_power(mode)
+
+    def test_get_lpmode_via_pin_not_implemented(self):
+        with pytest.raises(NotImplementedError):
+            SfpOptoeBase().get_lpmode_via_pin()
+
+    def test_set_lpmode_via_pin_not_implemented(self):
+        with pytest.raises(NotImplementedError):
+            SfpOptoeBase().set_lpmode_via_pin(True)
  
     def test_default_page(self):
         with patch("builtins.open", mock_open(read_data=b'\x01')) as mocked_file:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
This adds a base method to allow for platforms to provide a lpmode via pin. 
Based on discussion here: https://github.com/sonic-net/sonic-utilities/pull/4511

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)

