### PR TITLE
[sonic_xcvr] Restore Abort advertisement in FW mgmt features

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/cdb_fw.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cdb_fw.py
@@ -72,13 +72,14 @@ class CmisCdbFw:
             log.log_error(txt)
             return {'status': False, 'info': txt, 'feature': None}
 
-        startLPLsize, maxblocksize, lplonly_flag = fw_features
+        startLPLsize, maxblocksize, lplonly_flag, abort_supported = fw_features
         txt += 'Start payload size %d\n' % startLPLsize
         txt += 'Max block size %d\n' % maxblocksize
         if lplonly_flag:
             txt += 'Write to LPL supported\n'
         else:
             txt += 'Write to LPL/EPL supported\n'
+        txt += 'Abort CMD102h supported %s\n' % abort_supported
 
         elapsedtime = time.time()-starttime
         log.log_info('Get module FW upgrade features time: {:.2f} s\n'.format(elapsedtime))

--- a/sonic_platform_base/sonic_xcvr/cdb/cdb_fw.py
+++ b/sonic_platform_base/sonic_xcvr/cdb/cdb_fw.py
@@ -19,6 +19,7 @@ class CdbFwHandler(CdbCmdHandler):
         self.start_payload_size = 0
         self.is_lpl_only = False
         self.rw_length_ext = 0
+        self.is_abort_supported = False
         self.timeout_start = None
         self.timeout_abort = None
         self.timeout_write = None
@@ -40,16 +41,18 @@ class CdbFwHandler(CdbCmdHandler):
             log.log_notice("Failed to read firmware management features")
             return False
 
+        mgmt_features_adv = reply.get(cdb_consts.CDB_FIRMWARE_MGMT_ADV, {})
         self.start_payload_size = reply[cdb_consts.CDB_START_CMD_PAYLOAD_SIZE]
         self.is_lpl_only = reply[cdb_consts.CDB_WRITE_MECHANISM] == "LPL"
         self.rw_length_ext = reply[cdb_consts.CDB_READ_WRITE_LENGTH_EXT] + 8
+        self.is_abort_supported = bool(mgmt_features_adv.get(cdb_consts.CDB_ABORT_CMD_SUPPORTED, 0))
 
         if self.is_lpl_only:
             self.rw_length_ext = min(cdb_consts.LPL_MAX_PAYLOAD_SIZE, self.rw_length_ext)
         else:
             self.rw_length_ext = min(cdb_consts.EPL_MAX_PAYLOAD_SIZE, self.rw_length_ext)
 
-        multiplier = 10 if reply.get(cdb_consts.CDB_MAX_DURATION_ENCODING, 0) else 1
+        multiplier = 10 if mgmt_features_adv.get(cdb_consts.CDB_MAX_DURATION_ENCODING, 0) else 1
         duration_start = reply.get(cdb_consts.CDB_MAX_DURATION_START, 0)
         duration_abort = reply.get(cdb_consts.CDB_MAX_DURATION_ABORT, 0)
         duration_write = reply.get(cdb_consts.CDB_MAX_DURATION_WRITE, 0)
@@ -68,7 +71,7 @@ class CdbFwHandler(CdbCmdHandler):
         """
         if self.start_payload_size == 0 and self.rw_length_ext == 0:
             return None
-        return (self.start_payload_size, self.rw_length_ext, self.is_lpl_only)
+        return (self.start_payload_size, self.rw_length_ext, self.is_lpl_only, self.is_abort_supported)
 
     def get_firmware_info(self):
         """

--- a/sonic_platform_base/sonic_xcvr/mem_maps/public/cmis/pages/page9f_cdb.py
+++ b/sonic_platform_base/sonic_xcvr/mem_maps/public/cmis/pages/page9f_cdb.py
@@ -58,6 +58,7 @@ class CdbLplMessagePage(CmisPage):
                 cdb_consts.CDB_FIRMWARE_MGMT_ADV, self.getaddr(137),
                 RegBitField(cdb_consts.CDB_MAX_DURATION_ENCODING, 3),
                 RegBitField(cdb_consts.CDB_ABORT_CMD_SUPPORTED, 0),
+                bitdecode=True,
             ),
             NumberRegField(cdb_consts.CDB_START_CMD_PAYLOAD_SIZE, self.getaddr(138)),
             NumberRegField(cdb_consts.CDB_READ_WRITE_LENGTH_EXT, self.getaddr(140), scale=0.125),

--- a/tests/sonic_xcvr/test_cdb_fw.py
+++ b/tests/sonic_xcvr/test_cdb_fw.py
@@ -127,8 +127,9 @@ class TestCdbFwHandler:
         self.handler.start_payload_size = 112
         self.handler.rw_length_ext = 2048
         self.handler.is_lpl_only = True
+        self.handler.is_abort_supported = True
         result = self.handler.get_fw_mgmt_features()
-        assert result == (112, 2048, True)
+        assert result == (112, 2048, True, True)
     
     def test_get_firmware_info_success(self):
         """Test successful get_firmware_info"""

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -1943,8 +1943,8 @@ class TestCmis(object):
 
     @pytest.mark.parametrize("mock_fw_features, mock_eeprom_reads, expected", [
         (None, [True, 1], {'status': False, 'feature': None}),
-        ((0, 8, False), [True, 1], {'status': True, 'feature': (0, 8, False, True, 16)}),
-        ((112, 2048, True), [False, 1], {'status': True, 'feature': (112, 2048, True, False, 16)}),
+        ((0, 8, False, True), [True, 1], {'status': True, 'feature': (0, 8, False, True, 16)}),
+        ((112, 2048, True, False), [False, 1], {'status': True, 'feature': (112, 2048, True, False, 16)}),
     ])
     def test_get_module_fw_mgmt_feature(self, mock_fw_features, mock_eeprom_reads, expected):
         mock_fw_hdlr = MagicMock()


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
Restore the "Abort CMD102h supported" advertisement in the CDB firmware management features return text.

When `get_module_fw_mgmt_feature()` was refactored to route all firmware-management features through `CdbFwHandler.get_fw_mgmt_features()`. This dropped the `Abort CMD102h supported` line that the previous implementation emitted, and the abort advertisement was not captured in return text.

Changes:

- `cdb/cdb_fw.py`: capture `is_abort_supported` from the reply and include it in `get_fw_mgmt_features()`.
- Restore `Abort CMD102h supported <bool>` in the `info` text.
- Updated `test_cdb_fw.py` and `test_cmis.py` based on the changes.

#### Motivation and Context

#### How Has This Been Tested?
- Tested on 202605 image version.
- Unit tests: `test_cdb_fw.py` and  `test_cmis.py` passed -> 484 passed
- Tested on hardware with 202605 image `get_module_fw_mgmt_feature()` API now reports `Abort CMD102h supported <bool>`.

#### Additional Information (Optional)

