### PR TITLE
[CMIS] Gracefully handle setting of max_banks_size in optoe

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -144,6 +144,14 @@ class CmisApi(CmisCdbFw, XcvrApi):
     def _get_vdm_key_to_db_prefix_map(self):
         return CMIS_VDM_KEY_TO_DB_PREFIX_KEY_MAP
 
+    def get_max_supported_banks(self):
+        """Returns max supported banks"""
+
+        if self.is_flat_memory():
+            return 0
+        
+        return self.xcvr_eeprom.read(consts.BANKS_SUPPORTED_FIELD)
+
     def _get_vdm_key_to_db_prefix_map_by_observable_type(self, observable_type):
         """
         Returns the VDM key-to-DB-prefix map filtered by observable type,

--- a/sonic_platform_base/sonic_xcvr/codes/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/codes/public/cmis.py
@@ -152,4 +152,10 @@ class CmisCodes(Sff8024):
         15: '0'
     }
 
+    MAX_BANKS_SUPPORTED = {
+        0: 0,
+        1: 2,
+        2: 4
+    }
+
     # TODO: Add other codes

--- a/sonic_platform_base/sonic_xcvr/mem_maps/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/mem_maps/public/cmis.py
@@ -177,7 +177,7 @@ class CmisFlatMemMap(XcvrMemMap):
             return offset
 
         # If we are accessing a non-banked page, there is no reason to set the bank
-        # to a non-zero value. 
+        # to a non-zero value.
         bank = 0 if page < CMIS_NUM_NON_BANKED_PAGES else self.bank
         # Note: we consider CDB pages as non-banked here, though it
         # is possible to have multiple CDB instances exposed for a module where
@@ -227,7 +227,7 @@ class CmisMemMap(CmisFlatMemMap):
             RegGroupField(consts.APPLS_ADVT_FIELD_PAGE01,
                 *(NumberRegField("%s_%d" % (consts.MEDIA_LANE_ASSIGNMENT_OPTION, app), self.getaddr(0x1, 176 + (app - 1)),
                     format="B", size=1) for app in range(1, 16)),
-                
+
                 *(CodeRegField("%s_%d" % (consts.HOST_ELECTRICAL_INTERFACE, app), self.getaddr(0x1, 223 + 4 * (app - 9)),
                     self.codes.HOST_ELECTRICAL_INTERFACE) for app in range(9, 16)),
 
@@ -274,9 +274,11 @@ class CmisMemMap(CmisFlatMemMap):
                 RegBitField(consts.VDM_SUPPORTED, 6),
                 RegBitField(consts.DIAG_PAGE_SUPPORT_ADVT_FIELD, 5),
             ),
-            NumberRegField(consts.BANKS_SUPPORTED_FIELD, self.getaddr(0x1, 142),
+
+            CodeRegField(consts.BANKS_SUPPORTED_FIELD, self.getaddr(0x1, 142), self.codes.MAX_BANKS_SUPPORTED,
                 *(RegBitField("Bit%d" % bit, bit) for bit in range(0, 2))
             ),
+
             NumberRegField(consts.TX_INPUT_EQ_MAX, self.getaddr(0x1, 153),
                 *(RegBitField("Bit%d" % (bit), bit) for bit in range (0 , 4))
             ),
@@ -359,7 +361,7 @@ class CmisMemMap(CmisFlatMemMap):
             NumberRegField(consts.DATAPATH_DEINIT_FIELD, self.getaddr(0x10, 128), ro=False),
             NumberRegField(consts.TX_DISABLE_FIELD, self.getaddr(0x10, 130), ro=False),
             NumberRegField(consts.RX_DISABLE_FIELD, self.getaddr(0x10, 138), ro=False,
-                *(RegBitField("%s_%d" % (consts.RX_DISABLE_FIELD, channel), bitpos, ro=False) 
+                *(RegBitField("%s_%d" % (consts.RX_DISABLE_FIELD, channel), bitpos, ro=False)
                   for channel, bitpos in zip(range(1, 9), range(0, 8)))  # 8 channels
             )
         )

--- a/sonic_platform_base/sonic_xcvr/sfp_optoe_base.py
+++ b/sonic_platform_base/sonic_xcvr/sfp_optoe_base.py
@@ -331,7 +331,7 @@ class SfpOptoeBase(SfpBase):
 
         if self.bank != 0:
             try:
-                max_bank_size = self._xcvr_api.get_max_bank_size() if self._xcvr_api is not None else 0
+                max_bank_size = self._xcvr_api.get_max_supported_banks() if self._xcvr_api is not None else 0
             except:
                 max_bank_size = 0
                 pass

--- a/sonic_platform_base/sonic_xcvr/sfp_optoe_base.py
+++ b/sonic_platform_base/sonic_xcvr/sfp_optoe_base.py
@@ -313,34 +313,31 @@ class SfpOptoeBase(SfpBase):
             pass
 
     def set_optoe_max_bank_size(self, max_bank_size):
-        """Write max_bank_size to the optoe sysfs entry. Reads the current value first and skips the write if it already matches, since the driver tears down and recreates the eeprom bin file on every write regardless of whether the value changed. Exceptions propagate: a failure here means banked EEPROM offsets won't be accessible, and a loud failure now is preferable to a confusing read-past-EOF later."""
-        sys_path = self.get_eeprom_path().replace("eeprom", "max_bank_size")
-        with open(sys_path) as f:
-            if int(f.read().strip()) == max_bank_size:
-                return
-        with open(sys_path, mode='w') as f:
-            f.write(str(max_bank_size))
+        """Set max optoe bank size"""
 
-    def _read_optoe_max_bank_size(self):
-        """Determine optoe max_bank_size from the module's CMIS BanksSupported advertisement, or None if non-CMIS, flat-memory, or unreadable."""
-        id_byte = self.read_eeprom(0, 1)
-        if id_byte is None or id_byte[0] not in CMIS_MODULE_IDS:
-            return None
-        flat_mem = self.read_eeprom(CMIS_FLAT_MEM_FILE_OFFSET, 1)
-        if flat_mem is None or flat_mem[0] & CMIS_FLAT_MEM_BIT_MASK:
-            return None
-        raw = self.read_eeprom(CMIS_BANKS_SUPPORTED_FILE_OFFSET, 1)
-        if raw is None:
-            return None
-        return CMIS_BANKS_SUPPORTED_TO_MAX_BANK_SIZE.get(raw[0] & 0x03)
+        sys_path = self.get_eeprom_path().replace("eeprom", "max_bank_size")
+        try:
+            with open(sys_path) as f:
+                if int(f.read().strip()) == max_bank_size:
+                    return
+            with open(sys_path, mode='w') as f:
+                f.write(str(max_bank_size))
+        except FileNotFoundError:
+            # Some platforms/drivers do not expose max_bank_size in sysfs.
+            return
 
     def refresh_xcvr_api(self):
-        """Sync optoe max_bank_size to the module's BanksSupported before building the XcvrApi, so subsequent banked reads don't land past EOF. Only runs when self.bank is non-zero so we don't enable banking based on a module that may erroneously advertise it."""
-        if self.bank != 0:
-            max_bank_size = self._read_optoe_max_bank_size()
-            if max_bank_size is not None:
-                self.set_optoe_max_bank_size(max_bank_size)
         super().refresh_xcvr_api()
+
+        if self.bank != 0:
+            try:
+                max_bank_size = self._xcvr_api.get_max_bank_size() if self._xcvr_api is not None else 0
+            except:
+                max_bank_size = 0
+                pass
+
+            if 0 != max_bank_size:
+                self.set_optoe_max_bank_size(max_bank_size)
 
     def get_optoe_current_page(self):
         return self.read_eeprom(SFP_OPTOE_PAGE_SELECT_OFFSET, 1)[0]

--- a/sonic_platform_base/sonic_xcvr/sfp_optoe_base.py
+++ b/sonic_platform_base/sonic_xcvr/sfp_optoe_base.py
@@ -332,9 +332,8 @@ class SfpOptoeBase(SfpBase):
         if self.bank != 0:
             try:
                 max_bank_size = self._xcvr_api.get_max_supported_banks() if self._xcvr_api is not None else 0
-            except:
+            except (AttributeError, NotImplementedError):
                 max_bank_size = 0
-                pass
 
             if 0 != max_bank_size:
                 self.set_optoe_max_bank_size(max_bank_size)

--- a/tests/sonic_xcvr/test_sfp_optoe_base.py
+++ b/tests/sonic_xcvr/test_sfp_optoe_base.py
@@ -196,53 +196,94 @@ class TestSfpOptoeBase(object):
 
         mock_open.assert_called()
 
+    @patch.object(SfpOptoeBase, 'get_eeprom_path')
+    def test_set_optoe_max_bank_size_success(self, mock_get_eeprom_path):
+        mock_get_eeprom_path.return_value = "/sys/bus/i2c/devices/1-0050/eeprom"
+        expected_path = "/sys/bus/i2c/devices/1-0050/max_bank_size"
+
+        m = mock_open(read_data="0")
+        with patch("builtins.open", m):
+            self.sfp_optoe_api.set_optoe_max_bank_size(4)
+
+        m.assert_any_call(expected_path)
+        m.assert_any_call(expected_path, mode='w')
+        m().write.assert_called_once_with("4")
+
+    @patch.object(SfpOptoeBase, 'get_eeprom_path')
+    def test_set_optoe_max_bank_size_skips_when_value_matches(self, mock_get_eeprom_path):
+        mock_get_eeprom_path.return_value = "/sys/bus/i2c/devices/1-0050/eeprom"
+        expected_path = "/sys/bus/i2c/devices/1-0050/max_bank_size"
+
+        m = mock_open(read_data="4")
+        with patch("builtins.open", m):
+            self.sfp_optoe_api.set_optoe_max_bank_size(4)
+
+        m.assert_called_once_with(expected_path)
+        m().write.assert_not_called()
+
+    @patch.object(SfpOptoeBase, 'get_eeprom_path')
+    def test_set_optoe_max_bank_size_missing_sysfs_is_noop(self, mock_get_eeprom_path):
+        mock_get_eeprom_path.return_value = "/sys/bus/i2c/devices/1-0050/eeprom"
+        m = mock_open()
+        m.side_effect = FileNotFoundError
+
+        with patch("builtins.open", m):
+            self.sfp_optoe_api.set_optoe_max_bank_size(4)
+
+        m.assert_called_once_with("/sys/bus/i2c/devices/1-0050/max_bank_size")
+
     @patch('sonic_platform_base.sonic_xcvr.sfp_optoe_base.SfpBase.refresh_xcvr_api')
     @patch.object(SfpOptoeBase, 'set_optoe_max_bank_size')
-    @patch.object(SfpOptoeBase, '_read_optoe_max_bank_size')
     @patch.object(SfpOptoeBase, 'bank', new_callable=PropertyMock)
-    def test_refresh_xcvr_api_nonzero_bank_writes_max_bank_size(self, mock_bank, mock_read, mock_set, mock_super):
-        mock_bank.return_value = 1
-        mock_read.return_value = 4
+    def test_refresh_xcvr_api_bank_zero_skips_sync(self, mock_bank, mock_set, mock_super):
+        mock_bank.return_value = 0
+        self.sfp_optoe_api._xcvr_api = MagicMock()
+
         self.sfp_optoe_api.refresh_xcvr_api()
+
+        self.sfp_optoe_api._xcvr_api.get_max_supported_banks.assert_not_called()
+        mock_set.assert_not_called()
+        mock_super.assert_called_once()
+
+    @patch('sonic_platform_base.sonic_xcvr.sfp_optoe_base.SfpBase.refresh_xcvr_api')
+    @patch.object(SfpOptoeBase, 'set_optoe_max_bank_size')
+    @patch.object(SfpOptoeBase, 'bank', new_callable=PropertyMock)
+    def test_refresh_xcvr_api_nonzero_bank_writes_max_bank_size(self, mock_bank, mock_set, mock_super):
+        mock_bank.return_value = 1
+        self.sfp_optoe_api._xcvr_api = MagicMock()
+        self.sfp_optoe_api._xcvr_api.get_max_supported_banks.return_value = 4
+
+        self.sfp_optoe_api.refresh_xcvr_api()
+
+        self.sfp_optoe_api._xcvr_api.get_max_supported_banks.assert_called_once()
         mock_set.assert_called_once_with(4)
         mock_super.assert_called_once()
 
-    @pytest.mark.parametrize("id_byte, flat_mem_byte, banks_byte, expected", [
-        # Non-CMIS IDs short-circuit before any further reads
-        (0x03, None, None, None),       # SFP
-        (0x0D, None, None, None),       # QSFP+
-        (0x11, None, None, None),       # QSFP28
-        # Flat-memory CMIS modules short-circuit before the banks-byte read
-        (0x18, 0x80, None, None),       # bit 7 set: flat memory
-        (0x18, 0xFF, None, None),       # bit 7 set + other bits: still flat
-        # All four CMIS IDs reach the banks-byte read when flat_mem=0
-        (0x18, 0x00, 0x00, 0),          # QSFP-DD, 1 bank -> sysfs 0 (banking off)
-        (0x19, 0x00, 0x01, 2),          # OSFP, 2 banks
-        (0x1b, 0x00, 0x02, 4),          # DSFP, 4 banks
-        (0x1e, 0x00, 0x01, 2),          # QSFP+ CMIS, 2 banks
-        # Bits 0-6 in byte 2 are ignored by the &0x80 flat-mem mask
-        (0x18, 0x7F, 0x02, 4),          # all bits except bit 7: still paged
-        # Reserved encoding 0b11 in banks byte maps to None
-        (0x18, 0x00, 0x03, None),
-        # Bits 2-7 in banks byte 142 are ignored by the &0x03 mask
-        (0x18, 0x00, 0x62, 4),          # VDM/Diag bits set + 0b10 in low bits
-        (0x18, 0x00, 0xFB, None),       # high bits set + 0b11 reserved in low bits
-        # Read failures propagate as None
-        (None, None, None, None),       # ID byte read fails
-        (0x18, None, None, None),       # flat-mem byte read fails
-        (0x18, 0x00, None, None),       # banks byte read fails
-    ])
-    def test_read_optoe_max_bank_size(self, id_byte, flat_mem_byte, banks_byte, expected):
-        def fake_read(offset, num_bytes):
-            if offset == 0:
-                return bytearray([id_byte]) if id_byte is not None else None
-            if offset == 2:
-                return bytearray([flat_mem_byte]) if flat_mem_byte is not None else None
-            if offset == 270:
-                return bytearray([banks_byte]) if banks_byte is not None else None
-            return None
-        with patch.object(SfpOptoeBase, 'read_eeprom', side_effect=fake_read):
-            assert self.sfp_optoe_api._read_optoe_max_bank_size() == expected
+    @patch('sonic_platform_base.sonic_xcvr.sfp_optoe_base.SfpBase.refresh_xcvr_api')
+    @patch.object(SfpOptoeBase, 'set_optoe_max_bank_size')
+    @patch.object(SfpOptoeBase, 'bank', new_callable=PropertyMock)
+    def test_refresh_xcvr_api_nonzero_bank_noop_when_api_unsupported(self, mock_bank, mock_set, mock_super):
+        mock_bank.return_value = 1
+        self.sfp_optoe_api._xcvr_api = MagicMock()
+        self.sfp_optoe_api._xcvr_api.get_max_supported_banks.side_effect = AttributeError
+
+        self.sfp_optoe_api.refresh_xcvr_api()
+
+        mock_set.assert_not_called()
+        mock_super.assert_called_once()
+
+    @patch.object(CmisApi, 'is_flat_memory', return_value=True)
+    def test_get_max_supported_banks_flat_mem(self, _mock_flat):
+        assert self.cmis_api.get_max_supported_banks() == 0
+
+    @patch.object(CmisApi, 'is_flat_memory', return_value=False)
+    def test_get_max_supported_banks_reads_banks_supported_field(self, _mock_flat):
+        self.cmis_api.xcvr_eeprom.read = MagicMock(return_value=4)
+
+        result = self.cmis_api.get_max_supported_banks()
+
+        self.cmis_api.xcvr_eeprom.read.assert_called_once_with('BanksSupported')
+        assert result == 4
 
     def test_set_power(self):
         mode = 1

--- a/tests/sonic_xcvr/test_sfp_optoe_base.py
+++ b/tests/sonic_xcvr/test_sfp_optoe_base.py
@@ -196,43 +196,6 @@ class TestSfpOptoeBase(object):
 
         mock_open.assert_called()
 
-    @patch.object(SfpOptoeBase, 'get_eeprom_path')
-    def test_set_optoe_max_bank_size_success(self, mock_get_eeprom_path):
-        mock_get_eeprom_path.return_value = "/sys/bus/i2c/devices/1-0050/eeprom"
-        expected_path = "/sys/bus/i2c/devices/1-0050/max_bank_size"
-        expected_value = 4
-
-        m = mock_open(read_data="0")
-        with patch("builtins.open", m):
-            self.sfp_optoe_api.set_optoe_max_bank_size(expected_value)
-
-        m.assert_any_call(expected_path)
-        m.assert_any_call(expected_path, mode='w')
-        m().write.assert_called_once_with(str(expected_value))
-
-    @patch.object(SfpOptoeBase, 'get_eeprom_path')
-    def test_set_optoe_max_bank_size_skips_when_value_matches(self, mock_get_eeprom_path):
-        mock_get_eeprom_path.return_value = "/sys/bus/i2c/devices/1-0050/eeprom"
-        expected_path = "/sys/bus/i2c/devices/1-0050/max_bank_size"
-
-        m = mock_open(read_data="4")
-        with patch("builtins.open", m):
-            self.sfp_optoe_api.set_optoe_max_bank_size(4)
-
-        m.assert_called_once_with(expected_path)
-        m().write.assert_not_called()
-
-    @patch('sonic_platform_base.sonic_xcvr.sfp_optoe_base.SfpBase.refresh_xcvr_api')
-    @patch.object(SfpOptoeBase, 'set_optoe_max_bank_size')
-    @patch.object(SfpOptoeBase, '_read_optoe_max_bank_size')
-    @patch.object(SfpOptoeBase, 'bank', new_callable=PropertyMock)
-    def test_refresh_xcvr_api_bank_zero_skips_sync(self, mock_bank, mock_read, mock_set, mock_super):
-        mock_bank.return_value = 0
-        self.sfp_optoe_api.refresh_xcvr_api()
-        mock_read.assert_not_called()
-        mock_set.assert_not_called()
-        mock_super.assert_called_once()
-
     @patch('sonic_platform_base.sonic_xcvr.sfp_optoe_base.SfpBase.refresh_xcvr_api')
     @patch.object(SfpOptoeBase, 'set_optoe_max_bank_size')
     @patch.object(SfpOptoeBase, '_read_optoe_max_bank_size')


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
Refactored the code to gracefully handle setting of the maximum bank size for platforms using optoe kernel driver for the CMIS compliant transceivers/CPO

#### Motivation and Context
Use existing EEPROM memory map scheme for max supported bank and handle cases where platform does not use optoe driver

#### How Has This Been Tested?
Unit test

#### Additional Information (Optional)

