### PR TITLE
Refactor XcvrApiFactory to use ModuleEepromLowerMemoryInfo directly

### DIFF
--- a/sonic_platform_base/sonic_xcvr/xcvr_api_factory.py
+++ b/sonic_platform_base/sonic_xcvr/xcvr_api_factory.py
@@ -48,23 +48,12 @@ class XcvrApiFactory(object):
     def __init__(self, reader, writer):
         self.reader = reader
         self.writer = writer
-
-    def _get_id(self):
-        return ModuleEepromLowerMemoryInfo(self.reader).get_id()
-
-    def _get_revision_compliance(self):
-        return ModuleEepromLowerMemoryInfo(self.reader).get_revision_compliance()
-
-    def _get_vendor_name(self):
-        return ModuleEepromLowerMemoryInfo(self.reader).get_vendor_name()
-
-    def _get_vendor_part_num(self):
-        return ModuleEepromLowerMemoryInfo(self.reader).get_vendor_part_num()
+        self.lower_memory_info = ModuleEepromLowerMemoryInfo(self.reader)
 
     def _create_cmis_api(self, bank=0):
         api = None
-        vendor_name = self._get_vendor_name()
-        vendor_pn = self._get_vendor_part_num()
+        vendor_name = self.lower_memory_info.get_vendor_name()
+        vendor_pn = self.lower_memory_info.get_vendor_part_num()
 
         if vendor_name == 'Credo' and vendor_pn in CREDO_800G_AEC_VENDOR_PN_LIST:
             xcvr_eeprom = XcvrEeprom(self.reader, self.writer, CredoAec800gMemMap(CredoAec800gCodes, bank=bank))
@@ -88,7 +77,7 @@ class XcvrApiFactory(object):
         """
         QSFP/QSFP+ API implementation
         """
-        revision_compliance = self._get_revision_compliance()
+        revision_compliance = self.lower_memory_info.get_revision_compliance()
         if revision_compliance >= 3:
             return self._create_api(Sff8636Codes, Sff8636MemMap, Sff8636Api)
         else:
@@ -101,7 +90,7 @@ class XcvrApiFactory(object):
         return api_class(xcvr_eeprom)
 
     def create_xcvr_api(self, bank=0):
-        id = self._get_id()
+        id = self.lower_memory_info.get_id()
 
         # Instantiate various Optics implementation based upon their respective ID as per SFF8024
         id_mapping = {

--- a/tests/sonic_xcvr/test_eeprom_rw.py
+++ b/tests/sonic_xcvr/test_eeprom_rw.py
@@ -1,0 +1,95 @@
+from mock import MagicMock
+
+from sonic_platform_base.sonic_xcvr.eeprom_rw import ModuleEepromLowerMemoryInfo
+
+
+class TestModuleEepromLowerMemoryInfo(object):
+    def test_get_id(self):
+        reader = MagicMock(return_value=bytes([0x18]))
+        info = ModuleEepromLowerMemoryInfo(reader)
+        assert info.get_id() == 0x18
+        reader.assert_called_once_with(
+            ModuleEepromLowerMemoryInfo.ID_OFFSET, ModuleEepromLowerMemoryInfo.ID_LENGTH)
+
+    def test_get_id_none(self):
+        reader = MagicMock(return_value=None)
+        info = ModuleEepromLowerMemoryInfo(reader)
+        assert info.get_id() is None
+
+    def test_get_revision_compliance(self):
+        reader = MagicMock(return_value=bytes([0x06]))
+        info = ModuleEepromLowerMemoryInfo(reader)
+        assert info.get_revision_compliance() == 0x06
+        reader.assert_called_once_with(
+            ModuleEepromLowerMemoryInfo.REV_OFFSET, ModuleEepromLowerMemoryInfo.REV_LENGTH)
+
+    def test_get_revision_compliance_none(self):
+        reader = MagicMock(return_value=None)
+        info = ModuleEepromLowerMemoryInfo(reader)
+        assert info.get_revision_compliance() is None
+
+    def test_get_vendor_name(self):
+        reader = MagicMock(return_value=b'Credo')
+        info = ModuleEepromLowerMemoryInfo(reader)
+        assert info.get_vendor_name() == 'Credo'
+        reader.assert_called_once_with(
+            ModuleEepromLowerMemoryInfo.VENDOR_NAME_OFFSET,
+            ModuleEepromLowerMemoryInfo.VENDOR_NAME_LENGTH)
+
+    def test_get_vendor_name_strips_padding(self):
+        reader = MagicMock(return_value=b'Credo           ')
+        info = ModuleEepromLowerMemoryInfo(reader)
+        assert info.get_vendor_name() == 'Credo'
+
+    def test_get_vendor_name_ignores_undecodable_bytes(self):
+        reader = MagicMock(return_value=b'Credo\xff')
+        info = ModuleEepromLowerMemoryInfo(reader)
+        assert info.get_vendor_name() == 'Credo'
+
+    def test_get_vendor_name_none(self):
+        reader = MagicMock(return_value=None)
+        info = ModuleEepromLowerMemoryInfo(reader)
+        assert info.get_vendor_name() is None
+
+    def test_get_vendor_part_num(self):
+        reader = MagicMock(return_value=b'CAC81X321M2MC1MS')
+        info = ModuleEepromLowerMemoryInfo(reader)
+        assert info.get_vendor_part_num() == 'CAC81X321M2MC1MS'
+        reader.assert_called_once_with(
+            ModuleEepromLowerMemoryInfo.VENDOR_PART_NUM_OFFSET,
+            ModuleEepromLowerMemoryInfo.VENDOR_PART_NUM_LENGTH)
+
+    def test_get_vendor_part_num_strips_padding(self):
+        reader = MagicMock(return_value=b'CAC81X321M2MC1MS  ')
+        info = ModuleEepromLowerMemoryInfo(reader)
+        assert info.get_vendor_part_num() == 'CAC81X321M2MC1MS'
+
+    def test_get_vendor_part_num_none(self):
+        reader = MagicMock(return_value=None)
+        info = ModuleEepromLowerMemoryInfo(reader)
+        assert info.get_vendor_part_num() is None
+
+    def test_offset_shifts_all_reads(self):
+        offset = 0x4000
+        reader = MagicMock(return_value=bytes([0x18]))
+        info = ModuleEepromLowerMemoryInfo(reader, offset=offset)
+
+        info.get_id()
+        reader.assert_called_with(
+            ModuleEepromLowerMemoryInfo.ID_OFFSET + offset,
+            ModuleEepromLowerMemoryInfo.ID_LENGTH)
+
+        info.get_revision_compliance()
+        reader.assert_called_with(
+            ModuleEepromLowerMemoryInfo.REV_OFFSET + offset,
+            ModuleEepromLowerMemoryInfo.REV_LENGTH)
+
+        info.get_vendor_name()
+        reader.assert_called_with(
+            ModuleEepromLowerMemoryInfo.VENDOR_NAME_OFFSET + offset,
+            ModuleEepromLowerMemoryInfo.VENDOR_NAME_LENGTH)
+
+        info.get_vendor_part_num()
+        reader.assert_called_with(
+            ModuleEepromLowerMemoryInfo.VENDOR_PART_NUM_OFFSET + offset,
+            ModuleEepromLowerMemoryInfo.VENDOR_PART_NUM_LENGTH)

--- a/tests/sonic_xcvr/test_xcvr_api_factory.py
+++ b/tests/sonic_xcvr/test_xcvr_api_factory.py
@@ -20,51 +20,26 @@ def mock_reader_sff8636(start, length):
 def mock_reader_sff8436(start, length):
     return bytes([0x0d]) if start == 0 else bytes ([0x00])
 
-class BytesMock(bytes):
-    def decode(self, encoding='utf-8', errors='strict'):
-        return 'DecodedCredo'
+def mock_reader_cmis(start, length):
+    return bytes([0x18])
 
 class TestXcvrApiFactory(object):
-    read_eeprom = MagicMock
-    write_eeprom = MagicMock
-    api = XcvrApiFactory(read_eeprom, write_eeprom)
-
-    def test_get_vendor_name(self):
-        self.api.reader = MagicMock()
-        self.api.reader.return_value = b'Credo'
-        with patch.object(BytesMock, 'decode', return_value='DecodedCredo'):
-            result = self.api._get_vendor_name()
-        assert result == 'Credo'.strip()
-
-    def test_get_vendor_part_num(self):
-        self.api.reader = MagicMock()
-        self.api.reader.return_value = b'CAC81X321M2MC1MS'
-        with patch.object(BytesMock, 'decode', return_value='DecodedCAC81X321M2MC1MS'):
-            result = self.api._get_vendor_part_num()
-        assert result == 'CAC81X321M2MC1MS'.strip()
-
-    def mock_reader(self, start, length):
-        return bytes([0x18])
-
-    @patch('sonic_platform_base.sonic_xcvr.xcvr_api_factory.XcvrApiFactory._get_vendor_name', MagicMock(return_value='Credo'))
-    @patch('sonic_platform_base.sonic_xcvr.xcvr_api_factory.XcvrApiFactory._get_vendor_part_num', MagicMock(return_value='CAC81X321M2MC1MS'))
+    @patch('sonic_platform_base.sonic_xcvr.eeprom_rw.ModuleEepromLowerMemoryInfo.get_vendor_name', MagicMock(return_value='Credo'))
+    @patch('sonic_platform_base.sonic_xcvr.eeprom_rw.ModuleEepromLowerMemoryInfo.get_vendor_part_num', MagicMock(return_value='CAC81X321M2MC1MS'))
     def test_create_xcvr_api_credo(self):
-        self.api.reader = self.mock_reader
-        api = self.api.create_xcvr_api()
+        api = XcvrApiFactory(mock_reader_cmis, MagicMock()).create_xcvr_api()
         assert isinstance(api, CredoAec800gApi)
 
-    @patch('sonic_platform_base.sonic_xcvr.xcvr_api_factory.XcvrApiFactory._get_vendor_name', MagicMock(return_value='CISCO-INNOLIGHT'))
-    @patch('sonic_platform_base.sonic_xcvr.xcvr_api_factory.XcvrApiFactory._get_vendor_part_num', MagicMock(return_value='T-DH8CNT-NCI'))
+    @patch('sonic_platform_base.sonic_xcvr.eeprom_rw.ModuleEepromLowerMemoryInfo.get_vendor_name', MagicMock(return_value='CISCO-INNOLIGHT'))
+    @patch('sonic_platform_base.sonic_xcvr.eeprom_rw.ModuleEepromLowerMemoryInfo.get_vendor_part_num', MagicMock(return_value='T-DH8CNT-NCI'))
     def test_create_xcvr_api_innolight(self):
-        self.api.reader = self.mock_reader
-        api = self.api.create_xcvr_api()
+        api = XcvrApiFactory(mock_reader_cmis, MagicMock()).create_xcvr_api()
         assert isinstance(api, CmisFr800gApi)
 
-    @patch('sonic_platform_base.sonic_xcvr.xcvr_api_factory.XcvrApiFactory._get_vendor_name', MagicMock(return_value='Hisense'))
-    @patch('sonic_platform_base.sonic_xcvr.xcvr_api_factory.XcvrApiFactory._get_vendor_part_num', MagicMock(return_value='DEF8504-2C03-MB3'))
+    @patch('sonic_platform_base.sonic_xcvr.eeprom_rw.ModuleEepromLowerMemoryInfo.get_vendor_name', MagicMock(return_value='Hisense'))
+    @patch('sonic_platform_base.sonic_xcvr.eeprom_rw.ModuleEepromLowerMemoryInfo.get_vendor_part_num', MagicMock(return_value='DEF8504-2C03-MB3'))
     def test_create_xcvr_api_hisense(self):
-        self.api.reader = self.mock_reader
-        api = self.api.create_xcvr_api()
+        api = XcvrApiFactory(mock_reader_cmis, MagicMock()).create_xcvr_api()
         assert isinstance(api, CmisAocSingleBankApi)
 
     @pytest.mark.parametrize("reader, expected_api", [
@@ -72,19 +47,14 @@ class TestXcvrApiFactory(object):
         (mock_reader_sff8436, Sff8436Api),
     ])
     def test_create_xcvr_api_8436_8636(self, reader, expected_api):
-        self.api.reader = reader
-        api = self.api.create_xcvr_api()
+        api = XcvrApiFactory(reader, MagicMock()).create_xcvr_api()
         assert isinstance(api, expected_api)
-        
+
     @patch('sonic_platform_base.sonic_xcvr.xcvr_api_factory.XcvrApiFactory._create_api', MagicMock(side_effect=Exception('')))
     @patch('sonic_platform_base.sonic_xcvr.xcvr_api_factory.XcvrApiFactory._create_cmis_api', MagicMock(side_effect=Exception('')))
     def test_create_xcvr_api_with_exception(self):
-        self.api.reader = self.mock_reader
-        CmisCodes = MagicMock()
-        CmisMemMap = MagicMock()
-        XcvrEeprom = MagicMock()
-        CmisFr800gApi = MagicMock()
-        assert self.api.create_xcvr_api() is None
+        api = XcvrApiFactory(mock_reader_cmis, MagicMock())
+        assert api.create_xcvr_api() is None
 
 class TestAmphBackplaneImpl:
     @pytest.fixture


### PR DESCRIPTION
#### Description
`XcvrApiFactory` was using thin wrappers around the methods provided by `ModuleEepromLowerMemoryInfo`.

This PR does the following:
- refactors `XcvrApiFactory` to delete those wrappers and just use `ModuleEepromLowerMemoryInfo` directly.
- add unit-tests for `ModuleEepromLowerMemoryInfo`
- change `XcvrApiFactory` unit-tests to just mock out the methods on `ModuleEepromLowerMemoryInfo` and rely on the unit-tests added in the above point instead.

#### Motivation and Context
This change is just to cleanup code.

#### How Has This Been Tested?
All unit-tests are passing.

