### PR TITLE
Add is_liquid_cooled API to chassis_base

### DIFF
--- a/sonic_platform_base/chassis_base.py
+++ b/sonic_platform_base/chassis_base.py
@@ -174,6 +174,17 @@ class ChassisBase(device_base.DeviceBase):
         """
         return False
 
+    def is_liquid_cooled(self):
+        """
+        Gets back if the device is Liquid/Hybrid cooled or not
+
+        Returns:
+            A bool value, should return False by default.
+            Air cooled devices return back False
+            Liquid/Hybrid cooled devices return back True
+        """
+        return False
+
     def init_midplane_switch(self):
         """
         Initializes the midplane functionality of the modular chassis. For

--- a/tests/chassis_base_test.py
+++ b/tests/chassis_base_test.py
@@ -84,6 +84,17 @@ class TestChassisBase:
         bmc = BmcChassis()
         assert bmc.is_bmc() is True
 
+    def test_is_liquid_cooled(self):
+        chassis = ChassisBase()
+        assert chassis.is_liquid_cooled() is False
+
+        class LiquidCooledChassis(ChassisBase):
+            def is_liquid_cooled(self):
+                return True
+
+        liquid = LiquidCooledChassis()
+        assert liquid.is_liquid_cooled() is True
+
     def test_switch_host_module_at_index_zero(self):
         '''
         On a BMC chassis, only the Switch-Host is modelled as a module.


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
As per design doc : https://github.com/sonic-net/SONiC/blob/master/doc/bmc/sonicBMC/pmon-bmc-design.md#chassisbase


#### Motivation and Context
The same BMC module could be used for wither liquid cooled as well as air cooled devices. Hence we cannot keep static defenitions like "liquid_cooled=1" in platform_env.conf of BMC.

#### How Has This Been Tested?
It is an abstract API

#### Additional Information (Optional)

