### PR TITLE
Check lower memory for firmware versions when CDB is not supported

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -407,6 +407,12 @@ class CmisApi(CmisCdbFw, XcvrApi):
 
     def get_transceiver_info_firmware_versions(self):
         return_dict = {"active_firmware" : "N/A", "inactive_firmware" : "N/A"}
+
+        if not self.is_cdb_supported():
+            return_dict["active_firmware"] = self.get_module_active_firmware()
+            return_dict["inactive_firmware"] = self.get_module_inactive_firmware()
+            return return_dict
+
         result = self.get_module_fw_info()
         if result is None:
             return return_dict

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -3654,6 +3654,8 @@ class TestCmis(object):
             run_num -= 1
 
     def test_get_transceiver_info_firmware_versions(self):
+        self.api.is_cdb_supported = MagicMock()
+        self.api.is_cdb_supported.return_value = True
         self.api.get_module_fw_info = MagicMock()
         self.api.get_module_fw_info.return_value = None
         expected_result = {"active_firmware" : "N/A", "inactive_firmware" : "N/A"}
@@ -3667,6 +3669,16 @@ class TestCmis(object):
 
         expected_result = {"active_firmware" : "2.0.0", "inactive_firmware" : "1.0.0"}
         self.api.get_module_fw_info.side_effect = [{'result': ( '', '', '', '', '', '', '', '','2.0.0', '1.0.0')}]
+        result = self.api.get_transceiver_info_firmware_versions()
+        assert result == expected_result
+
+        # Fall back to lower memory registers when CDB is not supported
+        self.api.is_cdb_supported.return_value = False
+        self.api.get_module_active_firmware = MagicMock()
+        self.api.get_module_active_firmware.return_value = "2.0"
+        self.api.get_module_inactive_firmware = MagicMock()
+        self.api.get_module_inactive_firmware.return_value = "1.0"
+        expected_result = {"active_firmware" : "2.0", "inactive_firmware" : "1.0"}
         result = self.api.get_transceiver_info_firmware_versions()
         assert result == expected_result
 


### PR DESCRIPTION
Fixes #716

#### Description
In `get_transceiver_info_firmware_versions`, the active and inactive firmware versions are always fetched via CDB. For transceivers that do not support CDB, this will result in the versions being reported as "N/A".

This PR fixes that issue by reading the active and inactive firmware versions from bytes 39-40 of lower memory for transceivers that do not support CDB.

<img width="1390" height="244" alt="cmis-fw-registers" src="https://github.com/user-attachments/assets/af1551ce-9c73-4c33-a7f1-98fed2a8be0f" />

#### Motivation and Context
This function should work for CMIS-compliant transceivers that do not support CDB.

#### How Has This Been Tested?
Extended the existing unit-tests.

Manually tested via `show interface transceiver info`.

**Before**
```
~$ show int trans info Ethernet144
Ethernet144: SFP EEPROM detected
        Active Firmware: N/A
        Active application selected code assigned to host lane 1: 1
        Active application selected code assigned to host lane 2: 1
        Active application selected code assigned to host lane 3: 1
        Active application selected code assigned to host lane 4: 1
        Active application selected code assigned to host lane 5: N/A
        Active application selected code assigned to host lane 6: N/A
        Active application selected code assigned to host lane 7: N/A
        Active application selected code assigned to host lane 8: N/A
        Application Advertisement: 400GAUI-4-L C2M (Annex 120G) - Host Assign (0x11) - 400GBASE-DR4 (Cl 124) - Media Assign (0x11)
                                   800GAUI-8 L C2M (Annex 120G) - Host Assign (0x1) - 800GBASE-DR8 (Clause 124) - Media Assign (0x1)
        CMIS Rev: 5.2
        Connector: MPO 1x12
        Encoding: N/A
        Extended Identifier: Power Class 5 (8.5W Max)
        Extended RateSelect Compliance: N/A
        Host Lane Count: 4
        Identifier: OSFP 8X Pluggable Transceiver
        Inactive Firmware: N/A
        Length Cable Assembly(m): 0.0
        Media Interface Technology: 1310 nm DFB
        Media Lane Count: 4
        Module Hardware Rev: 4.0
        Nominal Bit Rate(100Mbs): N/A
        Specification compliance: sm_media_interface
        Vendor Date Code(YYYY-MM-DD Lot): 2025-09-01
        Vendor Name: Amphenol
        Vendor OUI: 78-a7-14
        Vendor PN: OP13LD8-005D
        Vendor Rev: 10
        Vendor SN: 2508220085
        cdb_supported: False
        is_replaceable: True
        last_update_time: Fri Jul 17 03:49:33 2026
        type_abbrv_name: OSFP-8X
        vdm_supported: False
```

Notice `Active Firmware` and `Inactive Firmware` being reported as `N/A`.

**After**
```
~$ show int trans info Ethernet144
Ethernet144: SFP EEPROM detected
        Active Firmware: 0.4
        Active application selected code assigned to host lane 1: 1
        Active application selected code assigned to host lane 2: 1
        Active application selected code assigned to host lane 3: 1
        Active application selected code assigned to host lane 4: 1
        Active application selected code assigned to host lane 5: N/A
        Active application selected code assigned to host lane 6: N/A
        Active application selected code assigned to host lane 7: N/A
        Active application selected code assigned to host lane 8: N/A
        Application Advertisement: 400GAUI-4-L C2M (Annex 120G) - Host Assign (0x11) - 400GBASE-DR4 (Cl 124) - Media Assign (0x11)
                                   800GAUI-8 L C2M (Annex 120G) - Host Assign (0x1) - 800GBASE-DR8 (Clause 124) - Media Assign (0x1)
        CMIS Rev: 5.2
        Connector: MPO 1x12
        Encoding: N/A
        Extended Identifier: Power Class 5 (8.5W Max)
        Extended RateSelect Compliance: N/A
        Host Lane Count: 4
        Identifier: OSFP 8X Pluggable Transceiver
        Inactive Firmware: 0.0
        Length Cable Assembly(m): 0.0
        Media Interface Technology: 1310 nm DFB
        Media Lane Count: 4
        Module Hardware Rev: 4.0
        Nominal Bit Rate(100Mbs): N/A
        Specification compliance: sm_media_interface
        Vendor Date Code(YYYY-MM-DD Lot): 2025-09-01
        Vendor Name: Amphenol
        Vendor OUI: 78-a7-14
        Vendor PN: OP13LD8-005D
        Vendor Rev: 10
        Vendor SN: 2508220085
        cdb_supported: False
        is_replaceable: True
        last_update_time: Fri Jul 17 03:53:16 2026
        type_abbrv_name: OSFP-8X
        vdm_supported: False
```

Note the valid firmware versions reported.