### PR TITLE
Fix Micron NVMe disk health output showing N/A

### DIFF
--- a/sonic_platform_base/sonic_storage/ssd.py
+++ b/sonic_platform_base/sonic_storage/ssd.py
@@ -6,6 +6,11 @@
 #  - InnoDisk
 #  - StorFly
 #  - Virtium
+#  - Swissbit
+#  - Intel
+#  - Transcend
+#  - ATP
+#  - Micron
 
 try:
     import re
@@ -104,9 +109,9 @@ class SsdUtil(StorageCommon):
         # Known vendor part
         if self.model:
             vendor = self._parse_vendor()
-            # For Virtium, ATP NVMe SSD, parse_generic_ssd_info should be called.
+            # For Virtium, ATP, Micron NVMe SSD, parse_generic_ssd_info should be called.
             # Skip here, otherwise data will be overwritten by N/A.
-            if vendor in ['Virtium', 'ATP'] and "nvme" in self.dev:
+            if vendor in ['Virtium', 'ATP', 'Micron'] and "nvme" in self.dev:
                 return
 
             if vendor:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
Adding `Micron` to the list of NVMe SSD vendors that skip vendor-specific parsing in `fetch_parse_info()` For Micron NVMe SSDs, the generic NVMe parser `parse_nvme_ssd_info` already correctly extracts the health value from the smartctl `Percentage Used` field. However, the code then proceeds to call `parse_micron_info()` which attempts to parse SATA-specific attributes `(Percent_Lifetime_Used / Percent_Lifetime_Remain)` that don't exist in NVMe output, overwriting the valid health value with N/A. 

This fix adds Micron to the early-return guard (alongside the already-handled Virtium and ATP vendors) so that the vendor-specific parser is skipped for Micron NVMe devices.

#### Motivation and Context
On platforms using Micron NVMe SSDs, `show platform ssdhealth` incorrectly returns N/A even though smartctl provides valid health data. The root cause is that parse_micron_info() is designed for SATA drives and looks for SATA SMART attributes that are absent in NVMe output, causing it to overwrite the correct health value that was already parsed by parse_nvme_ssd_info().


Microsoft ADO : 39376934

#### How Has This Been Tested?
Tested on platforms using Micron NVMe SSD disks 

#### Test result

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

- 202511: 20251110.42 :
- 202605: 20260510.11 :

Before changes :
```
# show platform ssdhealth
Disk Type    : NVME
Device Model : Micron_XXXXXXXX
Health       : N/A
Temperature  : 35.0C
```

After changes : 
```
# show platform ssdhealth
Disk Type    : NVME
Device Model : Micron_XXXXXXXX
Health       : 100.0%
Temperature  : 35.0C
```


#### Additional Information (Optional)

