### PR TITLE
azure-pipelines: install only libyang3 (drop libyang1)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,8 +42,7 @@ steps:
 - script: |
     set -xe
     sudo apt-get -y purge libnl-3-dev libnl-route-3-dev || true
-    sudo dpkg -i libyang_1.0.73_amd64.deb \
-                 libyang3_*.deb \
+    sudo dpkg -i libyang3_*.deb \
                  python3-libyang*.deb \
                  libnl-3-200_*.deb \
                  libnl-genl-3-200_*.deb \


### PR DESCRIPTION
#### Description
Update the CI pipeline to install only the libyang3 Debian packages and drop the libyang1 packages. sonic-buildimage no longer builds libyang1 (`libyang_1.0.73`); it now builds only libyang3, so the libyang1 download filter and install command no longer resolve to any artifact. The libyang3 packages (`libyang3_*.deb`, `python3-libyang*.deb`) were already added during the transition (#589) and remain in place using versionless globs.

#### Motivation and Context
sonic-buildimage stopped building the libyang1 packages (`libyang_1.0.73`, `libyang-cpp`, `python3-yang`) and now builds only libyang3 (see sonic-net/sonic-buildimage#22385). A prior change (#589) installed both libyang1 and libyang3 during the transition. With libyang1 gone, the `target/debs/trixie/libyang_1.0.73_amd64.deb` download filter and the `sudo dpkg -i libyang_1.0.73_amd64.deb` install step reference an artifact that no longer exists, which would break the pipeline. This change removes those libyang1 references and keeps only the libyang3 globs.

#### How Has This Been Tested?
Verified that after the change `azure-pipelines.yml` no longer references the libyang1 package and only references libyang3 packages via versionless globs (`libyang3_*.deb`, `python3-libyang*.deb`). The Debian dependency download and install steps continue to resolve against the libyang3 artifacts produced by current sonic-buildimage builds.

#### Additional Information (Optional)
Part of sonic-net/sonic-buildimage#22385.
