### PR TITLE
Update _strip_str to remove null characters

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -175,7 +175,7 @@ class CmisApi(CmisCdbFw, XcvrApi):
 
     @staticmethod
     def _strip_str(val):
-        return val.rstrip() if isinstance(val, str) else val
+        return val.replace('\x00', '').rstrip() if isinstance(val, str) else val
 
     def _update_vdm_dict(self, dict_to_update, new_key, vdm_raw_dict, vdm_observable_type, vdm_subtype_index, lane):
         """

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -144,6 +144,17 @@ class TestCmis(object):
         self.api._init_cdb_fw_handler = False
 
     @pytest.mark.parametrize("mock_response, expected", [
+        ("VENDOR_NAME", "VENDOR_NAME"),
+        ("A\x00\x00\x00\x00\x00Networks\n", "ANetworks"),
+    ])
+    def test_get_manufacturer(self, mock_response, expected):
+        self.api.xcvr_eeprom.read = MagicMock()
+        self.api.xcvr_eeprom.read.return_value = mock_response
+        self.clear_cache('get_manufacturer')
+        result = self.api.get_manufacturer()
+        assert result == expected
+
+    @pytest.mark.parametrize("mock_response, expected", [
         ("1234567890", "1234567890"),
         ("ABCD", "ABCD")
     ])


### PR DESCRIPTION
Modify _strip_str method to remove null characters.
e.g.sudo redis-cli -n 6 HGET 'TRANSCEIVER_INFO|Ethernet0' manufacturer | xxd | head -5;

The redis value stored is:
41 00 00 00 00 00 4e 65 74 77 6f 72 6b 73
A  \0 \0 \0 \0 \0  N  e  t  w  o  r  k  s

this is causing test_snmp_phy_entity to fail because of failing to parse the \0 above. 
```
>           assert transceiver_snmp_fact['entPhysMfgName'] == transceiver_info['manufacturer'], (
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                'Transceiver manufacturer name mismatch. Expected "entPhysMfgName" to be {}, '
                'but got {}. '
            ).format(
                transceiver_info['manufacturer'],
                transceiver_snmp_fact['entPhysMfgName']
            )
E           AssertionError: Transceiver manufacturer name mismatch. Expected "entPhysMfgName" to be ANetworks, but got A.

```
the failure was only seen on one of the DUT
 
which had
```
docker exec snmp redis-cli -n 6 HGET 'TRANSCEIVER_INFO|Ethernet0' manufacturer | xxd | head -5
00000000: 4100 0000 0000 4e65 7477 6f72 6b73 0a    A.....Networks.
 ```
 
so failing to strip the \0 is causing ssnmp agent returns just A
 
on another DUT it is fine because of not having \0:
```
admin@str5-7280r4-ut2-3:~$ docker exec snmp redis-cli -n 6 HGET 'TRANSCEIVER_INFO|Ethernet0' manufacturer | xxd | head -5
00000000: 4172 6973 7461 204e 6574 776f 726b 730a  Arista Networks.
```

<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
applied the fix on dut directly and restarted xcvrd:
  in /usr/local/lib/python3.11/dist-packages/sonic_platform_base/sonic_xcvr/api/public/cmis.py

Before: 41 00 00 00 00 00 4e 65 74 77 6f 72 6b 73 → A\x00\x00\x00\x00\x00Networks
After: 41 4e 65 74 77 6f 72 6b 73 → ANetworks


#### Additional Information (Optional)

