### PR TITLE
[sonic_pcie]: Fix regex string literals to use raw strings in pcie_common.py

### DIFF
--- a/sonic_platform_base/sonic_pcie/pcie_common.py
+++ b/sonic_platform_base/sonic_pcie/pcie_common.py
@@ -37,8 +37,8 @@ class PcieUtil(PcieBase):
     def get_pcie_device(self):
         pciDict = {}
         pciList = []
-        p1 = "^(\w+):(\w+)\.(\w)\s(.*)\s*\(*.*\)*"
-        p2 = "^.*:.*:.*:(\w+)\s*\(*.*\)*"
+        p1 = r"^(\w+):(\w+)\.(\w)\s(.*)\s*\(*.*\)*"
+        p2 = r"^.*:.*:.*:(\w+)\s*\(*.*\)*"
         command1 = ["sudo", "lspci"]
         command2 = ["sudo", "lspci", "-n"]
         # run command 1


### PR DESCRIPTION
#### Description
Updated regex patterns `p1` and `p2` in `PcieUtil.get_pcie_device()` to use raw string literals (`r"..."`) instead of plain string literals.

#### Motivation and Context
On SONiC `20251110.35` (Debian 13 / Python 3.13), `SyntaxWarning` was emitted to stderr on every CLI invocation (`show ver`, `show ip bgp sum`, etc.) on Arista `7060X6-16PE-384C-B` devices.

**Root cause:**
- `__pycache__/pcie_common.cpython-313.pyc` was created by a root process with a restrictive umask, resulting in `0600` permissions.
- Non-root `admin` users cannot read the `0600` `.pyc` -> Python falls back to parsing `pcie_common.py` from source on every CLI invocation.
- `pcie_common.py` contains invalid escape sequences (`\w`, `\s`) in plain string regex patterns -> Python 3.13 emits `SyntaxWarning` on every parse.

Python 3.12+ warns on invalid escape sequences in plain strings; Python 3.13 raises `SyntaxWarning`; Python 3.14 will raise `SyntaxError`. Raw strings (`r"..."`) are the correct and idiomatic way to write regex patterns and eliminate the warning regardless of `.pyc` cache state or permissions.

#### How Has This Been Tested?
- Existing test suite passes: `pytest tests/pcie_common_test.py -v`
- No `DeprecationWarning` or `SyntaxWarning` emitted under Python 3.12/3.13
- No behavioral change - regex patterns are identical

#### Tested branch
- [x] 202511
- [x] 202605

#### Test result
- 202511: Verified on Python 3.13 file compiles cleanly with no `SyntaxWarning`:
`$ python -W error::SyntaxWarning -m py_compile sonic_platform_base/sonic_pcie/pcie_common.py && echo "PASS: no SyntaxWarning" 
PASS: no SyntaxWarning`


- 202605: Verified on Python 3.13 file compiles cleanly with no `SyntaxWarning`:
`$ python -W error::SyntaxWarning -m py_compile sonic_platform_base/sonic_pcie/pcie_common.py && echo "PASS: no SyntaxWarning" 
PASS: no SyntaxWarning`
