### PR TITLE
Fix hardcoded lane masks when applying loopbacks

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -1183,6 +1183,72 @@ class CmisApi(CmisCdbFw, XcvrApi):
         active_apsel_code = self.xcvr_eeprom.read(consts.ACTIVE_APSEL_CODE)
         return defaultdict(lambda: 'N/A') if not active_apsel_code else active_apsel_code
 
+    def _get_active_appsel_descriptor(self):
+        '''
+        Returns the application-advertisement descriptor for the currently
+        active AppSel on host lane 1.
+
+        Raises RuntimeError if the active AppSel cannot be determined --
+        callers must not silently fall back to the default-application
+        descriptor, since that defeats the purpose of resolving the
+        runtime-configured application.
+        '''
+        if self.is_flat_memory():
+            raise RuntimeError(
+                'Cannot determine active AppSel descriptor: '
+                'module reports flat memory (page 11h unavailable)')
+
+        lane1_field = "%s%d" % (consts.ACTIVE_APSEL_HOSTLANE, 1)
+        active_apsel = self.xcvr_eeprom.read(lane1_field)
+        if not active_apsel:
+            raise RuntimeError(
+                'Cannot determine active AppSel descriptor: '
+                'read of %s returned %r' % (lane1_field, active_apsel))
+
+        appl_advt = self.get_application_advertisement()
+        descriptor = appl_advt.get(active_apsel)
+        if not descriptor:
+            raise RuntimeError(
+                'Cannot determine active AppSel descriptor: '
+                'AppSel %d has no entry in application advertisement %r'
+                % (active_apsel, appl_advt))
+
+        return active_apsel, descriptor
+
+    def get_active_appsel_host_lane_count(self):
+        '''
+        Returns the host lane count for the currently active application.
+
+        Reads the applied AppSel code from the DataPath Configuration
+        (Page 11h) and looks up the corresponding application descriptor.
+        Raises RuntimeError if the active AppSel cannot be determined or
+        the descriptor lacks a host_lane_count
+        '''
+        active_apsel, descriptor = self._get_active_appsel_descriptor()
+        if 'host_lane_count' not in descriptor:
+            raise RuntimeError(
+                'Cannot determine active AppSel host lane count: '
+                'AppSel %d descriptor %r has no host_lane_count'
+                % (active_apsel, descriptor))
+        return descriptor['host_lane_count']
+
+    def get_active_appsel_media_lane_count(self):
+        '''
+        Returns the media lane count for the currently active application.
+
+        Reads the applied AppSel code from the DataPath Configuration
+        (Page 11h) and looks up the corresponding application descriptor.
+        Raises RuntimeError if the active AppSel cannot be determined or
+        the descriptor lacks a media_lane_count
+        '''
+        active_apsel, descriptor = self._get_active_appsel_descriptor()
+        if 'media_lane_count' not in descriptor:
+            raise RuntimeError(
+                'Cannot determine active AppSel media lane count: '
+                'AppSel %d descriptor %r has no media_lane_count'
+                % (active_apsel, descriptor))
+        return descriptor['media_lane_count']
+
     def get_tx_config_power(self):
         '''
         This function returns the configured TX output power. Unit in dBm
@@ -1196,7 +1262,7 @@ class CmisApi(CmisCdbFw, XcvrApi):
         result = self.xcvr_eeprom.read(consts.MEDIA_OUTPUT_LOOPBACK)
         if result is None:
             return None
-        return result == 1
+        return bool(result)
 
     def get_media_input_loopback(self):
         '''
@@ -1205,7 +1271,7 @@ class CmisApi(CmisCdbFw, XcvrApi):
         result = self.xcvr_eeprom.read(consts.MEDIA_INPUT_LOOPBACK)
         if result is None:
             return None
-        return result == 1
+        return bool(result)
 
     def get_host_output_loopback(self):
         '''
@@ -1496,7 +1562,8 @@ class CmisApi(CmisCdbFw, XcvrApi):
             logger.error('Host input loopback is not supported')
             return False
 
-        if loopback_capability['per_lane_host_loopback_supported'] is False and lane_mask != 0xff:
+        all_lanes_mask = (1 << self.get_active_appsel_host_lane_count()) - 1
+        if loopback_capability['per_lane_host_loopback_supported'] is False and lane_mask != all_lanes_mask:
             logger.error('Per-lane host input loopback is not supported, lane_mask:%#x', lane_mask)
             return False
 
@@ -1537,7 +1604,8 @@ class CmisApi(CmisCdbFw, XcvrApi):
             logger.error('Host output loopback is not supported')
             return False
 
-        if loopback_capability['per_lane_host_loopback_supported'] is False and lane_mask != 0xff:
+        all_lanes_mask = (1 << self.get_active_appsel_host_lane_count()) - 1
+        if loopback_capability['per_lane_host_loopback_supported'] is False and lane_mask != all_lanes_mask:
             logger.error('Per-lane host output loopback is not supported, lane_mask:%#x', lane_mask)
             return False
 
@@ -1578,7 +1646,8 @@ class CmisApi(CmisCdbFw, XcvrApi):
             logger.error('Media input loopback is not supported')
             return False
 
-        if loopback_capability['per_lane_media_loopback_supported'] is False and lane_mask != 0xff:
+        all_lanes_mask = (1 << self.get_active_appsel_media_lane_count()) - 1
+        if loopback_capability['per_lane_media_loopback_supported'] is False and lane_mask != all_lanes_mask:
             logger.error('Per-lane media input loopback is not supported, lane_mask:%#x', lane_mask)
             return False
 
@@ -1619,7 +1688,8 @@ class CmisApi(CmisCdbFw, XcvrApi):
             logger.error('Media output loopback is not supported')
             return False
 
-        if loopback_capability['per_lane_media_loopback_supported'] is False and lane_mask != 0xff:
+        all_lanes_mask = (1 << self.get_active_appsel_media_lane_count()) - 1
+        if loopback_capability['per_lane_media_loopback_supported'] is False and lane_mask != all_lanes_mask:
             logger.error('Per-lane media output loopback is not supported, lane_mask:%#x', lane_mask)
             return False
 
@@ -1663,11 +1733,13 @@ class CmisApi(CmisCdbFw, XcvrApi):
         }
 
         if loopback_mode == 'none':
+            host_all_lanes_mask = (1 << self.get_active_appsel_host_lane_count()) - 1
+            media_all_lanes_mask = (1 << self.get_active_appsel_media_lane_count()) - 1
             return all([
-                self.set_host_input_loopback(0xff, False),
-                self.set_host_output_loopback(0xff, False),
-                self.set_media_input_loopback(0xff, False),
-                self.set_media_output_loopback(0xff, False)
+                self.set_host_input_loopback(host_all_lanes_mask, False),
+                self.set_host_output_loopback(host_all_lanes_mask, False),
+                self.set_media_input_loopback(media_all_lanes_mask, False),
+                self.set_media_output_loopback(media_all_lanes_mask, False)
             ])
 
         func = loopback_functions.get(loopback_mode)

--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -1118,11 +1118,30 @@ class CmisApi(CmisCdbFw, XcvrApi):
         duration = self.xcvr_eeprom.read(consts.MODULE_PWRDN_DURATION)
         return float(duration) if duration is not None else 0
 
-    def get_host_lane_count(self):
+    def get_host_lane_count(self, appl=None):
         '''
-        This function returns number of host lanes for default application
+        Returns the number of host lanes.
+
+        When appl is None, returns the default application's host lane count
+        from the lower page (Page 00h).  When appl is provided, looks up that
+        application's host_lane_count in the application advertisement (Page 00h
+        upper / Page 01h), mirroring the behaviour of get_media_lane_count.
+
+        Args:
+            appl (int or None): Application selector code (1-based).  Pass None
+                (default) to preserve the legacy behaviour.
+
+        Returns:
+            int: Host lane count, or 0 when the count cannot be determined.
         '''
-        return self.xcvr_eeprom.read(consts.HOST_LANE_COUNT)
+        if appl is None:
+            return self.xcvr_eeprom.read(consts.HOST_LANE_COUNT)
+        if self.is_flat_memory():
+            return 0
+        if appl <= 0:
+            return 0
+        appl_advt = self.get_application_advertisement()
+        return appl_advt[appl]['host_lane_count'] if len(appl_advt) >= appl else 0
 
     def get_media_lane_count(self, appl=1):
         '''
@@ -1182,72 +1201,6 @@ class CmisApi(CmisCdbFw, XcvrApi):
 
         active_apsel_code = self.xcvr_eeprom.read(consts.ACTIVE_APSEL_CODE)
         return defaultdict(lambda: 'N/A') if not active_apsel_code else active_apsel_code
-
-    def _get_active_appsel_descriptor(self):
-        '''
-        Returns the application-advertisement descriptor for the currently
-        active AppSel on host lane 1.
-
-        Raises RuntimeError if the active AppSel cannot be determined --
-        callers must not silently fall back to the default-application
-        descriptor, since that defeats the purpose of resolving the
-        runtime-configured application.
-        '''
-        if self.is_flat_memory():
-            raise RuntimeError(
-                'Cannot determine active AppSel descriptor: '
-                'module reports flat memory (page 11h unavailable)')
-
-        lane1_field = "%s%d" % (consts.ACTIVE_APSEL_HOSTLANE, 1)
-        active_apsel = self.xcvr_eeprom.read(lane1_field)
-        if not active_apsel:
-            raise RuntimeError(
-                'Cannot determine active AppSel descriptor: '
-                'read of %s returned %r' % (lane1_field, active_apsel))
-
-        appl_advt = self.get_application_advertisement()
-        descriptor = appl_advt.get(active_apsel)
-        if not descriptor:
-            raise RuntimeError(
-                'Cannot determine active AppSel descriptor: '
-                'AppSel %d has no entry in application advertisement %r'
-                % (active_apsel, appl_advt))
-
-        return active_apsel, descriptor
-
-    def get_active_appsel_host_lane_count(self):
-        '''
-        Returns the host lane count for the currently active application.
-
-        Reads the applied AppSel code from the DataPath Configuration
-        (Page 11h) and looks up the corresponding application descriptor.
-        Raises RuntimeError if the active AppSel cannot be determined or
-        the descriptor lacks a host_lane_count
-        '''
-        active_apsel, descriptor = self._get_active_appsel_descriptor()
-        if 'host_lane_count' not in descriptor:
-            raise RuntimeError(
-                'Cannot determine active AppSel host lane count: '
-                'AppSel %d descriptor %r has no host_lane_count'
-                % (active_apsel, descriptor))
-        return descriptor['host_lane_count']
-
-    def get_active_appsel_media_lane_count(self):
-        '''
-        Returns the media lane count for the currently active application.
-
-        Reads the applied AppSel code from the DataPath Configuration
-        (Page 11h) and looks up the corresponding application descriptor.
-        Raises RuntimeError if the active AppSel cannot be determined or
-        the descriptor lacks a media_lane_count
-        '''
-        active_apsel, descriptor = self._get_active_appsel_descriptor()
-        if 'media_lane_count' not in descriptor:
-            raise RuntimeError(
-                'Cannot determine active AppSel media lane count: '
-                'AppSel %d descriptor %r has no media_lane_count'
-                % (active_apsel, descriptor))
-        return descriptor['media_lane_count']
 
     def get_tx_config_power(self):
         '''
@@ -1562,7 +1515,16 @@ class CmisApi(CmisCdbFw, XcvrApi):
             logger.error('Host input loopback is not supported')
             return False
 
-        all_lanes_mask = (1 << self.get_active_appsel_host_lane_count()) - 1
+        appl = self.get_active_apsel_hostlane().get("%s%d" % (consts.ACTIVE_APSEL_HOSTLANE, 1), 0)
+        host_lane_count = self.get_host_lane_count(appl)
+        if not host_lane_count:
+            logger.error('Cannot determine active host lane count (appl=%r)', appl)
+            return False
+        all_lanes_mask = (1 << host_lane_count) - 1
+
+        if lane_mask == 0xff:
+            lane_mask = all_lanes_mask
+
         if loopback_capability['per_lane_host_loopback_supported'] is False and lane_mask != all_lanes_mask:
             logger.error('Per-lane host input loopback is not supported, lane_mask:%#x', lane_mask)
             return False
@@ -1571,8 +1533,10 @@ class CmisApi(CmisCdbFw, XcvrApi):
             media_input_val = self.xcvr_eeprom.read(consts.MEDIA_INPUT_LOOPBACK)
             media_output_val = self.xcvr_eeprom.read(consts.MEDIA_OUTPUT_LOOPBACK)
             if media_input_val or media_output_val:
+                m_in_str = f"{media_input_val:#x}" if media_input_val is not None else "None"
+                m_out_str = f"{media_output_val:#x}" if media_output_val is not None else "None"
                 txt = 'Simultaneous host media loopback is not supported\n'
-                txt += f'media_input_val:{media_input_val:#x}, media_output_val:{media_output_val:#x}'
+                txt += f'media_input_val:{m_in_str}, media_output_val:{m_out_str}'
                 logger.error(txt)
                 return False
 
@@ -1604,7 +1568,16 @@ class CmisApi(CmisCdbFw, XcvrApi):
             logger.error('Host output loopback is not supported')
             return False
 
-        all_lanes_mask = (1 << self.get_active_appsel_host_lane_count()) - 1
+        appl = self.get_active_apsel_hostlane().get("%s%d" % (consts.ACTIVE_APSEL_HOSTLANE, 1), 0)
+        host_lane_count = self.get_host_lane_count(appl)
+        if not host_lane_count:
+            logger.error('Cannot determine active host lane count (appl=%r)', appl)
+            return False
+        all_lanes_mask = (1 << host_lane_count) - 1
+
+        if lane_mask == 0xff:
+            lane_mask = all_lanes_mask
+
         if loopback_capability['per_lane_host_loopback_supported'] is False and lane_mask != all_lanes_mask:
             logger.error('Per-lane host output loopback is not supported, lane_mask:%#x', lane_mask)
             return False
@@ -1613,8 +1586,10 @@ class CmisApi(CmisCdbFw, XcvrApi):
             media_input_val = self.xcvr_eeprom.read(consts.MEDIA_INPUT_LOOPBACK)
             media_output_val = self.xcvr_eeprom.read(consts.MEDIA_OUTPUT_LOOPBACK)
             if media_input_val or media_output_val:
+                m_in_str = f"{media_input_val:#x}" if media_input_val is not None else "None"
+                m_out_str = f"{media_output_val:#x}" if media_output_val is not None else "None"
                 txt = 'Simultaneous host media loopback is not supported\n'
-                txt += f'media_input_val:{media_input_val:x}, media_output_val:{media_output_val:#x}'
+                txt += f'media_input_val:{m_in_str}, media_output_val:{m_out_str}'
                 logger.error(txt)
                 return False
 
@@ -1646,7 +1621,16 @@ class CmisApi(CmisCdbFw, XcvrApi):
             logger.error('Media input loopback is not supported')
             return False
 
-        all_lanes_mask = (1 << self.get_active_appsel_media_lane_count()) - 1
+        appl = self.get_active_apsel_hostlane().get("%s%d" % (consts.ACTIVE_APSEL_HOSTLANE, 1), 0)
+        media_lane_count = self.get_media_lane_count(appl)
+        if not media_lane_count:
+            logger.error('Cannot determine active media lane count (appl=%r)', appl)
+            return False
+        all_lanes_mask = (1 << media_lane_count) - 1
+
+        if lane_mask == 0xff:
+            lane_mask = all_lanes_mask
+
         if loopback_capability['per_lane_media_loopback_supported'] is False and lane_mask != all_lanes_mask:
             logger.error('Per-lane media input loopback is not supported, lane_mask:%#x', lane_mask)
             return False
@@ -1655,8 +1639,10 @@ class CmisApi(CmisCdbFw, XcvrApi):
             host_input_val = self.xcvr_eeprom.read(consts.HOST_INPUT_LOOPBACK)
             host_output_val = self.xcvr_eeprom.read(consts.HOST_OUTPUT_LOOPBACK)
             if host_input_val or host_output_val:
+                h_in_str = f"{host_input_val:#x}" if host_input_val is not None else "None"
+                h_out_str = f"{host_output_val:#x}" if host_output_val is not None else "None"
                 txt = 'Simultaneous host media loopback is not supported\n'
-                txt += f'host_input_val:{host_input_val:#x}, host_output_val:{host_output_val:#x}'
+                txt += f'host_input_val:{h_in_str}, host_output_val:{h_out_str}'
                 logger.error(txt)
                 return False
 
@@ -1688,7 +1674,16 @@ class CmisApi(CmisCdbFw, XcvrApi):
             logger.error('Media output loopback is not supported')
             return False
 
-        all_lanes_mask = (1 << self.get_active_appsel_media_lane_count()) - 1
+        appl = self.get_active_apsel_hostlane().get("%s%d" % (consts.ACTIVE_APSEL_HOSTLANE, 1), 0)
+        media_lane_count = self.get_media_lane_count(appl)
+        if not media_lane_count:
+            logger.error('Cannot determine active media lane count (appl=%r)', appl)
+            return False
+        all_lanes_mask = (1 << media_lane_count) - 1
+
+        if lane_mask == 0xff:
+            lane_mask = all_lanes_mask
+
         if loopback_capability['per_lane_media_loopback_supported'] is False and lane_mask != all_lanes_mask:
             logger.error('Per-lane media output loopback is not supported, lane_mask:%#x', lane_mask)
             return False
@@ -1697,8 +1692,10 @@ class CmisApi(CmisCdbFw, XcvrApi):
             host_input_val = self.xcvr_eeprom.read(consts.HOST_INPUT_LOOPBACK)
             host_output_val = self.xcvr_eeprom.read(consts.HOST_OUTPUT_LOOPBACK)
             if host_input_val or host_output_val:
+                h_in_str = f"{host_input_val:#x}" if host_input_val is not None else "None"
+                h_out_str = f"{host_output_val:#x}" if host_output_val is not None else "None"
                 txt = 'Simultaneous host media loopback is not supported\n'
-                txt += f'host_input_val:{host_input_val:#x}, host_output_val:{host_output_val:#x}'
+                txt += f'host_input_val:{h_in_str}, host_output_val:{h_out_str}'
                 logger.error(txt)
                 return False
 
@@ -1733,8 +1730,14 @@ class CmisApi(CmisCdbFw, XcvrApi):
         }
 
         if loopback_mode == 'none':
-            host_all_lanes_mask = (1 << self.get_active_appsel_host_lane_count()) - 1
-            media_all_lanes_mask = (1 << self.get_active_appsel_media_lane_count()) - 1
+            appl = self.get_active_apsel_hostlane().get("%s%d" % (consts.ACTIVE_APSEL_HOSTLANE, 1), 0)
+            host_lane_count = self.get_host_lane_count(appl)
+            media_lane_count = self.get_media_lane_count(appl)
+            if not host_lane_count or not media_lane_count:
+                logger.error("Cannot determine active lane counts for loopback 'none' (appl=%r)", appl)
+                return False
+            host_all_lanes_mask = (1 << host_lane_count) - 1
+            media_all_lanes_mask = (1 << media_lane_count) - 1
             return all([
                 self.set_host_input_loopback(host_all_lanes_mask, False),
                 self.set_host_output_loopback(host_all_lanes_mask, False),

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -1174,6 +1174,107 @@ class TestCmis(object):
         result = self.api.get_active_apsel_hostlane()
         assert result == expected
 
+    @pytest.mark.parametrize(
+        "is_flat_memory, active_apsel, appl_advt, expected",
+        [
+            # AppSel 2 is the configured 4-lane application.
+            (False, 2,
+             {1: {'host_lane_count': 1}, 2: {'host_lane_count': 4}},
+             4),
+            # AppSel 1 is the configured 1-lane application.
+            (False, 1,
+             {1: {'host_lane_count': 1}, 2: {'host_lane_count': 4}},
+             1),
+        ]
+    )
+    def test_get_active_appsel_host_lane_count(
+        self, is_flat_memory, active_apsel, appl_advt, expected
+    ):
+        # patch.object as a context manager so mocks don't leak onto self.api
+        # (which is a class-shared instance) and break later tests like
+        # test_get_application_advertisement.
+        self.api.xcvr_eeprom.read = MagicMock(return_value=active_apsel)
+        with patch.object(self.api, 'is_flat_memory', return_value=is_flat_memory), \
+             patch.object(self.api, 'get_application_advertisement', return_value=appl_advt):
+            assert self.api.get_active_appsel_host_lane_count() == expected
+
+    @pytest.mark.parametrize(
+        "is_flat_memory, active_apsel, appl_advt",
+        [
+            # Flat memory: page 11h is unreadable.
+            (True, None, {}),
+            # AppSel read returns None.
+            (False, None,
+             {1: {'host_lane_count': 1}, 2: {'host_lane_count': 4}}),
+            # AppSel read returns 0 (no app active).
+            (False, 0,
+             {1: {'host_lane_count': 1}, 2: {'host_lane_count': 4}}),
+            # AppSel code has no matching descriptor.
+            (False, 5,
+             {1: {'host_lane_count': 1}, 2: {'host_lane_count': 4}}),
+            # Descriptor present but missing host_lane_count.
+            (False, 2,
+             {1: {'host_lane_count': 1}, 2: {}}),
+        ]
+    )
+    def test_get_active_appsel_host_lane_count_raises(
+        self, is_flat_memory, active_apsel, appl_advt
+    ):
+        self.api.xcvr_eeprom.read = MagicMock(return_value=active_apsel)
+        with patch.object(self.api, 'is_flat_memory', return_value=is_flat_memory), \
+             patch.object(self.api, 'get_application_advertisement', return_value=appl_advt):
+            with pytest.raises(RuntimeError):
+                self.api.get_active_appsel_host_lane_count()
+
+    @pytest.mark.parametrize(
+        "is_flat_memory, active_apsel, appl_advt, expected",
+        [
+            # AppSel 2 is the configured 4-lane media application.
+            (False, 2,
+             {1: {'media_lane_count': 1}, 2: {'media_lane_count': 4}},
+             4),
+            # AppSel 1 is the configured 1-lane media application.
+            (False, 1,
+             {1: {'media_lane_count': 1}, 2: {'media_lane_count': 4}},
+             1),
+        ]
+    )
+    def test_get_active_appsel_media_lane_count(
+        self, is_flat_memory, active_apsel, appl_advt, expected
+    ):
+        self.api.xcvr_eeprom.read = MagicMock(return_value=active_apsel)
+        with patch.object(self.api, 'is_flat_memory', return_value=is_flat_memory), \
+             patch.object(self.api, 'get_application_advertisement', return_value=appl_advt):
+            assert self.api.get_active_appsel_media_lane_count() == expected
+
+    @pytest.mark.parametrize(
+        "is_flat_memory, active_apsel, appl_advt",
+        [
+            # Flat memory: page 11h is unreadable.
+            (True, None, {}),
+            # AppSel read returns None.
+            (False, None,
+             {1: {'media_lane_count': 1}, 2: {'media_lane_count': 4}}),
+            # AppSel read returns 0 (no app active).
+            (False, 0,
+             {1: {'media_lane_count': 1}, 2: {'media_lane_count': 4}}),
+            # AppSel code has no matching descriptor.
+            (False, 5,
+             {1: {'media_lane_count': 1}, 2: {'media_lane_count': 4}}),
+            # Descriptor present but missing media_lane_count.
+            (False, 2,
+             {1: {'media_lane_count': 1}, 2: {}}),
+        ]
+    )
+    def test_get_active_appsel_media_lane_count_raises(
+        self, is_flat_memory, active_apsel, appl_advt
+    ):
+        self.api.xcvr_eeprom.read = MagicMock(return_value=active_apsel)
+        with patch.object(self.api, 'is_flat_memory', return_value=is_flat_memory), \
+             patch.object(self.api, 'get_application_advertisement', return_value=appl_advt):
+            with pytest.raises(RuntimeError):
+                self.api.get_active_appsel_media_lane_count()
+
     @pytest.mark.parametrize("mock_response, expected", [
         (-10, -10)
     ])
@@ -1395,37 +1496,44 @@ class TestCmis(object):
         result = self.api.get_loopback_capability()
         assert result == expected
 
-    @pytest.mark.parametrize("input_param, mock_response, expected",[
-        ([0xf, True], None, False),
+    @pytest.mark.parametrize("input_param, mock_response, host_lane_count, expected",[
+        ([0xf, True], None, 8, False),
         ([0xf, True], {
             'host_side_input_loopback_supported': False,
             'simultaneous_host_media_loopback_supported': True,
             'per_lane_host_loopback_supported': True,
-        }, False),
+        }, 8, False),
         ([0xf, True], {
             'host_side_input_loopback_supported': True,
             'simultaneous_host_media_loopback_supported': True,
             'per_lane_host_loopback_supported': False,
-        }, False),
+        }, 8, False),
         ([0xf, True], {
             'host_side_input_loopback_supported': True,
             'simultaneous_host_media_loopback_supported': False,
             'per_lane_host_loopback_supported': True,
-        }, False),
+        }, 8, False),
         ([0xf, True], {
             'host_side_input_loopback_supported': True,
             'simultaneous_host_media_loopback_supported': True,
             'per_lane_host_loopback_supported': True,
-        }, True),
+        }, 8, True),
         ([0xf, False], {
             'host_side_input_loopback_supported': True,
             'simultaneous_host_media_loopback_supported': True,
             'per_lane_host_loopback_supported': True,
-        }, True),
+        }, 8, True),
+        # 4-lane module: 0x0f is the all-lanes mask, so per_lane=False must succeed.
+        ([0x0f, True], {
+            'host_side_input_loopback_supported': True,
+            'simultaneous_host_media_loopback_supported': True,
+            'per_lane_host_loopback_supported': False,
+        }, 4, True),
     ])
-    def test_set_host_input_loopback(self, input_param, mock_response, expected):
+    def test_set_host_input_loopback(self, input_param, mock_response, host_lane_count, expected):
         self.api.get_loopback_capability = MagicMock()
         self.api.get_loopback_capability.return_value = mock_response
+        self.api.get_active_appsel_host_lane_count = MagicMock(return_value=host_lane_count)
         self.api.xcvr_eeprom.read = MagicMock()
         self.api.xcvr_eeprom.read.side_effect = [0x0f,0x0f]
         self.api.xcvr_eeprom.write = MagicMock()
@@ -1433,37 +1541,44 @@ class TestCmis(object):
         result = self.api.set_host_input_loopback(input_param[0], input_param[1])
         assert result == expected
 
-    @pytest.mark.parametrize("input_param, mock_response, expected",[
-        ([0xf, True], None, False),
+    @pytest.mark.parametrize("input_param, mock_response, host_lane_count, expected",[
+        ([0xf, True], None, 8, False),
         ([0xf, True], {
             'host_side_output_loopback_supported': False,
             'simultaneous_host_media_loopback_supported': True,
             'per_lane_host_loopback_supported': True,
-        }, False),
+        }, 8, False),
         ([0xf, True], {
             'host_side_output_loopback_supported': True,
             'simultaneous_host_media_loopback_supported': True,
             'per_lane_host_loopback_supported': False,
-        }, False),
+        }, 8, False),
         ([0xf, True], {
             'host_side_output_loopback_supported': True,
             'simultaneous_host_media_loopback_supported': False,
             'per_lane_host_loopback_supported': True,
-        }, False),
+        }, 8, False),
         ([0xf, True], {
             'host_side_output_loopback_supported': True,
             'simultaneous_host_media_loopback_supported': True,
             'per_lane_host_loopback_supported': True,
-        }, True),
+        }, 8, True),
         ([0xf, False], {
             'host_side_output_loopback_supported': True,
             'simultaneous_host_media_loopback_supported': True,
             'per_lane_host_loopback_supported': True,
-        }, True),
+        }, 8, True),
+        # 4-lane module: 0x0f is the all-lanes mask, so per_lane=False must succeed.
+        ([0x0f, True], {
+            'host_side_output_loopback_supported': True,
+            'simultaneous_host_media_loopback_supported': True,
+            'per_lane_host_loopback_supported': False,
+        }, 4, True),
     ])
-    def test_set_host_output_loopback(self, input_param, mock_response, expected):
+    def test_set_host_output_loopback(self, input_param, mock_response, host_lane_count, expected):
         self.api.get_loopback_capability = MagicMock()
         self.api.get_loopback_capability.return_value = mock_response
+        self.api.get_active_appsel_host_lane_count = MagicMock(return_value=host_lane_count)
         self.api.xcvr_eeprom.read = MagicMock()
         self.api.xcvr_eeprom.read.side_effect = [0x0f,0x0f]
         self.api.xcvr_eeprom.write = MagicMock()
@@ -1471,37 +1586,44 @@ class TestCmis(object):
         result = self.api.set_host_output_loopback(input_param[0], input_param[1])
         assert result == expected
 
-    @pytest.mark.parametrize("input_param, mock_response, expected",[
-        ([0xf, True], None, False),
+    @pytest.mark.parametrize("input_param, mock_response, media_lane_count, expected",[
+        ([0xf, True], None, 8, False),
         ([0xf, True], {
             'media_side_input_loopback_supported': False,
             'simultaneous_host_media_loopback_supported': True,
             'per_lane_media_loopback_supported': True,
-        }, False),
+        }, 8, False),
         ([0xf, True], {
             'media_side_input_loopback_supported': True,
             'simultaneous_host_media_loopback_supported': True,
             'per_lane_media_loopback_supported': False,
-        }, False),
+        }, 8, False),
         ([0xf, True], {
             'media_side_input_loopback_supported': True,
             'simultaneous_host_media_loopback_supported': False,
             'per_lane_media_loopback_supported': True,
-        }, False),
+        }, 8, False),
         ([0xf, True], {
             'media_side_input_loopback_supported': True,
             'simultaneous_host_media_loopback_supported': True,
             'per_lane_media_loopback_supported': True,
-        }, True),
+        }, 8, True),
         ([0xf, False], {
             'media_side_input_loopback_supported': True,
             'simultaneous_host_media_loopback_supported': True,
             'per_lane_media_loopback_supported': True,
-        }, True),
+        }, 8, True),
+        # 4-lane module: 0x0f is the all-lanes mask, so per_lane=False must succeed.
+        ([0x0f, True], {
+            'media_side_input_loopback_supported': True,
+            'simultaneous_host_media_loopback_supported': True,
+            'per_lane_media_loopback_supported': False,
+        }, 4, True),
     ])
-    def test_set_media_input_loopback(self, input_param, mock_response, expected):
+    def test_set_media_input_loopback(self, input_param, mock_response, media_lane_count, expected):
         self.api.get_loopback_capability = MagicMock()
         self.api.get_loopback_capability.return_value = mock_response
+        self.api.get_active_appsel_media_lane_count = MagicMock(return_value=media_lane_count)
         self.api.xcvr_eeprom.read = MagicMock()
         self.api.xcvr_eeprom.read.side_effect = [0x0f,0x0f]
         self.api.xcvr_eeprom.write = MagicMock()
@@ -1509,37 +1631,44 @@ class TestCmis(object):
         result = self.api.set_media_input_loopback(input_param[0], input_param[1])
         assert result == expected
 
-    @pytest.mark.parametrize("input_param, mock_response, expected",[
-        ([0xf, True], None, False),
+    @pytest.mark.parametrize("input_param, mock_response, media_lane_count, expected",[
+        ([0xf, True], None, 8, False),
         ([0xf, True], {
             'media_side_output_loopback_supported': False,
             'simultaneous_host_media_loopback_supported': True,
             'per_lane_media_loopback_supported': True,
-        }, False),
+        }, 8, False),
         ([0xf, True], {
             'media_side_output_loopback_supported': True,
             'simultaneous_host_media_loopback_supported': True,
             'per_lane_media_loopback_supported': False,
-        }, False),
+        }, 8, False),
         ([0xf, True], {
             'media_side_output_loopback_supported': True,
             'simultaneous_host_media_loopback_supported': False,
             'per_lane_media_loopback_supported': True,
-        }, False),
+        }, 8, False),
         ([0xf, True], {
             'media_side_output_loopback_supported': True,
             'simultaneous_host_media_loopback_supported': True,
             'per_lane_media_loopback_supported': True,
-        }, True),
+        }, 8, True),
         ([0xf, False], {
             'media_side_output_loopback_supported': True,
             'simultaneous_host_media_loopback_supported': True,
             'per_lane_media_loopback_supported': True,
-        }, True),
+        }, 8, True),
+        # 4-lane module: 0x0f is the all-lanes mask, so per_lane=False must succeed.
+        ([0x0f, True], {
+            'media_side_output_loopback_supported': True,
+            'simultaneous_host_media_loopback_supported': True,
+            'per_lane_media_loopback_supported': False,
+        }, 4, True),
     ])
-    def test_set_media_output_loopback(self, input_param, mock_response, expected):
+    def test_set_media_output_loopback(self, input_param, mock_response, media_lane_count, expected):
         self.api.get_loopback_capability = MagicMock()
         self.api.get_loopback_capability.return_value = mock_response
+        self.api.get_active_appsel_media_lane_count = MagicMock(return_value=media_lane_count)
         self.api.xcvr_eeprom.read = MagicMock()
         self.api.xcvr_eeprom.read.side_effect = [0x0f,0x0f]
         self.api.xcvr_eeprom.write = MagicMock()
@@ -1569,6 +1698,8 @@ class TestCmis(object):
         self.api.set_media_input_loopback.return_value = mock_response
         self.api.set_media_output_loopback = MagicMock()
         self.api.set_media_output_loopback.return_value = mock_response
+        self.api.get_active_appsel_host_lane_count = MagicMock(return_value=8)
+        self.api.get_active_appsel_media_lane_count = MagicMock(return_value=8)
         result = self.api.set_loopback_mode(input_param[0], input_param[1])
         assert result == expected
 

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -1174,106 +1174,33 @@ class TestCmis(object):
         result = self.api.get_active_apsel_hostlane()
         assert result == expected
 
+
     @pytest.mark.parametrize(
-        "is_flat_memory, active_apsel, appl_advt, expected",
+        "appl, is_flat_memory, appl_advt, expected",
         [
-            # AppSel 2 is the configured 4-lane application.
-            (False, 2,
+            # Default (appl=None): reads from lower page.
+            (None, False, {}, 8),
+            # appl=2 on a non-flat module with 2 apps: returns host_lane_count.
+            (2, False,
              {1: {'host_lane_count': 1}, 2: {'host_lane_count': 4}},
              4),
-            # AppSel 1 is the configured 1-lane application.
-            (False, 1,
+            # appl=1 returns that app's count.
+            (1, False,
              {1: {'host_lane_count': 1}, 2: {'host_lane_count': 4}},
              1),
+            # Flat memory with explicit appl returns 0.
+            (1, True, {}, 0),
+            # appl=0 returns 0.
+            (0, False, {1: {'host_lane_count': 1}}, 0),
+            # appl not in advertisement returns 0.
+            (5, False, {1: {'host_lane_count': 1}}, 0),
         ]
     )
-    def test_get_active_appsel_host_lane_count(
-        self, is_flat_memory, active_apsel, appl_advt, expected
-    ):
-        # patch.object as a context manager so mocks don't leak onto self.api
-        # (which is a class-shared instance) and break later tests like
-        # test_get_application_advertisement.
-        self.api.xcvr_eeprom.read = MagicMock(return_value=active_apsel)
+    def test_get_host_lane_count(self, appl, is_flat_memory, appl_advt, expected):
+        self.api.xcvr_eeprom.read = MagicMock(return_value=8)
         with patch.object(self.api, 'is_flat_memory', return_value=is_flat_memory), \
              patch.object(self.api, 'get_application_advertisement', return_value=appl_advt):
-            assert self.api.get_active_appsel_host_lane_count() == expected
-
-    @pytest.mark.parametrize(
-        "is_flat_memory, active_apsel, appl_advt",
-        [
-            # Flat memory: page 11h is unreadable.
-            (True, None, {}),
-            # AppSel read returns None.
-            (False, None,
-             {1: {'host_lane_count': 1}, 2: {'host_lane_count': 4}}),
-            # AppSel read returns 0 (no app active).
-            (False, 0,
-             {1: {'host_lane_count': 1}, 2: {'host_lane_count': 4}}),
-            # AppSel code has no matching descriptor.
-            (False, 5,
-             {1: {'host_lane_count': 1}, 2: {'host_lane_count': 4}}),
-            # Descriptor present but missing host_lane_count.
-            (False, 2,
-             {1: {'host_lane_count': 1}, 2: {}}),
-        ]
-    )
-    def test_get_active_appsel_host_lane_count_raises(
-        self, is_flat_memory, active_apsel, appl_advt
-    ):
-        self.api.xcvr_eeprom.read = MagicMock(return_value=active_apsel)
-        with patch.object(self.api, 'is_flat_memory', return_value=is_flat_memory), \
-             patch.object(self.api, 'get_application_advertisement', return_value=appl_advt):
-            with pytest.raises(RuntimeError):
-                self.api.get_active_appsel_host_lane_count()
-
-    @pytest.mark.parametrize(
-        "is_flat_memory, active_apsel, appl_advt, expected",
-        [
-            # AppSel 2 is the configured 4-lane media application.
-            (False, 2,
-             {1: {'media_lane_count': 1}, 2: {'media_lane_count': 4}},
-             4),
-            # AppSel 1 is the configured 1-lane media application.
-            (False, 1,
-             {1: {'media_lane_count': 1}, 2: {'media_lane_count': 4}},
-             1),
-        ]
-    )
-    def test_get_active_appsel_media_lane_count(
-        self, is_flat_memory, active_apsel, appl_advt, expected
-    ):
-        self.api.xcvr_eeprom.read = MagicMock(return_value=active_apsel)
-        with patch.object(self.api, 'is_flat_memory', return_value=is_flat_memory), \
-             patch.object(self.api, 'get_application_advertisement', return_value=appl_advt):
-            assert self.api.get_active_appsel_media_lane_count() == expected
-
-    @pytest.mark.parametrize(
-        "is_flat_memory, active_apsel, appl_advt",
-        [
-            # Flat memory: page 11h is unreadable.
-            (True, None, {}),
-            # AppSel read returns None.
-            (False, None,
-             {1: {'media_lane_count': 1}, 2: {'media_lane_count': 4}}),
-            # AppSel read returns 0 (no app active).
-            (False, 0,
-             {1: {'media_lane_count': 1}, 2: {'media_lane_count': 4}}),
-            # AppSel code has no matching descriptor.
-            (False, 5,
-             {1: {'media_lane_count': 1}, 2: {'media_lane_count': 4}}),
-            # Descriptor present but missing media_lane_count.
-            (False, 2,
-             {1: {'media_lane_count': 1}, 2: {}}),
-        ]
-    )
-    def test_get_active_appsel_media_lane_count_raises(
-        self, is_flat_memory, active_apsel, appl_advt
-    ):
-        self.api.xcvr_eeprom.read = MagicMock(return_value=active_apsel)
-        with patch.object(self.api, 'is_flat_memory', return_value=is_flat_memory), \
-             patch.object(self.api, 'get_application_advertisement', return_value=appl_advt):
-            with pytest.raises(RuntimeError):
-                self.api.get_active_appsel_media_lane_count()
+            assert self.api.get_host_lane_count(appl) == expected
 
     @pytest.mark.parametrize("mock_response, expected", [
         (-10, -10)
@@ -1533,7 +1460,8 @@ class TestCmis(object):
     def test_set_host_input_loopback(self, input_param, mock_response, host_lane_count, expected):
         self.api.get_loopback_capability = MagicMock()
         self.api.get_loopback_capability.return_value = mock_response
-        self.api.get_active_appsel_host_lane_count = MagicMock(return_value=host_lane_count)
+        self.api.get_active_apsel_hostlane = MagicMock(return_value={"ActiveAppSelLane1": 1})
+        self.api.get_host_lane_count = MagicMock(return_value=host_lane_count)
         self.api.xcvr_eeprom.read = MagicMock()
         self.api.xcvr_eeprom.read.side_effect = [0x0f,0x0f]
         self.api.xcvr_eeprom.write = MagicMock()
@@ -1578,7 +1506,8 @@ class TestCmis(object):
     def test_set_host_output_loopback(self, input_param, mock_response, host_lane_count, expected):
         self.api.get_loopback_capability = MagicMock()
         self.api.get_loopback_capability.return_value = mock_response
-        self.api.get_active_appsel_host_lane_count = MagicMock(return_value=host_lane_count)
+        self.api.get_active_apsel_hostlane = MagicMock(return_value={"ActiveAppSelLane1": 1})
+        self.api.get_host_lane_count = MagicMock(return_value=host_lane_count)
         self.api.xcvr_eeprom.read = MagicMock()
         self.api.xcvr_eeprom.read.side_effect = [0x0f,0x0f]
         self.api.xcvr_eeprom.write = MagicMock()
@@ -1623,7 +1552,8 @@ class TestCmis(object):
     def test_set_media_input_loopback(self, input_param, mock_response, media_lane_count, expected):
         self.api.get_loopback_capability = MagicMock()
         self.api.get_loopback_capability.return_value = mock_response
-        self.api.get_active_appsel_media_lane_count = MagicMock(return_value=media_lane_count)
+        self.api.get_active_apsel_hostlane = MagicMock(return_value={"ActiveAppSelLane1": 1})
+        self.api.get_media_lane_count = MagicMock(return_value=media_lane_count)
         self.api.xcvr_eeprom.read = MagicMock()
         self.api.xcvr_eeprom.read.side_effect = [0x0f,0x0f]
         self.api.xcvr_eeprom.write = MagicMock()
@@ -1668,7 +1598,8 @@ class TestCmis(object):
     def test_set_media_output_loopback(self, input_param, mock_response, media_lane_count, expected):
         self.api.get_loopback_capability = MagicMock()
         self.api.get_loopback_capability.return_value = mock_response
-        self.api.get_active_appsel_media_lane_count = MagicMock(return_value=media_lane_count)
+        self.api.get_active_apsel_hostlane = MagicMock(return_value={"ActiveAppSelLane1": 1})
+        self.api.get_media_lane_count = MagicMock(return_value=media_lane_count)
         self.api.xcvr_eeprom.read = MagicMock()
         self.api.xcvr_eeprom.read.side_effect = [0x0f,0x0f]
         self.api.xcvr_eeprom.write = MagicMock()
@@ -1687,9 +1618,11 @@ class TestCmis(object):
         (['media-side-input', 0xF0, False], True, True),
         (['media-side-output', 0xF0, False], True, True),
         (['', 0xF0, False], True, False),
-
+        # 4-lane module case: 0x0f is the all-lanes mask for 4 lanes.
+        (['host-side-input', 0x0F, True, 4], True, True),
     ])
     def test_set_loopback_mode(self, input_param, mock_response, expected):
+        lane_count = input_param[3] if len(input_param) > 3 else 8
         self.api.set_host_input_loopback = MagicMock()
         self.api.set_host_input_loopback.return_value = mock_response
         self.api.set_host_output_loopback = MagicMock()
@@ -1698,8 +1631,9 @@ class TestCmis(object):
         self.api.set_media_input_loopback.return_value = mock_response
         self.api.set_media_output_loopback = MagicMock()
         self.api.set_media_output_loopback.return_value = mock_response
-        self.api.get_active_appsel_host_lane_count = MagicMock(return_value=8)
-        self.api.get_active_appsel_media_lane_count = MagicMock(return_value=8)
+        self.api.get_active_apsel_hostlane = MagicMock(return_value={"ActiveAppSelLane1": 1})
+        self.api.get_host_lane_count = MagicMock(return_value=lane_count)
+        self.api.get_media_lane_count = MagicMock(return_value=lane_count)
         result = self.api.set_loopback_mode(input_param[0], input_param[1])
         assert result == expected
 

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -1637,6 +1637,32 @@ class TestCmis(object):
         result = self.api.set_loopback_mode(input_param[0], input_param[1])
         assert result == expected
 
+    @pytest.mark.parametrize("host_lane_count, media_lane_count, expected_host_mask, expected_media_mask", [
+        (8, 8, 0xff, 0xff),
+        (4, 4, 0x0f, 0x0f),
+        (4, 1, 0x0f, 0x01),
+    ])
+    def test_set_loopback_mode_none_uses_active_lane_mask(self, host_lane_count, media_lane_count,
+                                                          expected_host_mask, expected_media_mask):
+        self.api.set_host_input_loopback = MagicMock(return_value=True)
+        self.api.set_host_output_loopback = MagicMock(return_value=True)
+        self.api.set_media_input_loopback = MagicMock(return_value=True)
+        self.api.set_media_output_loopback = MagicMock(return_value=True)
+        self.api.get_active_apsel_hostlane = MagicMock(return_value={"ActiveAppSelLane1": 1})
+        self.api.get_host_lane_count = MagicMock(return_value=host_lane_count)
+        self.api.get_media_lane_count = MagicMock(return_value=media_lane_count)
+        assert self.api.set_loopback_mode('none') == True
+        self.api.set_host_input_loopback.assert_called_once_with(expected_host_mask, False)
+        self.api.set_host_output_loopback.assert_called_once_with(expected_host_mask, False)
+        self.api.set_media_input_loopback.assert_called_once_with(expected_media_mask, False)
+        self.api.set_media_output_loopback.assert_called_once_with(expected_media_mask, False)
+
+    def test_set_loopback_mode_none_returns_false_when_lane_count_unknown(self):
+        self.api.get_active_apsel_hostlane = MagicMock(return_value={"ActiveAppSelLane1": 0})
+        self.api.get_host_lane_count = MagicMock(return_value=0)
+        self.api.get_media_lane_count = MagicMock(return_value=0)
+        assert self.api.set_loopback_mode('none') == False
+
     def test_is_transceiver_vdm_supported_no_vdm(self):
         self.api.vdm = None
         assert self.api.is_transceiver_vdm_supported() == False


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

Certain transceivers expect exact lane masks for the active appsel when setting Media Side and Host side loopbacks respectively.
Currently, we have them hardcoded as 0xFF which works on certain transceivers but not others. On a 1 media lane transceiver, trying to disable loopback on it with 0xFF might fail depending on the device. We noticed this on several transceivers




#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

Tested on INPHI CORP IN-Q3JZ1-TC-M1 and Acacia DP04QSDD-E20-001

Acacia works with and without the fix
IN-Q3JZ1-TC-M1 fails to set any kind of media loopback without the fix

#### Additional Information (Optional)

