### PR TITLE
Speed up sonic_xcvr unit tests by patching time.sleep via autouse fixture

### DIFF
--- a/tests/sonic_xcvr/conftest.py
+++ b/tests/sonic_xcvr/conftest.py
@@ -5,5 +5,5 @@ import pytest
 
 @pytest.fixture(autouse=True)
 def _no_sleep():
-    with patch("time.sleep"):
+    with patch("time.sleep", autospec=True, return_value=None):
         yield

--- a/tests/sonic_xcvr/conftest.py
+++ b/tests/sonic_xcvr/conftest.py
@@ -1,0 +1,9 @@
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep():
+    with patch("time.sleep"):
+        yield


### PR DESCRIPTION
#### Description
Add an autouse pytest fixture in `tests/sonic_xcvr/conftest.py` that
patches `time.sleep` for every test in the `tests/sonic_xcvr` package.

```python
@pytest.fixture(autouse=True)
def _no_sleep():
    with patch("time.sleep"):
        yield
```

#### Motivation and Context

Several `tests/sonic_xcvr` tests exercise production code paths that
call `time.sleep` directly, without mocking it. The suite therefore
spends almost all of its wall time blocked in real sleeps:

| Test | Count | Per-run | Total | Source of sleep |
|---|---|---|---|---|
| `test_cmisCDB.py::test_start_fw_download` | 3 | 5.00s | 15.0s | `cmisCDB.py:288` — `time.sleep(MAX_CDB_CMD_FOREGROUND_PROCESSING_TIME_tCDBF)` (5s) |
| `test_cmisCDB.py::test_validate_fw_image` | 3 | 5.00s | 15.0s | `cmisCDB.py:419` — same 5s constant |
| `test_cmis.py::test_reset` | 1 | 2.00s | 2.0s | `cmis.py:1369` — `time.sleep(2)` after `reset_module()` |
| `test_cmisCDB.py::test_run_fw_image` | 3 | 0.56s | 1.7s | `cmisCDB.py:459` — `time.sleep(delay/1000)` (delay ≈ 562 ms) |
| `test_ccmis.py::test_set_tx_power` | 2 | 1.00s | 2.0s | `c_cmis.py:187` — `time.sleep(1)` |

These 12 test invocations account for ~35.7s of a ~36.7s suite — about
97% of the runtime.

#### How Has This Been Tested?
Ran the full `tests/sonic_xcvr` suite before and after the change.

```
# Before
============================= 824 passed in 36.71s =============================

# After
============================= 824 passed in 1.07s ==============================
```

All 824 tests still pass; no behavior change. Suite is ~34× faster.

#### Additional Information (Optional)