### PR TITLE
[smartswitch] Record DPU reboot time at command invocation

### DIFF
--- a/sonic_platform_base/module_base.py
+++ b/sonic_platform_base/module_base.py
@@ -9,6 +9,7 @@ import sys
 import os
 import fcntl
 import time
+from datetime import datetime, timezone
 from . import device_base
 import json
 import contextlib
@@ -18,6 +19,9 @@ import subprocess
 PCIE_DETACH_INFO_TABLE = "PCIE_DETACH_INFO"
 PCIE_OPERATION_DETACHING = "detaching"
 PCIE_OPERATION_ATTACHING = "attaching"
+
+# Reboot cause directory for DPU modules
+MODULE_REBOOT_CAUSE_DIR = "/host/reboot-cause/module/"
 
 class ModuleBase(device_base.DeviceBase):
     """
@@ -248,6 +252,26 @@ class ModuleBase(device_base.DeviceBase):
         """
         raise NotImplementedError
 
+    def reboot_gracefully(self, reboot_type):
+        """
+        Records the reboot time and then issues the reboot request.
+
+        This wrapper ensures prev_reboot_time.txt is written at the moment the
+        reboot command is issued, eliminating the race condition where chassisd
+        might restart (e.g. config reload) before detecting the Online→Offline
+        transition.
+
+        Args:
+            reboot_type: A string, the type of reboot requested from one of the
+            predefined reboot types: MODULE_REBOOT_DEFAULT, MODULE_REBOOT_CPU_COMPLEX,
+            MODULE_REBOOT_FPGA_COMPLEX, MODULE_REBOOT_DPU or MODULE_REBOOT_SMARTSWITCH
+
+        Returns:
+            bool: True if the request has been issued successfully, False if not
+        """
+        self._record_dpu_reboot_time()
+        return self.reboot(reboot_type)
+
     def set_admin_state(self, up):
         """
         Request to keep the card in administratively up/down state.
@@ -287,6 +311,35 @@ class ModuleBase(device_base.DeviceBase):
     ##############################################
     # SmartSwitch methods
     ##############################################
+
+    def _record_dpu_reboot_time(self):
+        """
+        Records the current UTC time to prev_reboot_time.txt for this module.
+
+        Called at the moment a reboot or admin-down command is issued, so that
+        chassisd can later compare this timestamp against the stored reboot-cause
+        timestamp to detect whether a new reboot occurred — even if chassisd
+        restarts (e.g. config reload) before it observes the Online→Offline
+        transition.
+
+        The file is written to:
+            /host/reboot-cause/module/{module_name_lower}/prev_reboot_time.txt
+
+        Returns:
+            bool: True if the file was written successfully, False otherwise.
+        """
+        try:
+            module_name = self.get_name()
+            time_str = datetime.now(timezone.utc).strftime("%Y_%m_%d_%H_%M_%S")
+            path = os.path.join(MODULE_REBOOT_CAUSE_DIR, module_name.lower(), "prev_reboot_time.txt")
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            with open(path, 'w') as f:
+                f.write(time_str)
+            return True
+        except Exception as e:
+            sys.stderr.write("Failed to record DPU reboot time for {}: {}\n".format(
+                self.get_name(), str(e)))
+            return False
 
     def get_dpu_id(self):
         """
@@ -460,6 +513,11 @@ class ModuleBase(device_base.DeviceBase):
 
             return admin_status
         else:
+            # Record the reboot time at command invocation so chassisd can
+            # detect new reboots even if it restarts before observing the
+            # Online→Offline transition.
+            self._record_dpu_reboot_time()
+
             # Initiate graceful shutdown before setting admin state to down.
             if not self.set_module_state_transition(module_name, "shutdown"):
                 sys.stderr.write("Failed to set module state transition for admin state DOWN\n")

--- a/tests/module_base_test.py
+++ b/tests/module_base_test.py
@@ -332,6 +332,7 @@ class TestModuleBase:
         db = MagicMock()
         self.module.state_db = db
         with patch.object(self.module, "get_name", return_value="DPU0"), \
+             patch.object(self.module, "_record_dpu_reboot_time", return_value=True), \
              patch.object(self.module, "set_module_state_transition", return_value=True), \
              patch.object(self.module, "clear_module_state_transition", return_value=True), \
              patch.object(self.module, "set_admin_state", return_value=True) as mset:
@@ -362,6 +363,7 @@ class TestModuleBase:
 
     def test_set_admin_state_gracefully_pre_shutdown_warn(self, capsys):
         with patch.object(self.module, "get_name", return_value="DPU0"), \
+             patch.object(self.module, "_record_dpu_reboot_time", return_value=True), \
              patch.object(self.module, "set_module_state_transition", return_value=True), \
              patch.object(self.module, "clear_module_state_transition", return_value=True), \
              patch.object(self.module, "set_admin_state", return_value=True), \
@@ -383,6 +385,7 @@ class TestModuleBase:
     def test_set_admin_state_gracefully_clear_transition_fail_down(self, capsys):
         """Test clear_module_state_transition failure for admin DOWN path (lines 463-464)"""
         with patch.object(self.module, "get_name", return_value="DPU0"), \
+             patch.object(self.module, "_record_dpu_reboot_time", return_value=True), \
              patch.object(self.module, "set_module_state_transition", return_value=True), \
              patch.object(self.module, "clear_module_state_transition", return_value=False), \
              patch.object(self.module, "set_admin_state", return_value=True), \
@@ -394,6 +397,7 @@ class TestModuleBase:
     def test_set_admin_state_gracefully_set_transition_fail_down(self, capsys):
         """Test set_module_state_transition failure for admin DOWN path (lines 448-450)"""
         with patch.object(self.module, "get_name", return_value="DPU0"), \
+             patch.object(self.module, "_record_dpu_reboot_time", return_value=True), \
              patch.object(self.module, "set_module_state_transition", return_value=False):
             assert self.module.set_admin_state_gracefully(False) is False
         assert "Failed to set module state transition for admin state DOWN" in capsys.readouterr().err
@@ -401,6 +405,7 @@ class TestModuleBase:
     def test_set_admin_state_gracefully_graceful_shutdown_fail(self, capsys):
         """Test graceful shutdown handler failure/timeout (lines 456-458)"""
         with patch.object(self.module, "get_name", return_value="DPU0"), \
+             patch.object(self.module, "_record_dpu_reboot_time", return_value=True), \
              patch.object(self.module, "set_module_state_transition", return_value=True), \
              patch.object(self.module, "clear_module_state_transition", return_value=True), \
              patch.object(self.module, "set_admin_state", return_value=True), \
@@ -426,6 +431,7 @@ class TestModuleBase:
     def test_set_admin_state_gracefully_all_failures_down_path(self, capsys):
         """Test multiple failure scenarios in the DOWN path for maximum coverage"""
         with patch.object(self.module, "get_name", return_value="DPU0"), \
+             patch.object(self.module, "_record_dpu_reboot_time", return_value=True), \
              patch.object(self.module, "set_module_state_transition", return_value=True), \
              patch.object(self.module, "clear_module_state_transition", return_value=False), \
              patch.object(self.module, "set_admin_state", return_value=True), \
@@ -1143,3 +1149,74 @@ class TestModuleBase:
             self.module.set_admin_state(True)
         with pytest.raises(NotImplementedError):
             self.module.set_admin_state(False)
+
+    # ---------------------------------- _record_dpu_reboot_time tests --
+    def test_record_dpu_reboot_time_success(self, tmp_path):
+        """Test that _record_dpu_reboot_time writes the correct file."""
+        with patch.object(self.module, "get_name", return_value="DPU0"), \
+             patch("sonic_platform_base.module_base.MODULE_REBOOT_CAUSE_DIR", str(tmp_path)):
+            result = self.module._record_dpu_reboot_time()
+            assert result is True
+            path = tmp_path / "dpu0" / "prev_reboot_time.txt"
+            assert path.exists()
+            content = path.read_text()
+            # Verify format: YYYY_MM_DD_HH_MM_SS
+            assert len(content.split("_")) == 6
+
+    def test_record_dpu_reboot_time_failure(self, capsys):
+        """Test that _record_dpu_reboot_time handles errors gracefully."""
+        with patch.object(self.module, "get_name", return_value="DPU0"), \
+             patch("os.makedirs", side_effect=PermissionError("denied")):
+            result = self.module._record_dpu_reboot_time()
+            assert result is False
+        assert "Failed to record DPU reboot time for DPU0" in capsys.readouterr().err
+
+    # ---------------------------------- reboot_gracefully tests --
+    def test_reboot_gracefully_records_time_then_reboots(self, tmp_path):
+        """Test that reboot_gracefully writes time file and calls reboot()."""
+        with patch.object(self.module, "get_name", return_value="DPU0"), \
+             patch("sonic_platform_base.module_base.MODULE_REBOOT_CAUSE_DIR", str(tmp_path)), \
+             patch.object(self.module, "reboot", return_value=True) as mock_reboot:
+            result = self.module.reboot_gracefully(ModuleBase.MODULE_REBOOT_DPU)
+            assert result is True
+            mock_reboot.assert_called_once_with(ModuleBase.MODULE_REBOOT_DPU)
+            # Verify time file was created
+            path = tmp_path / "dpu0" / "prev_reboot_time.txt"
+            assert path.exists()
+
+    def test_reboot_gracefully_still_reboots_on_time_record_failure(self):
+        """Test that reboot proceeds even if time recording fails."""
+        with patch.object(self.module, "get_name", return_value="DPU0"), \
+             patch.object(self.module, "_record_dpu_reboot_time", return_value=False), \
+             patch.object(self.module, "reboot", return_value=True) as mock_reboot:
+            result = self.module.reboot_gracefully(ModuleBase.MODULE_REBOOT_DPU)
+            assert result is True
+            mock_reboot.assert_called_once_with(ModuleBase.MODULE_REBOOT_DPU)
+
+    # ---------------------------------- set_admin_state_gracefully records time --
+    def test_set_admin_state_gracefully_down_records_time(self, tmp_path):
+        """Test that admin-down path calls _record_dpu_reboot_time."""
+        db = MagicMock()
+        self.module.state_db = db
+        with patch.object(self.module, "get_name", return_value="DPU0"), \
+             patch.object(self.module, "_record_dpu_reboot_time", return_value=True) as mock_record, \
+             patch.object(self.module, "set_module_state_transition", return_value=True), \
+             patch.object(self.module, "clear_module_state_transition", return_value=True), \
+             patch.object(self.module, "set_admin_state", return_value=True), \
+             patch.object(self.module, "module_pre_shutdown", return_value=True), \
+             patch.object(self.module, "_graceful_shutdown_handler", return_value=True):
+            assert self.module.set_admin_state_gracefully(False) is True
+            mock_record.assert_called_once()
+
+    def test_set_admin_state_gracefully_up_does_not_record_time(self):
+        """Test that admin-up path does NOT call _record_dpu_reboot_time."""
+        db = MagicMock()
+        self.module.state_db = db
+        with patch.object(self.module, "get_name", return_value="DPU0"), \
+             patch.object(self.module, "_record_dpu_reboot_time", return_value=True) as mock_record, \
+             patch.object(self.module, "set_module_state_transition", return_value=True), \
+             patch.object(self.module, "clear_module_state_transition", return_value=True), \
+             patch.object(self.module, "set_admin_state", return_value=True), \
+             patch.object(self.module, "module_post_startup", return_value=True):
+            assert self.module.set_admin_state_gracefully(True) is True
+            mock_record.assert_not_called()


### PR DESCRIPTION
#### Description

Write `prev_reboot_time.txt` from `module_base.py` when `reboot()` or `set_admin_state(down)` is issued, rather than relying solely on chassisd to write it when it detects the Online→Offline transition.

Changes:
- Add `_record_dpu_reboot_time()` helper to `ModuleBase` that writes the current UTC timestamp to `/host/reboot-cause/module/{module}/prev_reboot_time.txt`
- Add `reboot_gracefully(reboot_type)` wrapper that records the reboot time then calls `reboot()`
- Call `_record_dpu_reboot_time()` in `set_admin_state_gracefully(up=False)` at the start of the down path
- Add unit tests for the new methods
- 
Fixes: https://github.com/sonic-net/sonic-buildimage/issues/24275

#### Motivation and Context

There is a race condition in the current DPU reboot-cause persistence flow: if `config reload` is issued shortly after `reboot -d DPUX`, chassisd restarts before it can detect the Online→Offline transition and write `prev_reboot_time.txt`. When chassisd comes back, it sees EMPTY→Offline and has no reboot time to compare against, potentially losing the reboot event.

By writing `prev_reboot_time.txt` at the moment the user issues the reboot/shutdown command (in `module_base`), the timestamp is already persisted before any race can occur. Chassisd's existing write during Online→Offline detection is preserved as a fallback for spontaneous DPU crashes (not user-initiated).

Related PRs: sonic-net/sonic-platform-daemons#771
https://github.com/sonic-net/sonic-utilities/pull/4571

#### How Has This Been Tested?

1. Unit tests — all 5 new test cases pass:
   - `test_record_dpu_reboot_time_success` — verifies file creation and format
   - `test_record_dpu_reboot_time_failure` — verifies graceful error handling
   - `test_reboot_gracefully_records_time_then_reboots` — verifies wrapper calls both methods
   - `test_reboot_gracefully_still_reboots_on_time_record_failure` — verifies reboot proceeds on time-write failure
   - `test_set_admin_state_gracefully_down_records_time` — verifies admin-down calls `_record_dpu_reboot_time`
   - `test_set_admin_state_gracefully_up_does_not_record_time` — verifies admin-up does NOT record time

2. Existing `module_base_test.py` tests updated to patch `_record_dpu_reboot_time` in down-path tests — all continue to pass.

#### Additional Information (Optional)

This change is complementary to sonic-net/sonic-platform-daemons#771. The two writes are safe to coexist:

| Scenario | module_base writes | chassisd writes |
|---|---|---|
| `reboot -d DPU0` (normal) | ✅ at command time | ✅ at Online→Offline detection |
| `reboot -d DPU0` + `config reload` (race) | ✅ at command time | ❌ missed (chassisd restarted) |
| Spontaneous DPU crash | ❌ (no command) | ✅ at Online→Offline detection |
