### PR TITLE
[chassis_base] Add REBOOT_CAUSE_POWER_DOWN_REQUEST_FROM_BMC

### DIFF
--- a/sonic_platform_base/chassis_base.py
+++ b/sonic_platform_base/chassis_base.py
@@ -18,6 +18,7 @@ class ChassisBase(device_base.DeviceBase):
 
     # Possible reboot causes
     REBOOT_CAUSE_POWER_LOSS = "Power Loss"
+    REBOOT_CAUSE_POWER_DOWN_REQUEST_FROM_BMC = "Power down request from BMC"
     REBOOT_CAUSE_THERMAL_OVERLOAD_CPU = "Thermal Overload: CPU"
     REBOOT_CAUSE_THERMAL_OVERLOAD_ASIC = "Thermal Overload: ASIC"
     REBOOT_CAUSE_THERMAL_OVERLOAD_OTHER = "Thermal Overload: Other"

--- a/tests/chassis_base_test.py
+++ b/tests/chassis_base_test.py
@@ -5,6 +5,7 @@ class TestChassisBase:
     def test_reboot_cause(self):
         chassis = ChassisBase()
         assert(chassis.REBOOT_CAUSE_POWER_LOSS == "Power Loss")
+        assert(chassis.REBOOT_CAUSE_POWER_DOWN_REQUEST_FROM_BMC == "Power down request from BMC")
         assert(chassis.REBOOT_CAUSE_THERMAL_OVERLOAD_CPU == "Thermal Overload: CPU")
         assert(chassis.REBOOT_CAUSE_THERMAL_OVERLOAD_ASIC == "Thermal Overload: ASIC")
         assert(chassis.REBOOT_CAUSE_THERMAL_OVERLOAD_OTHER == "Thermal Overload: Other")


### PR DESCRIPTION
#### Description
Add a new reboot cause REBOOT_CAUSE_POWER_DOWN_REQUEST_FROM_BMC.

#### Motivation and Context
Add a dedicated reboot cause for a power down requested by the BMC, so platforms paired with a BMC can distinguish it from a real power loss.

#### How Has This Been Tested?
Manual tests on the BMC platform and a new unit test.

#### Additional Information (Optional)

#### Tested branch (Please provide the tested image version)

- [x] 202605 

