### PR TITLE
[sonic_xcvr] Use advertised timeouts for CDB firmware commands

### DIFF
--- a/sonic_platform_base/sonic_xcvr/cdb/cdb.py
+++ b/sonic_platform_base/sonic_xcvr/cdb/cdb.py
@@ -63,7 +63,7 @@ class CdbCmdHandler(XcvrEeprom):
         """
         delay = 0
         if timeout is None:
-            timeout = cdb_consts.CDB_MAX_ACCESS_HOLD_OFF_PERIOD  + 5000  # 5 sec safety margin
+            timeout = cdb_consts.CDB_MAX_ACCESS_HOLD_OFF_PERIOD + cdb_consts.CDB_TIMEOUT_SAFETY_MARGIN
         status = None
 
         assert timeout > delay, "Timeout must be greater than delay"
@@ -144,7 +144,7 @@ class CdbCmdHandler(XcvrEeprom):
         payload = {"password": password}
         return self.send_cmd(cdb_consts.CDB_ENTER_PASSWORD_CMD, payload)
     
-    def write_lpl_block(self, blkaddr, blkdata):
+    def write_lpl_block(self, blkaddr, blkdata, timeout=None):
         """
         Write LPL block
         """
@@ -153,7 +153,7 @@ class CdbCmdHandler(XcvrEeprom):
             "blkdata" : blkdata
         }
         # Send the CDB write firmware LPL command
-        return self.send_cmd(cdb_consts.CDB_WRITE_FIRMWARE_LPL_CMD, payload)
+        return self.send_cmd(cdb_consts.CDB_WRITE_FIRMWARE_LPL_CMD, payload, timeout=timeout)
 
     def write_epl_pages(self, blkdata):
         """
@@ -171,7 +171,7 @@ class CdbCmdHandler(XcvrEeprom):
             remaining_data = blkdata[pages * cdb_consts.PAGE_SIZE:]
             assert True == self.write_epl_page(pages + cdb_consts.EPL_PAGE, remaining_data)
 
-    def write_epl_block(self, blkaddr, blkdata):
+    def write_epl_block(self, blkaddr, blkdata, timeout=None):
         """
         Write EPL block
         """
@@ -181,4 +181,4 @@ class CdbCmdHandler(XcvrEeprom):
         }
 
         # Send the CDB write firmware EPL command
-        return self.send_cmd(cdb_consts.CDB_WRITE_FIRMWARE_EPL_CMD, payload)
+        return self.send_cmd(cdb_consts.CDB_WRITE_FIRMWARE_EPL_CMD, payload, timeout=timeout)

--- a/sonic_platform_base/sonic_xcvr/cdb/cdb_fw.py
+++ b/sonic_platform_base/sonic_xcvr/cdb/cdb_fw.py
@@ -19,6 +19,11 @@ class CdbFwHandler(CdbCmdHandler):
         self.start_payload_size = 0
         self.is_lpl_only = False
         self.rw_length_ext = 0
+        self.timeout_start = None
+        self.timeout_abort = None
+        self.timeout_write = None
+        self.timeout_complete = None
+        self.timeout_copy = None
         assert True == self.initFwHandler(), "Failed to initialize firmware handler"
 
     def initFwHandler(self):
@@ -43,6 +48,13 @@ class CdbFwHandler(CdbCmdHandler):
             self.rw_length_ext = min(cdb_consts.LPL_MAX_PAYLOAD_SIZE, self.rw_length_ext)
         else:
             self.rw_length_ext = min(cdb_consts.EPL_MAX_PAYLOAD_SIZE, self.rw_length_ext)
+
+        multiplier = 10 if reply.get(cdb_consts.CDB_MAX_DURATION_ENCODING, 0) else 1
+        self.timeout_start = reply.get(cdb_consts.CDB_MAX_DURATION_START, 0) * multiplier + cdb_consts.CDB_TIMEOUT_SAFETY_MARGIN
+        self.timeout_abort = reply.get(cdb_consts.CDB_MAX_DURATION_ABORT, 0) * multiplier + cdb_consts.CDB_TIMEOUT_SAFETY_MARGIN
+        self.timeout_write = reply.get(cdb_consts.CDB_MAX_DURATION_WRITE, 0) * multiplier + cdb_consts.CDB_TIMEOUT_SAFETY_MARGIN
+        self.timeout_complete = reply.get(cdb_consts.CDB_MAX_DURATION_COMPLETE, 0) * multiplier + cdb_consts.CDB_TIMEOUT_SAFETY_MARGIN
+        self.timeout_copy = reply.get(cdb_consts.CDB_MAX_DURATION_COPY, 0) * multiplier + cdb_consts.CDB_TIMEOUT_SAFETY_MARGIN
 
         return True
 
@@ -88,7 +100,8 @@ class CdbFwHandler(CdbCmdHandler):
         }
 
         # Send the CDB start firmware download command
-        return self.send_cmd(cdb_consts.CDB_START_FIRMWARE_DOWNLOAD_CMD, payload)
+        return self.send_cmd(cdb_consts.CDB_START_FIRMWARE_DOWNLOAD_CMD, payload,
+                            timeout=self.timeout_start)
 
     def download_fw_image(self, imgpath):
         """
@@ -119,11 +132,11 @@ class CdbFwHandler(CdbCmdHandler):
                     # TODO Handle auto paging for EPL
                     # Write the block data to the EPL
                     if self.is_lpl_only:
-                        self.write_lpl_block(blkaddr, blkdata)
+                        self.write_lpl_block(blkaddr, blkdata, timeout=self.timeout_write)
                     else:
                         # For EPL, write the data in pages
                         self.write_epl_pages(blkdata)
-                        if True != self.write_epl_block(blkaddr, blkdata):
+                        if True != self.write_epl_block(blkaddr, blkdata, timeout=self.timeout_write):
                             log.log_error("Failed to write EPL block at address {}".format(blkaddr))
                             return False, blkaddr
 
@@ -164,11 +177,13 @@ class CdbFwHandler(CdbCmdHandler):
         Complete the firmware download
         """
         # Send the CDB complete firmware download command
-        return self.send_cmd(cdb_consts.CDB_COMPLETE_FIRMWARE_DOWNLOAD_CMD)
+        return self.send_cmd(cdb_consts.CDB_COMPLETE_FIRMWARE_DOWNLOAD_CMD,
+                            timeout=self.timeout_complete)
 
     def commit_fw_image(self):
         return self.send_cmd(cdb_consts.CDB_COMMIT_FIRMWARE_IMAGE_CMD)
 
     def abort_fw_download(self):
-        return self.send_cmd(cdb_consts.CDB_ABORT_FIRMWARE_DOWNLOAD_CMD)
+        return self.send_cmd(cdb_consts.CDB_ABORT_FIRMWARE_DOWNLOAD_CMD,
+                            timeout=self.timeout_abort)
 

--- a/sonic_platform_base/sonic_xcvr/cdb/cdb_fw.py
+++ b/sonic_platform_base/sonic_xcvr/cdb/cdb_fw.py
@@ -23,7 +23,7 @@ class CdbFwHandler(CdbCmdHandler):
         self.timeout_abort = None
         self.timeout_write = None
         self.timeout_complete = None
-        self.timeout_copy = None
+
         assert True == self.initFwHandler(), "Failed to initialize firmware handler"
 
     def initFwHandler(self):
@@ -50,12 +50,16 @@ class CdbFwHandler(CdbCmdHandler):
             self.rw_length_ext = min(cdb_consts.EPL_MAX_PAYLOAD_SIZE, self.rw_length_ext)
 
         multiplier = 10 if reply.get(cdb_consts.CDB_MAX_DURATION_ENCODING, 0) else 1
-        self.timeout_start = reply.get(cdb_consts.CDB_MAX_DURATION_START, 0) * multiplier + cdb_consts.CDB_TIMEOUT_SAFETY_MARGIN
-        self.timeout_abort = reply.get(cdb_consts.CDB_MAX_DURATION_ABORT, 0) * multiplier + cdb_consts.CDB_TIMEOUT_SAFETY_MARGIN
-        self.timeout_write = reply.get(cdb_consts.CDB_MAX_DURATION_WRITE, 0) * multiplier + cdb_consts.CDB_TIMEOUT_SAFETY_MARGIN
-        self.timeout_complete = reply.get(cdb_consts.CDB_MAX_DURATION_COMPLETE, 0) * multiplier + cdb_consts.CDB_TIMEOUT_SAFETY_MARGIN
-        self.timeout_copy = reply.get(cdb_consts.CDB_MAX_DURATION_COPY, 0) * multiplier + cdb_consts.CDB_TIMEOUT_SAFETY_MARGIN
-
+        duration_start = reply.get(cdb_consts.CDB_MAX_DURATION_START, 0)
+        duration_abort = reply.get(cdb_consts.CDB_MAX_DURATION_ABORT, 0)
+        duration_write = reply.get(cdb_consts.CDB_MAX_DURATION_WRITE, 0)
+        duration_complete = reply.get(cdb_consts.CDB_MAX_DURATION_COMPLETE, 0)
+        
+        self.timeout_start = duration_start * multiplier + cdb_consts.CDB_TIMEOUT_SAFETY_MARGIN if duration_start else None
+        self.timeout_abort = duration_abort * multiplier + cdb_consts.CDB_TIMEOUT_SAFETY_MARGIN if duration_abort else None
+        self.timeout_write = duration_write * multiplier + cdb_consts.CDB_TIMEOUT_SAFETY_MARGIN if duration_write else None
+        self.timeout_complete = duration_complete * multiplier + cdb_consts.CDB_TIMEOUT_SAFETY_MARGIN if duration_complete else None
+        
         return True
 
     def get_fw_mgmt_features(self):
@@ -132,7 +136,9 @@ class CdbFwHandler(CdbCmdHandler):
                     # TODO Handle auto paging for EPL
                     # Write the block data to the EPL
                     if self.is_lpl_only:
-                        self.write_lpl_block(blkaddr, blkdata, timeout=self.timeout_write)
+                        if True != self.write_lpl_block(blkaddr, blkdata, timeout=self.timeout_write):
+                            log.log_error("Failed to write LPL block at address {}".format(blkaddr))
+                            return False, blkaddr
                     else:
                         # For EPL, write the data in pages
                         self.write_epl_pages(blkdata)

--- a/sonic_platform_base/sonic_xcvr/fields/cdb_consts.py
+++ b/sonic_platform_base/sonic_xcvr/fields/cdb_consts.py
@@ -45,6 +45,11 @@ CDB_START_CMD_PAYLOAD_SIZE = "CdbStartCmdPayloadSize"
 CDB_READ_WRITE_LENGTH_EXT = "CdbReadWriteLengthExt"
 CDB_WRITE_MECHANISM = "CdbWriteMechanism"
 CDB_READ_MECHANISM = "CdbReadMechanism"
+CDB_MAX_DURATION_START = "CdbMaxDurationStart"
+CDB_MAX_DURATION_ABORT = "CdbMaxDurationAbort"
+CDB_MAX_DURATION_WRITE = "CdbMaxDurationWrite"
+CDB_MAX_DURATION_COMPLETE = "CdbMaxDurationComplete"
+CDB_MAX_DURATION_COPY = "CdbMaxDurationCopy"
 
 
 LPL_PAGE = 0x9F
@@ -59,6 +64,7 @@ EPL_MAX_PAYLOAD_SIZE = 2048
 CDB_MAX_ACCESS_HOLD_OFF_PERIOD = 4960 # tCDBF msec
 CDB_MAX_CAPTURE_TIME = 100 # tCDBC msec
 CDB_RUN_FIRMWARE_CMD_TIMEOUT = 15000 # Delay to switch to new firmware in msec
+CDB_TIMEOUT_SAFETY_MARGIN = 5000 # Safety margin for timeouts in msec
 
 #CDB Commands
 CDB_CMD_ID_LEN = 2

--- a/sonic_platform_base/sonic_xcvr/mem_maps/public/cmis/pages/page9f_cdb.py
+++ b/sonic_platform_base/sonic_xcvr/mem_maps/public/cmis/pages/page9f_cdb.py
@@ -52,7 +52,7 @@ class CdbLplMessagePage(CmisPage):
             NumberRegField(cdb_consts.CDB1_FACTORY_BUILD_VERSION, self.getaddr(212), size=2, format=">H"),
         ]
 
-        # Firmware management features group (bytes 137..142)
+        # Firmware management features group (bytes 137..153)
         self.fields[cdb_consts.CDB_FIRMWARE_MGMT_FEATURES] = [
             NumberRegField(
                 cdb_consts.CDB_FIRMWARE_MGMT_ADV, self.getaddr(137),

--- a/sonic_platform_base/sonic_xcvr/mem_maps/public/cmis/pages/page9f_cdb.py
+++ b/sonic_platform_base/sonic_xcvr/mem_maps/public/cmis/pages/page9f_cdb.py
@@ -63,4 +63,9 @@ class CdbLplMessagePage(CmisPage):
             NumberRegField(cdb_consts.CDB_READ_WRITE_LENGTH_EXT, self.getaddr(140), scale=0.125),
             CodeRegField(cdb_consts.CDB_WRITE_MECHANISM, self.getaddr(141), codes.CDB_WRITE_METHOD),
             CodeRegField(cdb_consts.CDB_READ_MECHANISM, self.getaddr(142), codes.CDB_READ_METHOD),
+            NumberRegField(cdb_consts.CDB_MAX_DURATION_START, self.getaddr(144), size=2, format=">H"),
+            NumberRegField(cdb_consts.CDB_MAX_DURATION_ABORT, self.getaddr(146), size=2, format=">H"),
+            NumberRegField(cdb_consts.CDB_MAX_DURATION_WRITE, self.getaddr(148), size=2, format=">H"),
+            NumberRegField(cdb_consts.CDB_MAX_DURATION_COMPLETE, self.getaddr(150), size=2, format=">H"),
+            NumberRegField(cdb_consts.CDB_MAX_DURATION_COPY, self.getaddr(152), size=2, format=">H"),
         ]

--- a/tests/sonic_xcvr/test_cdb.py
+++ b/tests/sonic_xcvr/test_cdb.py
@@ -914,7 +914,8 @@ class TestCdbCmdHandler:
         assert result is True
         self.handler.send_cmd.assert_called_once_with(
             cdb_consts.CDB_WRITE_FIRMWARE_LPL_CMD,
-            {"blkaddr": 0x1000, "blkdata": b'\x01\x02'}
+            {"blkaddr": 0x1000, "blkdata": b'\x01\x02'},
+            timeout=None
         )
 
 

--- a/tests/sonic_xcvr/test_cdb_fw.py
+++ b/tests/sonic_xcvr/test_cdb_fw.py
@@ -233,11 +233,13 @@ class TestCdbFwHandler:
     def test_complete_fw_download(self):
         """Test complete_fw_download"""
         self.handler.send_cmd = MagicMock(return_value=True)
+        self.handler.timeout_complete = 20000
         
         result = self.handler.complete_fw_download()
         
         assert result == True
-        self.handler.send_cmd.assert_called_once_with(cdb_consts.CDB_COMPLETE_FIRMWARE_DOWNLOAD_CMD)
+        self.handler.send_cmd.assert_called_once_with(cdb_consts.CDB_COMPLETE_FIRMWARE_DOWNLOAD_CMD,
+                            timeout=self.handler.timeout_complete)
     
     def test_commit_fw_image(self):
         """Test commit_fw_image"""
@@ -251,11 +253,13 @@ class TestCdbFwHandler:
     def test_abort_fw_download(self):
         """Test abort_fw_download"""
         self.handler.send_cmd = MagicMock(return_value=True)
+        self.handler.timeout_abort = 5080
         
         result = self.handler.abort_fw_download()
         
         assert result == True
-        self.handler.send_cmd.assert_called_once_with(cdb_consts.CDB_ABORT_FIRMWARE_DOWNLOAD_CMD)
+        self.handler.send_cmd.assert_called_once_with(cdb_consts.CDB_ABORT_FIRMWARE_DOWNLOAD_CMD,
+                            timeout=self.handler.timeout_abort)
     
     @patch("builtins.open", new_callable=mock_open)
     def test_download_fw_image_lpl_success(self, mock_file):
@@ -277,7 +281,7 @@ class TestCdbFwHandler:
         
         assert result == True
         assert bytes_written == 1024
-        self.handler.write_lpl_block.assert_called_once_with(0, b"D" * 1024)
+        self.handler.write_lpl_block.assert_called_once_with(0, b"D" * 1024, timeout=self.handler.timeout_write)
     
     @patch("builtins.open", new_callable=mock_open)
     def test_download_fw_image_epl_success(self, mock_file):
@@ -305,8 +309,8 @@ class TestCdbFwHandler:
         
         # Verify calls
         calls = self.handler.write_epl_block.call_args_list
-        assert calls[0] == call(0, b"D" * 2048)
-        assert calls[1] == call(2048, b"E" * 1024)
+        assert calls[0] == call(0, b"D" * 2048, timeout=self.handler.timeout_write)
+        assert calls[1] == call(2048, b"E" * 1024, timeout=self.handler.timeout_write)
     
     @patch("builtins.open", new_callable=mock_open)
     def test_download_fw_image_no_header(self, mock_file):
@@ -400,9 +404,9 @@ class TestCdbFwHandler:
         
         # Verify calls
         calls = self.handler.write_lpl_block.call_args_list
-        assert calls[0] == call(0, b"A" * 512)
-        assert calls[1] == call(512, b"B" * 512)
-        assert calls[2] == call(1024, b"C" * 256)
+        assert calls[0] == call(0, b"A" * 512, timeout=self.handler.timeout_write)
+        assert calls[1] == call(512, b"B" * 512, timeout=self.handler.timeout_write)
+        assert calls[2] == call(1024, b"C" * 256, timeout=self.handler.timeout_write)
     
     def test_download_fw_image_empty_file_with_header(self):
         """Test download_fw_image with empty file when header is required"""


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
Use module advertised timeouts for CDB firmware commands. This change parses the `MaxDuration` fields and uses them as per-command timeouts for firmware operations. These timeouts are passed to the Start, Abort, Write, and Complete firmware commands. Commands without a spec defined `MaxDuration` continue to use the default timeout. Unit tests have been updated accordingly.
#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
The CDB firmware commands previously used a default timeout for all operations. However, per CMIS spec, modules advertise per command MaxDuration values, and commands can have different execution times. This change ensures to respect module advertised timing constraints as defined in the CMIS specification.
#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
 - Tested the changes on a device performing a full firmware download and activation cycle
 - Confirmed `MaxDuration` values are correctly parsed from the module
 - Firmware download and activation completed successfully using module advertised timeouts
 - Updated unit tests in `test_cdb_fw.py` and `test_cdb.py` pass with new timeout parameters -> 98 passed
 - Tested on branch 202605 with 98 unit tests passing
```
root@sonic:~# sfputil firmware upgrade EthernetXX "/path/to/firmware.bin"
Image A Version: 1.5.0
Image B Version: 1.4.0
Factory Image Version: 1.6.0
Running Image: B
Committed Image: B
Active Firmware: 1.4.0
Inactive Firmware: 1.5.0

CDB: Starting firmware download
Downloading ...  [###################################-]   99%  00:00:00
CDB: firmware download complete
Firmware download complete success
Running firmware: Non-hitless Reset to Inactive Image
Firmware run in mode 0 successful
FW images switch successful : ImageA is running
Firmware commit successful
```


#### Additional Information (Optional)

MSFT ADO - 38035182