### PR TITLE
[xcvr]: Fix appl_advt dict-lookup for non-sequential AppSel indices

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -1141,7 +1141,7 @@ class CmisApi(CmisCdbFw, XcvrApi):
         if appl <= 0:
             return 0
         appl_advt = self.get_application_advertisement()
-        return appl_advt[appl]['host_lane_count'] if len(appl_advt) >= appl else 0
+        return appl_advt[appl]['host_lane_count'] if appl in appl_advt else 0
 
     def get_media_lane_count(self, appl=1):
         '''
@@ -1154,7 +1154,7 @@ class CmisApi(CmisCdbFw, XcvrApi):
             return 0
 
         appl_advt = self.get_application_advertisement()
-        return appl_advt[appl]['media_lane_count'] if len(appl_advt) >= appl else 0
+        return appl_advt[appl]['media_lane_count'] if appl in appl_advt else 0
 
     def get_media_interface_technology(self):
         '''
@@ -1190,7 +1190,7 @@ class CmisApi(CmisCdbFw, XcvrApi):
             return 0
 
         appl_advt = self.get_application_advertisement()
-        return appl_advt[appl]['media_lane_assignment_options'] if len(appl_advt) >= appl else 0
+        return appl_advt[appl]['media_lane_assignment_options'] if appl in appl_advt else 0
 
     def get_active_apsel_hostlane(self):
         '''

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -1098,9 +1098,9 @@ class TestCmis(object):
         assert result == expected
 
     @pytest.mark.parametrize("appl, appl_advt, expected", [
-        # Regression: appl present but with an index higher than
-        # len(appl_advt). A previous `len(appl_advt) >= appl` check
-        # incorrectly returned 0 here even though appl_advt[9] exists.
+        # Sparse advertisement: only a high-index App is present (lower ones
+        # were skipped as undecodable SFF-8024 codes), so the App must be
+        # looked up by key - appl_advt[9] exists and returns its count.
         (9, {9: {'media_lane_count': 4}}, 4),
         # appl genuinely absent from the advertisement still returns 0.
         (5, {1: {'media_lane_count': 1}}, 0),
@@ -1178,9 +1178,9 @@ class TestCmis(object):
         assert result == expected
 
     @pytest.mark.parametrize("appl, appl_advt, expected", [
-        # Regression: appl present but with an index higher than
-        # len(appl_advt). A previous `len(appl_advt) >= appl` check
-        # incorrectly returned 0 here even though appl_advt[9] exists.
+        # Sparse advertisement: only a high-index App is present (lower ones
+        # were skipped as undecodable SFF-8024 codes), so the App must be
+        # looked up by key - appl_advt[9] exists and returns its value.
         (9, {9: {'media_lane_assignment_options': 1}}, 1),
         # appl genuinely absent from the advertisement still returns 0.
         (5, {1: {'media_lane_assignment_options': 1}}, 0),
@@ -1220,10 +1220,9 @@ class TestCmis(object):
             (0, False, {1: {'host_lane_count': 1}}, 0),
             # appl not in advertisement returns 0.
             (5, False, {1: {'host_lane_count': 1}}, 0),
-            # Regression: appl present but with an index higher than
-            # len(appl_advt) (e.g. App index 9 from Page 01h NAD advertised
-            # alongside a single App in the Lower Page). A previous
-            # `len(appl_advt) >= appl` check incorrectly returned 0 here.
+            # Sparse advertisement: only a high-index App is present (lower
+            # ones were skipped as undecodable SFF-8024 codes), so the App
+            # must be looked up by key - appl_advt[9] returns its count.
             (9, False, {9: {'host_lane_count': 8}}, 8),
         ]
     )

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -1097,6 +1097,19 @@ class TestCmis(object):
         result = self.api.get_media_lane_count(appl)
         assert result == expected
 
+    @pytest.mark.parametrize("appl, appl_advt, expected", [
+        # Regression: appl present but with an index higher than
+        # len(appl_advt). A previous `len(appl_advt) >= appl` check
+        # incorrectly returned 0 here even though appl_advt[9] exists.
+        (9, {9: {'media_lane_count': 4}}, 4),
+        # appl genuinely absent from the advertisement still returns 0.
+        (5, {1: {'media_lane_count': 1}}, 0),
+    ])
+    def test_get_media_lane_count_sparse_appl_advt(self, appl, appl_advt, expected):
+        self.api.is_flat_memory = MagicMock(return_value=False)
+        with patch.object(self.api, 'get_application_advertisement', return_value=appl_advt):
+            assert self.api.get_media_lane_count(appl) == expected
+
     @pytest.mark.parametrize("mock_response, expected", [
         ('C-band tunable laser', 'C-band tunable laser')
     ])
@@ -1164,6 +1177,19 @@ class TestCmis(object):
         result = self.api.get_media_lane_assignment_option(appl)
         assert result == expected
 
+    @pytest.mark.parametrize("appl, appl_advt, expected", [
+        # Regression: appl present but with an index higher than
+        # len(appl_advt). A previous `len(appl_advt) >= appl` check
+        # incorrectly returned 0 here even though appl_advt[9] exists.
+        (9, {9: {'media_lane_assignment_options': 1}}, 1),
+        # appl genuinely absent from the advertisement still returns 0.
+        (5, {1: {'media_lane_assignment_options': 1}}, 0),
+    ])
+    def test_get_media_lane_assignment_option_sparse_appl_advt(self, appl, appl_advt, expected):
+        self.api.is_flat_memory = MagicMock(return_value=False)
+        with patch.object(self.api, 'get_application_advertisement', return_value=appl_advt):
+            assert self.api.get_media_lane_assignment_option(appl) == expected
+
     @pytest.mark.parametrize("mock_response, expected", [
         ({'ActiveAppSelLane1': 1},
          {'ActiveAppSelLane1': 1})
@@ -1194,6 +1220,11 @@ class TestCmis(object):
             (0, False, {1: {'host_lane_count': 1}}, 0),
             # appl not in advertisement returns 0.
             (5, False, {1: {'host_lane_count': 1}}, 0),
+            # Regression: appl present but with an index higher than
+            # len(appl_advt) (e.g. App index 9 from Page 01h NAD advertised
+            # alongside a single App in the Lower Page). A previous
+            # `len(appl_advt) >= appl` check incorrectly returned 0 here.
+            (9, False, {9: {'host_lane_count': 8}}, 8),
         ]
     )
     def test_get_host_lane_count(self, appl, is_flat_memory, appl_advt, expected):


### PR DESCRIPTION
#### Description
`get_host_lane_count()`, `get_media_lane_count()` and `get_media_lane_assignment_option()`
in `cmis.py` guard their dict lookup into the application advertisement with
`len(appl_advt) >= appl`. That holds only when the advertised Applications form a
contiguous `1..N` range, and returns `0` for a valid Application on a **sparse**
advertisement, where `appl in appl_advt` is true but `len(appl_advt) < appl`.

Changed the guard to `appl in appl_advt`, matching the pattern already used by
`get_host_lane_assignment_option()` in the same file.

#### Motivation and Context
`get_application_advertisement()` is best-effort: it skips any Application whose
host/media interface code cannot be decoded (an unknown SFF-8024 code decodes to
`Unknown` and is dropped). The advertisement dict is therefore allowed to be
sparse / non-contiguous, so consumers must look Applications up by key rather
than assume the keys are `1..N`. Under the old guard, when a module advertises an
Application at an index higher than the number of decoded entries (e.g. `appl=9`
with `len(appl_advt) == 4`), these getters return `0` for a valid Application.

#### How Has This Been Tested?
Added regression cases with a sparse `appl_advt` (single high-index entry) for all
three affected functions in `tests/sonic_xcvr/test_cmis.py`, plus a case confirming
a genuinely-absent index still returns `0`.