### PR TITLE
Fix regular expression syntax warning

### DIFF
--- a/sonic_platform_base/sonic_pcie/pcie_common.py
+++ b/sonic_platform_base/sonic_pcie/pcie_common.py
@@ -37,8 +37,8 @@ class PcieUtil(PcieBase):
     def get_pcie_device(self):
         pciDict = {}
         pciList = []
-        p1 = "^(\w+):(\w+)\.(\w)\s(.*)\s*\(*.*\)*"
-        p2 = "^.*:.*:.*:(\w+)\s*\(*.*\)*"
+        p1 = r"^(\w+):(\w+)\.(\w)\s(.*)\s*\(*.*\)*"
+        p2 = r"^.*:.*:.*:(\w+)\s*\(*.*\)*"
         command1 = ["sudo", "lspci"]
         command2 = ["sudo", "lspci", "-n"]
         # run command 1


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

Change regular expressions from regular strings to raw strings.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

This change eliminates warnings in the logs from Python trying to interpret regular expression escape codes as string escape codes:

```
2026-05-19T05:32:46.808693+00:00 sonic determine-reboot-cause[1812]: /usr/local/lib/python3.13/dist-packages/sonic_platform_base/sonic_pcie/pcie_common.py:40: SyntaxWarning: invalid escape sequence '\\\\w'\\n
2026-05-19T05:32:46.808782+00:00 sonic determine-reboot-cause[1812]:   p1 = "^(\\\\w+):(\\\\w+)\\\\.(\\\\w)\\\\s(.*)\\\\s*\\\\(*.*\\\\)*"\\n
2026-05-19T05:32:46.808825+00:00 sonic determine-reboot-cause[1812]: /usr/local/lib/python3.13/dist-packages/sonic_platform_base/sonic_pcie/pcie_common.py:41: SyntaxWarning: invalid escape sequence '\\\\w'\\n
2026-05-19T05:32:46.808863+00:00 sonic determine-reboot-cause[1812]:   p2 = "^.*:.*:.*:(\\\\w+)\\\\s*\\\\(*.*\\\\)*"\\n
```

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

Verified that SONiC and all docker containers can successfully boot with the changes applied, and the SyntaxWarnings do not appear in syslog.

#### Additional Information (Optional)

