### PR TITLE
Add CPO module identifier (0x80) to SFF-8024 XCVR identifier tables

### DIFF
--- a/sonic_platform_base/sonic_xcvr/codes/public/sff8024.py
+++ b/sonic_platform_base/sonic_xcvr/codes/public/sff8024.py
@@ -40,6 +40,7 @@ class Sff8024(XcvrCodes):
         29: 'x8 MiniLink',
         30: 'QSFP+ or later with CMIS',
        126: 'Backplane Cartridge',
+       128: 'CPO',  # Vendor-specific allocation for Co-Packaged Optics
     }
 
     XCVR_IDENTIFIER_ABBRV = {
@@ -75,6 +76,7 @@ class Sff8024(XcvrCodes):
         29: 'Link-x8',
         30: 'QSFP+C',
         126: 'BP',  # Backplane Cartridge
+        128: 'CPO',
     }
 
     CONNECTORS = {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
Add the SFF-8024 Identifier value `0x80` (decimal `128`) for **Co-Packaged Optics (CPO)** modules to the `Sff8024` code class in `sonic_platform_base/sonic_xcvr/codes/public/sff8024.py`:

- `XCVR_IDENTIFIERS[128] = 'CPO'`
- `XCVR_IDENTIFIER_ABBRV[128] = 'CPO'`

#### Motivation and Context
CPO is a new module form factor whose SFF-8024 Identifier (`0x80`) was not present in SONiC's `XCVR_IDENTIFIERS` / `XCVR_IDENTIFIER_ABBRV` tables. As a result, CPO modules were decoded as "Unknown", and `type` / `type_abbrv_name` in `TRANSCEIVER_INFO` were left empty, which prevented the rest of the stack from recognising them as a known form factor.

Adding this mapping lets SONiC correctly identify CPO modules end-to-end, and is the prerequisite that allows them to be picked up by the CMIS state machine in `xcvrd`

#### How Has This Been Tested?
Manual testing.

#### Additional Information (Optional)

