### PR TITLE
[BMC] Wait the BMC to be up after BMC update and restart

### DIFF
--- a/sonic_platform_base/bmc_fw_update.py
+++ b/sonic_platform_base/bmc_fw_update.py
@@ -46,12 +46,13 @@ def main():
             # Wait for BMC to become operational
             max_retries = 5
             bmc_is_up = False
-            for _ in range(max_retries):
+            for retry in range(max_retries):
                 bmc_is_up = bmc.get_status()
                 if bmc_is_up:
                     break
-                logger.log_notice("Waiting for BMC to restart...")
-                time.sleep(20)
+                if retry < max_retries - 1:
+                    logger.log_notice("Waiting for BMC to restart...")
+                    time.sleep(20)
 
             if not bmc_is_up:
                 logger.log_error("BMC did not become operational after restart")

--- a/sonic_platform_base/bmc_fw_update.py
+++ b/sonic_platform_base/bmc_fw_update.py
@@ -6,6 +6,7 @@ Handles BMC firmware update process
 """
 
 import sys
+import time
 
 def main():
     try:
@@ -39,6 +40,23 @@ def main():
             if ret != 0:
                 logger.log_error(f'Failed to restart BMC. Error {ret}: {error_msg}')
                 sys.exit(1)
+
+            # Wait for BMC to restart itself
+            time.sleep(20)
+            # Wait for BMC to become operational
+            max_retries = 5
+            bmc_is_up = False
+            for _ in range(max_retries):
+                bmc_is_up = bmc.get_status()
+                if bmc_is_up:
+                    break
+                logger.log_notice("Waiting for BMC to restart...")
+                time.sleep(20)
+
+            if not bmc_is_up:
+                logger.log_error("BMC did not become operational after restart")
+                sys.exit(1)
+
             logger.log_notice("BMC firmware update completed successfully")
 
     except Exception as e:

--- a/tests/bmc_fw_update_test.py
+++ b/tests/bmc_fw_update_test.py
@@ -24,9 +24,10 @@ from sonic_platform_base import bmc_fw_update
 class TestBMCFWUpdate:
     """Test class for bmc_fw_update module"""
 
+    @mock.patch('bmc_fw_update.time.sleep')
     @mock.patch('sys.exit')
     @mock.patch('sonic_py_common.logger.Logger')
-    def test_main_success_bmc_firmware_updated(self, mock_logger_class, mock_exit):
+    def test_main_success_bmc_firmware_updated(self, mock_logger_class, mock_exit, mock_sleep):
         """Test successful firmware update with BMC firmware component updated"""
         mock_logger = mock.MagicMock()
         mock_bmc = mock.MagicMock()
@@ -40,6 +41,7 @@ class TestBMCFWUpdate:
         mock_bmc.update_firmware.return_value = (0, ('Success', ['BMC_FW_0', 'OTHER_FW']))
         mock_bmc.get_firmware_id.return_value = 'BMC_FW_0'
         mock_bmc.request_bmc_reset.return_value = (0, 'BMC reset successful')
+        mock_bmc.get_status.return_value = True
 
         test_args = ['bmc_fw_update.py', '/path/to/firmware.bin']
         with mock.patch.dict(sys.modules, {'sonic_platform': mock_sonic_platform}):
@@ -51,6 +53,8 @@ class TestBMCFWUpdate:
         mock_bmc.update_firmware.assert_called_once_with('/path/to/firmware.bin')
         mock_bmc.get_firmware_id.assert_called_once()
         mock_bmc.request_bmc_reset.assert_called_once()
+        mock_bmc.get_status.assert_called_once()
+        mock_sleep.assert_not_called()
         mock_exit.assert_not_called()
 
     @mock.patch('sys.exit')

--- a/tests/bmc_fw_update_test.py
+++ b/tests/bmc_fw_update_test.py
@@ -193,7 +193,9 @@ class TestBMCFWUpdate:
                 bmc_fw_update.main()
 
         mock_logger.log_notice.assert_any_call("Waiting for BMC to restart...")
-        mock_sleep.assert_any_call(20)
+        assert mock_bmc.get_status.call_count == 2
+        assert mock_sleep.call_count == 2
+        mock_sleep.assert_has_calls([mock.call(20), mock.call(20)])
         mock_exit.assert_not_called()
 
     @mock.patch('sonic_platform_base.bmc_fw_update.time.sleep')
@@ -221,4 +223,6 @@ class TestBMCFWUpdate:
                 bmc_fw_update.main()
 
         mock_logger.log_error.assert_any_call("BMC did not become operational after restart")
+        assert mock_bmc.get_status.call_count == 5
+        assert mock_sleep.call_count == 5
         mock_exit.assert_called_once_with(1)

--- a/tests/bmc_fw_update_test.py
+++ b/tests/bmc_fw_update_test.py
@@ -167,3 +167,58 @@ class TestBMCFWUpdate:
 
         mock_logger.log_error.assert_called_once_with('Failed to restart BMC. Error 1: Reset failed')
         mock_exit.assert_called_once_with(1)
+
+    @mock.patch('sonic_platform_base.bmc_fw_update.time.sleep')
+    @mock.patch('sys.exit')
+    @mock.patch('sonic_py_common.logger.Logger')
+    def test_main_bmc_waiting_after_restart(self, mock_logger_class, mock_exit, mock_sleep):
+        """Test waiting loop when BMC is not yet operational after restart"""
+        mock_logger = mock.MagicMock()
+        mock_bmc = mock.MagicMock()
+        mock_chassis = mock.MagicMock()
+        mock_platform = mock.MagicMock()
+        mock_chassis.get_bmc.return_value = mock_bmc
+        mock_platform.get_chassis.return_value = mock_chassis
+        mock_sonic_platform = mock.MagicMock()
+        mock_sonic_platform.platform.Platform.return_value = mock_platform
+        mock_logger_class.return_value = mock_logger
+        mock_bmc.update_firmware.return_value = (0, ('Success', ['BMC_FW_0']))
+        mock_bmc.get_firmware_id.return_value = 'BMC_FW_0'
+        mock_bmc.request_bmc_reset.return_value = (0, 'BMC reset successful')
+        mock_bmc.get_status.side_effect = [False, True]
+
+        test_args = ['bmc_fw_update.py', '/path/to/firmware.bin']
+        with mock.patch.dict(sys.modules, {'sonic_platform': mock_sonic_platform}):
+            with mock.patch.object(sys, 'argv', test_args):
+                bmc_fw_update.main()
+
+        mock_logger.log_notice.assert_any_call("Waiting for BMC to restart...")
+        mock_sleep.assert_any_call(20)
+        mock_exit.assert_not_called()
+
+    @mock.patch('sonic_platform_base.bmc_fw_update.time.sleep')
+    @mock.patch('sys.exit')
+    @mock.patch('sonic_py_common.logger.Logger')
+    def test_main_bmc_not_operational_after_restart(self, mock_logger_class, mock_exit, mock_sleep):
+        """Test failure when BMC does not become operational after restart"""
+        mock_logger = mock.MagicMock()
+        mock_bmc = mock.MagicMock()
+        mock_chassis = mock.MagicMock()
+        mock_platform = mock.MagicMock()
+        mock_chassis.get_bmc.return_value = mock_bmc
+        mock_platform.get_chassis.return_value = mock_chassis
+        mock_sonic_platform = mock.MagicMock()
+        mock_sonic_platform.platform.Platform.return_value = mock_platform
+        mock_logger_class.return_value = mock_logger
+        mock_bmc.update_firmware.return_value = (0, ('Success', ['BMC_FW_0']))
+        mock_bmc.get_firmware_id.return_value = 'BMC_FW_0'
+        mock_bmc.request_bmc_reset.return_value = (0, 'BMC reset successful')
+        mock_bmc.get_status.return_value = False
+
+        test_args = ['bmc_fw_update.py', '/path/to/firmware.bin']
+        with mock.patch.dict(sys.modules, {'sonic_platform': mock_sonic_platform}):
+            with mock.patch.object(sys, 'argv', test_args):
+                bmc_fw_update.main()
+
+        mock_logger.log_error.assert_any_call("BMC did not become operational after restart")
+        mock_exit.assert_called_once_with(1)

--- a/tests/bmc_fw_update_test.py
+++ b/tests/bmc_fw_update_test.py
@@ -24,7 +24,7 @@ from sonic_platform_base import bmc_fw_update
 class TestBMCFWUpdate:
     """Test class for bmc_fw_update module"""
 
-    @mock.patch('bmc_fw_update.time.sleep')
+    @mock.patch('sonic_platform_base.bmc_fw_update.time.sleep')
     @mock.patch('sys.exit')
     @mock.patch('sonic_py_common.logger.Logger')
     def test_main_success_bmc_firmware_updated(self, mock_logger_class, mock_exit, mock_sleep):
@@ -54,7 +54,7 @@ class TestBMCFWUpdate:
         mock_bmc.get_firmware_id.assert_called_once()
         mock_bmc.request_bmc_reset.assert_called_once()
         mock_bmc.get_status.assert_called_once()
-        mock_sleep.assert_not_called()
+        mock_sleep.assert_called_once_with(20)
         mock_exit.assert_not_called()
 
     @mock.patch('sys.exit')


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
Update bmc_fw_update.py to return only after BMC becomes reachable again.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
The BMC update flow includes update and restart commands.
After the restart command succeeds, we need to wait for the BMC restart to complete,
since the completion indication should only be returned once the BMC is reachable again.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
config platform firmware install chassis component BMC fw PATH

#### Additional Information (Optional)

