### PR TITLE
Added missing ccmis vdm observables

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/c_cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/c_cmis.py
@@ -26,7 +26,13 @@ C_CMIS_DELTA_VDM_KEY_TO_DB_PREFIX_KEY_MAP = {
     'CFO [MHz]' : 'cfo',
     'Tx Power [dBm]' : 'txcurrpower',
     'Rx Total Power [dBm]' : 'rxtotpower',
-    'Rx Signal Power [dBm]' : 'rxsigpower'
+    'Rx Signal Power [dBm]' : 'rxsigpower',
+    'Clock Recovery Loop [%]' : 'clkreloop',
+    'SOPMD low granularity [ps^2]' : 'sopmdshort',
+    'SNR Margin [dB]' : 'snrmargin',
+    'Q-Factor [dB]' : 'qfactor',
+    'Q-Margin [dB]' : 'qmargin',
+    'CFO low granularity [MHz]' : 'cfoshort'
 }
 
 VDM_SUBTYPE_IDX_MAP= {

--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -2037,6 +2037,12 @@ class CmisApi(CmisCdbFw, XcvrApi):
         txcurrpower{lane_num}                          = FLOAT                  ; tx current output power in dbm
         rxtotpower{lane_num}                           = FLOAT                  ; rx total power in  dbm
         rxsigpower{lane_num}                           = FLOAT                  ; rx signal power in dbm
+        clkreloop{lane_num}                            = FLOAT                  ; clock recovery loop in percentage
+        sopmdshort{lane_num}                           = FLOAT                  ; second order polarization mode dispersion, low granularity in ps^2
+        snrmargin{lane_num}                            = FLOAT                  ; snr margin in db
+        qfactor{lane_num}                              = FLOAT                  ; q-factor in db
+        qmargin{lane_num}                              = FLOAT                  ; q-margin in db
+        cfoshort{lane_num}                             = FLOAT                  ; carrier frequency offset, low granularity in MHz
         ========================================================================
         """
         vdm_real_value_dict = dict()
@@ -2131,7 +2137,14 @@ class CmisApi(CmisCdbFw, XcvrApi):
         cfo_xxx{lane_num}                                = FLOAT         ; carrier frequency offset in Hz (high/low alarm/warning)
         txcurrpower_xxx{lane_num}                        = FLOAT         ; tx current output power in dbm (high/low alarm/warning)
         rxtotpower_xxx{lane_num}                         = FLOAT         ; rx total power in  dbm (high/low alarm/warning)
-        rxsigpower_xxx{lane_num}                         = FLOAT         ; rx signal power in dbm (high/low alarm/warning)        ========================================================================
+        rxsigpower_xxx{lane_num}                         = FLOAT         ; rx signal power in dbm (high/low alarm/warning)
+        clkreloop_xxx{lane_num}                          = FLOAT         ; clock recovery loop in percentage (high/low alarm/warning)
+        sopmdshort_xxx{lane_num}                         = FLOAT         ; second order polarization mode dispersion, low granularity in ps^2 (high/low alarm/warning)
+        snrmargin_xxx{lane_num}                          = FLOAT         ; snr margin in db (high/low alarm/warning)
+        qfactor_xxx{lane_num}                            = FLOAT         ; q-factor in db (high/low alarm/warning)
+        qmargin_xxx{lane_num}                            = FLOAT         ; q-margin in db (high/low alarm/warning)
+        cfoshort_xxx{lane_num}                           = FLOAT         ; carrier frequency offset, low granularity in MHz (high/low alarm/warning)
+        ========================================================================
         """
         vdm_thresholds_dict = dict()
         vdm_raw_dict = self.get_vdm(self.vdm.VDM_THRESHOLD, self.vdm.VDM_OBSERVABLE_ALL)
@@ -2199,6 +2212,12 @@ class CmisApi(CmisCdbFw, XcvrApi):
         txcurrpower_xxx{lane_num}                        = FLOAT         ; tx current output power in dbm (high/low alarm/warning flag)
         rxtotpower_xxx{lane_num}                         = FLOAT         ; rx total power in  dbm (high/low alarm/warning flag)
         rxsigpower_xxx{lane_num}                         = FLOAT         ; rx signal power in dbm (high/low alarm/warning flag)
+        clkreloop_xxx{lane_num}                          = FLOAT         ; clock recovery loop in percentage (high/low alarm/warning flag)
+        sopmdshort_xxx{lane_num}                         = FLOAT         ; second order polarization mode dispersion, low granularity in ps^2 (high/low alarm/warning flag)
+        snrmargin_xxx{lane_num}                          = FLOAT         ; snr margin in db (high/low alarm/warning flag)
+        qfactor_xxx{lane_num}                            = FLOAT         ; q-factor in db (high/low alarm/warning flag)
+        qmargin_xxx{lane_num}                            = FLOAT         ; q-margin in db (high/low alarm/warning flag)
+        cfoshort_xxx{lane_num}                           = FLOAT         ; carrier frequency offset, low granularity in MHz (high/low alarm/warning flag)
         """
         vdm_flags_dict = dict()
         vdm_raw_dict = self.get_vdm(self.vdm.VDM_FLAG, self.vdm.VDM_OBSERVABLE_ALL)

--- a/sonic_platform_base/sonic_xcvr/codes/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/codes/public/cmis.py
@@ -142,7 +142,13 @@ class CmisCodes(Sff8024):
         144: ['Rx Total Power [dBm]', 'S16', 0.01, 'B'],
         145: ['Rx Signal Power [dBm]', 'S16', 0.01, 'B'],
         146: ['SOP ROC [krad/s]', 'U16', 1, 'B'],
-        147: ['MER [dB]', 'U16', 0.1, 'B']
+        147: ['MER [dB]', 'U16', 0.1, 'B'],
+        148: ['Clock Recovery Loop [%]', 'S16', 100.0/32767, 'B'],
+        149: ['SOPMD low granularity [ps^2]', 'U16', 1, 'B'],
+        150: ['SNR Margin [dB]', 'S16', 0.1, 'B'],
+        151: ['Q-Factor [dB]', 'U16', 0.1, 'B'],
+        152: ['Q-Margin [dB]', 'S16', 0.1, 'B'],
+        153: ['CFO low granularity [MHz]', 'S16', 5, 'B']
     }
 
     CDB_FAIL_STATUS = {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
Adds six new VDM observable type codes (148–153) to `CmisCodes`.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
New coherent observable types (Clock Recovery Loop, SOPMD low granularity, SNR Margin, Q-Factor, Q-Margin, CFO low granularity) were missing from the VDM observable list.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
`pytest tests/sonic_xcvr/test_ccmis.py`

#### Additional Information (Optional)

