### PR TITLE
[CPO] Extend ChassisBase to support CPO ports

### DIFF
--- a/sonic_platform_base/chassis_base.py
+++ b/sonic_platform_base/chassis_base.py
@@ -91,7 +91,7 @@ class ChassisBase(device_base.DeviceBase):
         from sonic_py_common import device_info
         optical_device_data = device_info.get_optical_devices_data()
         if optical_device_data:
-            self.construct_sfp_list_for_topology(optical_device_data)
+            self.construct_optical_devices(optical_device_data)
 
     def get_base_mac(self):
         """
@@ -714,11 +714,11 @@ class ChassisBase(device_base.DeviceBase):
     # SFP methods
     ##############################################
 
-    def construct_sfp_list_for_topology(self, optical_device_data):
+    def construct_optical_devices(self, optical_device_data):
         """
         Construct objects representing the devices driving traffic through
         a front panel port on the chassis based on topology data in
-        optical_devices.json and appends them to self._sfp_list
+        optical_devices.json
 
         Subclasses should implement this method on platforms that provide
         an optical_devices.json file.

--- a/sonic_platform_base/chassis_base.py
+++ b/sonic_platform_base/chassis_base.py
@@ -80,6 +80,15 @@ class ChassisBase(device_base.DeviceBase):
         # SED (Self-Encrypting Drive) password management
         self._sed_mgmt = None
 
+        # On platforms that provide an optical_devices.json file (e.g.
+        # platforms using co-packaged optics, where each port can be driven
+        # by multiple devices), populate the SFP list based on the optical
+        # device topology described in that file
+        from sonic_py_common import device_info
+        optical_device_data = device_info.get_optical_devices_data()
+        if optical_device_data:
+            self.construct_sfp_list_for_topology(optical_device_data)
+
     def get_base_mac(self):
         """
         Retrieves the base MAC address for the chassis
@@ -700,6 +709,21 @@ class ChassisBase(device_base.DeviceBase):
     ##############################################
     # SFP methods
     ##############################################
+
+    def construct_sfp_list_for_topology(self, optical_device_data):
+        """
+        Construct objects representing the devices driving traffic through
+        a front panel port on the chassis based on topology data in
+        optical_devices.json and appends them to self._sfp_list
+
+        Subclasses should implement this method on platforms that provide
+        an optical_devices.json file.
+
+        Args:
+            optical_device_data: Optical device topology data parsed from
+                optical_devices.json
+        """
+        raise NotImplementedError
 
     def get_num_sfps(self):
         """

--- a/sonic_platform_base/chassis_base.py
+++ b/sonic_platform_base/chassis_base.py
@@ -84,14 +84,12 @@ class ChassisBase(device_base.DeviceBase):
         # SED (Self-Encrypting Drive) password management
         self._sed_mgmt = None
 
-        # On platforms that provide an optical_devices.json file (e.g.
-        # platforms using co-packaged optics, where each port can be driven
-        # by multiple devices), populate the SFP list based on the optical
-        # device topology described in that file
+        # On platforms that provide a cpo.json file, populate self._cpo_list
+        # based on the device topology described in that file
         from sonic_py_common import device_info
-        optical_device_data = device_info.get_optical_devices_data()
-        if optical_device_data:
-            self.construct_optical_devices(optical_device_data)
+        cpo_data = device_info.get_cpo_data()
+        if cpo_data:
+            self.construct_cpo_devices(cpo_data)
 
     def get_base_mac(self):
         """
@@ -714,18 +712,17 @@ class ChassisBase(device_base.DeviceBase):
     # SFP methods
     ##############################################
 
-    def construct_optical_devices(self, optical_device_data):
+    def construct_cpo_devices(self, cpo_data):
         """
         Construct objects representing the devices driving traffic through
         a front panel port on the chassis based on topology data in
-        optical_devices.json
+        cpo.json
 
         Subclasses should implement this method on platforms that provide
-        an optical_devices.json file.
+        an cpo.json file.
 
         Args:
-            optical_device_data: Optical device topology data parsed from
-                optical_devices.json
+            cpo_data: device topology data parsed from cpo.json
         """
         raise NotImplementedError
 

--- a/sonic_platform_base/chassis_base.py
+++ b/sonic_platform_base/chassis_base.py
@@ -65,6 +65,10 @@ class ChassisBase(device_base.DeviceBase):
         # available on the chassis
         self._sfp_list = []
 
+        # List of CpoBase-derived objects representing all CPO ports
+        # available on the chassis, indexed by physical port.
+        self._cpo_list = []
+
         # Object derived from WatchdogBase for interacting with hardware watchdog
         self._watchdog = None
 
@@ -768,6 +772,41 @@ class ChassisBase(device_base.DeviceBase):
 
         return sfp
 
+    def get_num_cpos(self):
+        """
+        Retrieves the number of CPO ports available on this chassis
+
+        Returns:
+            An integer, the number of CPO ports available on this chassis
+        """
+        return len(self._cpo_list)
+
+    def get_all_cpos(self):
+        """
+        Retrieves all CPO ports available on this chassis
+
+        Returns:
+            A list of objects derived from CpoBase representing all CPO ports
+            available on this chassis
+        """
+        return [cpo for cpo in self._cpo_list if cpo is not None]
+
+    def get_cpo(self, index):
+        """
+        Retrieves the CPO port corresponding to physical port <index>, if
+        that port is driven by CPO devices.
+
+        Args:
+            index: An integer (>=0), the physical port index (same indexing as
+                   get_sfp()).
+
+        Returns:
+            An object derived from CpoBase representing the specified CPO port,
+            or None if the port is not a CPO port.
+        """
+        if 0 <= index < len(self._cpo_list):
+            return self._cpo_list[index]
+        return None
 
     def get_port_or_cage_type(self, index):
         """

--- a/sonic_platform_base/chassis_base.py
+++ b/sonic_platform_base/chassis_base.py
@@ -776,7 +776,7 @@ class ChassisBase(device_base.DeviceBase):
         Returns:
             An integer, the number of CPO ports available on this chassis
         """
-        return len(self._cpo_list)
+        return sum(1 for cpo in self._cpo_list if cpo is not None)
 
     def get_all_cpos(self):
         """

--- a/sonic_platform_base/chassis_base.py
+++ b/sonic_platform_base/chassis_base.py
@@ -62,12 +62,17 @@ class ChassisBase(device_base.DeviceBase):
         self._current_sensor_list = []
 
         # List of SfpBase-derived objects representing all sfps
-        # available on the chassis
+        # available on the chassis, indexed by physical port.
         self._sfp_list = []
 
         # List of CpoBase-derived objects representing all CPO ports
         # available on the chassis, indexed by physical port.
         self._cpo_list = []
+
+        # Set once the port lists have been checked for consistency. The check
+        # is deferred until the lists are first accessed, since subclasses
+        # populate them after ChassisBase.__init__ has returned.
+        self._port_lists_validated = False
 
         # Object derived from WatchdogBase for interacting with hardware watchdog
         self._watchdog = None
@@ -726,6 +731,38 @@ class ChassisBase(device_base.DeviceBase):
         """
         raise NotImplementedError
 
+    def _validate_port_lists(self):
+        """
+        Check that _sfp_list and _cpo_list follow the indexing convention:
+        both are indexed by physical front panel port, with None at the
+        indices driven by the other technology. A platform which has only one
+        kind of port need only populate the corresponding list.
+        """
+        if self._port_lists_validated:
+            return
+
+        if not self._sfp_list or not self._cpo_list:
+            # This is a platform that only has one type of transceiver technology.
+            # We do not need to perform validation against both lists, because only
+            # one will be used.
+            return
+
+        if len(self._sfp_list) != len(self._cpo_list):
+            raise RuntimeError(
+                "_sfp_list (length {}) and _cpo_list (length {}) must be the "
+                "same length: both are indexed by physical front panel port, "
+                "with None at the indices driven by the other technology".format(
+                    len(self._sfp_list), len(self._cpo_list)))
+
+        for index, (sfp, cpo) in enumerate(zip(self._sfp_list, self._cpo_list)):
+            if sfp is not None and cpo is not None:
+                raise RuntimeError(
+                    "Physical port {} has both an SFP and a CPO object; each "
+                    "port must appear in exactly one of _sfp_list and "
+                    "_cpo_list".format(index))
+
+        self._port_lists_validated = True
+
     def get_num_sfps(self):
         """
         Retrieves the number of sfps available on this chassis
@@ -733,7 +770,8 @@ class ChassisBase(device_base.DeviceBase):
         Returns:
             An integer, the number of sfps available on this chassis
         """
-        return len(self._sfp_list)
+        self._validate_port_lists()
+        return sum(1 for sfp in self._sfp_list if sfp is not None)
 
     def get_all_sfps(self):
         """
@@ -743,6 +781,7 @@ class ChassisBase(device_base.DeviceBase):
             A list of objects derived from SfpBase representing all sfps
             available on this chassis
         """
+        self._validate_port_lists()
         return [ sfp for sfp in self._sfp_list if sfp is not None ]
 
     def get_sfp(self, index):
@@ -757,10 +796,12 @@ class ChassisBase(device_base.DeviceBase):
                    0 for Ethernet0, 1 for Ethernet4 and so on for another platform.
 
         Returns:
-            An object dervied from SfpBase representing the specified sfp
+            An object dervied from SfpBase representing the specified sfp,
+            or None if the port is not an SFP port
         """
         sfp = None
 
+        self._validate_port_lists()
         try:
             sfp = self._sfp_list[index]
         except IndexError:
@@ -776,6 +817,7 @@ class ChassisBase(device_base.DeviceBase):
         Returns:
             An integer, the number of CPO ports available on this chassis
         """
+        self._validate_port_lists()
         return sum(1 for cpo in self._cpo_list if cpo is not None)
 
     def get_all_cpos(self):
@@ -786,6 +828,7 @@ class ChassisBase(device_base.DeviceBase):
             A list of objects derived from CpoBase representing all CPO ports
             available on this chassis
         """
+        self._validate_port_lists()
         return [cpo for cpo in self._cpo_list if cpo is not None]
 
     def get_cpo(self, index):
@@ -802,6 +845,7 @@ class ChassisBase(device_base.DeviceBase):
             or None if the port is not a CPO port.
         """
         cpo = None
+        self._validate_port_lists()
         try:
             cpo = self._cpo_list[index]
         except IndexError:

--- a/sonic_platform_base/chassis_base.py
+++ b/sonic_platform_base/chassis_base.py
@@ -6,6 +6,7 @@
 """
 
 import sys
+from sonic_py_common import device_info
 from . import device_base
 from . import sfp_base
 
@@ -91,7 +92,6 @@ class ChassisBase(device_base.DeviceBase):
 
         # On platforms that provide a cpo.json file, populate self._cpo_list
         # based on the device topology described in that file
-        from sonic_py_common import device_info
         cpo_data = device_info.get_cpo_data()
         if cpo_data:
             self.construct_cpo_devices(cpo_data)

--- a/sonic_platform_base/chassis_base.py
+++ b/sonic_platform_base/chassis_base.py
@@ -719,7 +719,7 @@ class ChassisBase(device_base.DeviceBase):
         cpo.json
 
         Subclasses should implement this method on platforms that provide
-        an cpo.json file.
+        a cpo.json file.
 
         Args:
             cpo_data: device topology data parsed from cpo.json
@@ -801,9 +801,13 @@ class ChassisBase(device_base.DeviceBase):
             An object derived from CpoBase representing the specified CPO port,
             or None if the port is not a CPO port.
         """
-        if 0 <= index < len(self._cpo_list):
-            return self._cpo_list[index]
-        return None
+        cpo = None
+        try:
+            cpo = self._cpo_list[index]
+        except IndexError:
+            sys.stderr.write("CPO index {} out of range (0-{})\n".format(
+                             index, len(self._cpo_list)-1))
+        return cpo
 
     def get_port_or_cage_type(self, index):
         """

--- a/sonic_platform_base/sonic_xcvr/cpo/cpo_base.py
+++ b/sonic_platform_base/sonic_xcvr/cpo/cpo_base.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Optional
 
+from sonic_platform_base import device_base
 from sonic_platform_base.sonic_xcvr.xcvr_eeprom import XcvrEeprom
 from sonic_platform_base.sonic_xcvr.eeprom_rw import EepromReadWriteMixin
 
@@ -36,7 +37,7 @@ class CpoApiFactory(ABC):
         raise NotImplementedError
 
 
-class CpoDeviceBase(EepromReadWriteMixin):
+class CpoDeviceBase(device_base.DeviceBase, EepromReadWriteMixin):
     def __init__(self, hardware_id: CpoHardwareInfo, bank: int = 0):
         self.bank = bank
         self.hardware_id = hardware_id
@@ -55,16 +56,25 @@ class CpoDeviceBase(EepromReadWriteMixin):
             self.refresh_api()
         return self._api
 
+    def remove_api(self):
+        self._api = None
 
-class CpoBase:
+
+class CpoBase(device_base.DeviceBase):
     def __init__(self, hardware_id: CpoHardwareInfo, oe: "OeBase", elsfp: "ElsfpBase"):
         self.hardware_id = hardware_id
         self.oe = oe
         self.elsfp = elsfp
 
-# TODO: Implement CPO-specific methods
-#     def do_fiber_check(self, lane):
-#         self.oe.get_api().do_fiber_check(lane)
-#
-#     def tx_disable(self, lane):
-#         self.elsfp.get_api().tx_disable(lane)
+    def refresh_xcvr_api(self):
+        self.oe.refresh_api()
+        self.elsfp.refresh_api()
+
+    def get_xcvr_api(self):
+        # We always default to the OE API for CPO. If the ELSFP API is required,
+        # then that can be accessed via self.elsfp.get_api() directly.
+        return self.oe.get_api()
+
+    def remove_xcvr_api(self):
+        self.oe.remove_api()
+        self.elsfp.remove_api()

--- a/tests/chassis_base_test.py
+++ b/tests/chassis_base_test.py
@@ -1,6 +1,16 @@
+import pytest
+from unittest import mock
+
 from sonic_platform_base.chassis_base import ChassisBase
 
 class TestChassisBase:
+
+    @pytest.fixture(autouse=True)
+    def _mock_optical_devices_data(self):
+        with mock.patch("sonic_py_common.device_info.get_optical_devices_data",
+                        return_value=None) as mock_get:
+            self.mock_get_optical_devices_data = mock_get
+            yield
 
     def test_reboot_cause(self):
         chassis = ChassisBase()
@@ -161,3 +171,39 @@ class TestChassisBase:
         assert chassis.get_pdb(-4) is None
         err_neg = capsys.readouterr().err
         assert "PDB index -4 out of range (0-2)" in err_neg
+
+    def test_no_optical_devices_data(self):
+        chassis = ChassisBase()
+        self.mock_get_optical_devices_data.assert_called_once()
+        assert chassis.get_num_sfps() == 0
+
+    def test_optical_devices_data_base_class_not_implemented(self):
+        self.mock_get_optical_devices_data.return_value = {"devices": {}, "interfaces": {}}
+        with pytest.raises(NotImplementedError):
+            ChassisBase()
+
+    def test_construct_sfp_list_for_topology(self):
+        optical_device_data = {
+            "devices": {
+                "OE1": {"device_type": "optical_engine"},
+                "ELS1": {"device_type": "external_laser_source"},
+            },
+            "interfaces": {
+                "Ethernet0": {
+                    "associated_devices": [
+                        {"device_id": "OE1", "bank": 0},
+                        {"device_id": "ELS1", "bank": 0},
+                    ]
+                }
+            },
+        }
+        self.mock_get_optical_devices_data.return_value = optical_device_data
+
+        class CpoChassis(ChassisBase):
+            def construct_sfp_list_for_topology(self, optical_device_data):
+                for interface in optical_device_data["interfaces"]:
+                    self._sfp_list.append(interface)
+
+        chassis = CpoChassis()
+        assert chassis.get_num_sfps() == 1
+        assert chassis.get_sfp(0) == "Ethernet0"

--- a/tests/chassis_base_test.py
+++ b/tests/chassis_base_test.py
@@ -6,10 +6,10 @@ from sonic_platform_base.chassis_base import ChassisBase
 class TestChassisBase:
 
     @pytest.fixture(autouse=True)
-    def _mock_optical_devices_data(self):
-        with mock.patch("sonic_py_common.device_info.get_optical_devices_data",
+    def _mock_cpo_data(self):
+        with mock.patch("sonic_py_common.device_info.get_cpo_data",
                         return_value=None) as mock_get:
-            self.mock_get_optical_devices_data = mock_get
+            self.mock_get_cpo_data = mock_get
             yield
 
     def test_reboot_cause(self):
@@ -172,18 +172,18 @@ class TestChassisBase:
         err_neg = capsys.readouterr().err
         assert "PDB index -4 out of range (0-2)" in err_neg
 
-    def test_no_optical_devices_data(self):
+    def test_no_cpo_data(self):
         chassis = ChassisBase()
-        self.mock_get_optical_devices_data.assert_called_once()
-        assert chassis.get_num_sfps() == 0
+        self.mock_get_cpo_data.assert_called_once()
+        assert chassis.get_num_cpos() == 0
 
-    def test_optical_devices_data_base_class_not_implemented(self):
-        self.mock_get_optical_devices_data.return_value = {"devices": {}, "interfaces": {}}
+    def test_cpo_data_base_class_not_implemented(self):
+        self.mock_get_cpo_data.return_value = {"devices": {}, "interfaces": {}}
         with pytest.raises(NotImplementedError):
             ChassisBase()
 
     def test_construct_sfp_list_for_topology(self):
-        optical_device_data = {
+        cpo_data = {
             "devices": {
                 "OE1": {"device_type": "optical_engine"},
                 "ELS1": {"device_type": "external_laser_source"},
@@ -197,13 +197,13 @@ class TestChassisBase:
                 }
             },
         }
-        self.mock_get_optical_devices_data.return_value = optical_device_data
+        self.mock_get_cpo_data.return_value = cpo_data
 
         class CpoChassis(ChassisBase):
-            def construct_sfp_list_for_topology(self, optical_device_data):
-                for interface in optical_device_data["interfaces"]:
-                    self._sfp_list.append(interface)
+            def construct_cpo_devices(self, cpo_data):
+                for interface in cpo_data["interfaces"]:
+                    self._cpo_list.append(interface)
 
         chassis = CpoChassis()
-        assert chassis.get_num_sfps() == 1
-        assert chassis.get_sfp(0) == "Ethernet0"
+        assert chassis.get_num_cpos() == 1
+        assert chassis.get_cpo(0) == "Ethernet0"

--- a/tests/chassis_base_test.py
+++ b/tests/chassis_base_test.py
@@ -182,7 +182,7 @@ class TestChassisBase:
         with pytest.raises(NotImplementedError):
             ChassisBase()
 
-    def test_construct_sfp_list_for_topology(self):
+    def test_construct_cpo_list_for_topology(self):
         cpo_data = {
             "devices": {
                 "OE1": {"device_type": "optical_engine"},

--- a/tests/chassis_base_test.py
+++ b/tests/chassis_base_test.py
@@ -207,3 +207,49 @@ class TestChassisBase:
         chassis = CpoChassis()
         assert chassis.get_num_cpos() == 1
         assert chassis.get_cpo(0) == "Ethernet0"
+
+    def test_sfp_counts_only_valid_objects(self):
+        chassis = ChassisBase()
+        sfp2 = mock.MagicMock()
+        sfp3 = mock.MagicMock()
+        chassis._sfp_list = [None, None, sfp2, sfp3]
+
+        assert chassis.get_num_sfps() == 2
+        assert chassis.get_all_sfps() == [sfp2, sfp3]
+        assert chassis.get_sfp(0) is None
+        assert chassis.get_sfp(2) is sfp2
+
+    def test_port_lists_valid(self):
+        chassis = ChassisBase()
+        chassis._sfp_list = [None, None, mock.MagicMock(), mock.MagicMock()]
+        chassis._cpo_list = [mock.MagicMock(), mock.MagicMock(), None, None]
+
+        assert chassis.get_num_sfps() == 2
+        assert chassis.get_num_cpos() == 2
+
+    def test_port_lists_length_mismatch(self):
+        chassis = ChassisBase()
+        chassis._sfp_list = [None, None, mock.MagicMock(), mock.MagicMock()]
+        chassis._cpo_list = [mock.MagicMock(), mock.MagicMock()]
+
+        with pytest.raises(RuntimeError, match="must be the same length"):
+            chassis.get_num_cpos()
+
+        with pytest.raises(RuntimeError, match="must be the same length"):
+            chassis.get_num_sfps()
+
+    def test_port_lists_double_claimed_port(self):
+        chassis = ChassisBase()
+        chassis._sfp_list = [None, mock.MagicMock(), mock.MagicMock()]
+        chassis._cpo_list = [mock.MagicMock(), mock.MagicMock(), None]
+
+        with pytest.raises(RuntimeError,
+                           match="Physical port 1 has both an SFP and a CPO object"):
+            chassis.get_num_sfps()
+
+    def test_port_lists_single_technology_not_checked(self):
+        chassis = ChassisBase()
+        chassis._sfp_list = [None, mock.MagicMock(), mock.MagicMock()]
+
+        assert chassis.get_num_sfps() == 2
+        assert chassis.get_num_cpos() == 0

--- a/tests/sonic_xcvr/test_cpo_base.py
+++ b/tests/sonic_xcvr/test_cpo_base.py
@@ -68,3 +68,15 @@ class TestCpoBase(object):
         assert cpo.hardware_id is hardware_id
         assert cpo.oe is oe
         assert cpo.elsfp is elsfp
+
+    def test_get_xcvr_api_returns_oe_api(self):
+        hardware_id = CpoHardwareInfo(oe_id=SOME_OE_ID, elsfp_id=SOME_ELSFP_ID)
+        oe = OeBase(hardware_id)
+        elsfp = ElsfpBase(hardware_id)
+        oe_api = MagicMock()
+        oe.get_api = MagicMock(return_value=oe_api)
+
+        cpo = CpoBase(hardware_id, oe, elsfp)
+
+        assert cpo.get_xcvr_api() is oe_api
+        oe.get_api.assert_called_with()


### PR DESCRIPTION
#### Description
The ["Port Mapping for CPO" HLD](https://github.com/sonic-net/SONiC/pull/2211) proposes changes to the Chassis object for CPO hardware platforms, where a function called `construct_cpo_devices` is called when an `cpo.json` file is present for the SONiC device. The intent is for vendors to implement `construct_cpo_devices` and create the CPO platform API objects required for each interface on the vendor's switch.

Example usage, from the HLD:
```python3
class VendorCpoChassis(ChassisBase):
  ...
  def construct_cpo_devices(self, cpo_data):
      for interface_name, interface in cpo_data["interfaces"].items():
          associated_devices = interface["associated_devices"]
          assert len(associated_devices) == 2, \
              "We expect 2 devices per interface on this CPO hardware platform"

          # Construct OE/ELSFP objects
          oe = None
          elsfp = None
          for dvc_info in associated_devices:
              device = cpo_data["devices"][dvc_info["device_id"]]
              if device["device_type"] == "optical_engine":
                  oe = VendorOe(hardware_id=self.hw_id, bank=dvc_info["bank"])
              elif device["device_type"] == "external_laser_source":
                  elsfp = VendorElsfp(hardware_id=self.hw_id, bank=dvc_info["bank"])

          # Create a CpoBase-derived object to represent this interface
          assert oe, "No optical engine found for this interface"
          assert elsfp, "No ELSFP found for this interface"
          # VendorCpoSfp would be a subclass of CpoSfpBase here.
          self._sfp_list.append(VendorCpo(hardware_id=self.hw_id, oe=oe, els=elsfp))
```

This PR adds a `construct_cpo_devices` stub function for vendors to implement and calls this function when `cpo.json` is present. It also adds function to store and retrieve CpoBase objects on a Chassis object. Additionally, it changes CPO Platform objects to inherit from DeviceBase so that they adhere to the DeviceBase interface.

Note: this PR requires https://github.com/sonic-net/sonic-buildimage/pull/28077 to be merged first.

#### Motivation and Context
This change is required to instantiate the required platform API objects (OE, ELSFP, etc) for a Chassis that models CPO hardware.

#### How Has This Been Tested?
Unit-tests have been added.
