### PR TITLE
Provide BMC defaults for system status LED methods in ChassisBase

### DIFF
--- a/sonic_platform_base/chassis_base.py
+++ b/sonic_platform_base/chassis_base.py
@@ -884,6 +884,18 @@ class ChassisBase(device_base.DeviceBase):
     # System LED methods
     ##############################################
 
+    def initizalize_system_led(self):
+        """
+        Initialize the system status LED.
+
+        Returns:
+            bool: True if the system LED was initialized successfully.
+        """
+        if device_info and device_info.is_switch_bmc():
+            # BMC platforms have no controllable system LED, nothing to initialize.
+            return True
+        raise NotImplementedError
+
     def set_status_led(self, color):
         """
         Sets the state of the system LED
@@ -895,6 +907,9 @@ class ChassisBase(device_base.DeviceBase):
         Returns:
             bool: True if system LED state is set successfully, False if not
         """
+        if device_info and device_info.is_switch_bmc():
+            # BMC platforms have no controllable system LED.
+            return False
         raise NotImplementedError
 
     def get_status_led(self):
@@ -905,6 +920,9 @@ class ChassisBase(device_base.DeviceBase):
             A string, one of the valid LED color strings which could be vendor
             specified.
         """
+        if device_info and device_info.is_switch_bmc():
+            # BMC platforms have no controllable system LED.
+            return "N/A"
         raise NotImplementedError
 
     ##############################################

--- a/tests/chassis_base_test.py
+++ b/tests/chassis_base_test.py
@@ -58,6 +58,61 @@ class TestChassisBase:
 
             assert exception_raised
 
+    @mock.patch('sonic_py_common.device_info.is_switch_bmc', return_value=True)
+    def test_system_led_bmc(self, _mock_is_switch_bmc):
+        # BMC platforms have no controllable system LED, so the base class
+        # provides no-op defaults instead of raising NotImplementedError.
+        chassis = ChassisBase()
+        assert(chassis.initizalize_system_led() == True)
+        assert(chassis.set_status_led("green") == False)
+        assert(chassis.get_status_led() == "N/A")
+
+    @mock.patch.object(chassis_base, 'device_info', None)
+    def test_system_led_no_device_info(self):
+        # chassis_base tolerates device_info being None when sonic_py_common is
+        # shadowed by a partial mock. These methods must still raise
+        # NotImplementedError rather than AttributeError in that case.
+        chassis = ChassisBase()
+        not_implemented_methods = [
+                [chassis.initizalize_system_led, [], {}],
+                [chassis.set_status_led, ["COLOR"], {}],
+                [chassis.get_status_led, [], {}],
+            ]
+
+        for method in not_implemented_methods:
+            exception_raised = False
+            try:
+                func = method[0]
+                args = method[1]
+                kwargs = method[2]
+                func(*args, **kwargs)
+            except NotImplementedError:
+                exception_raised = True
+
+            assert exception_raised
+
+    @mock.patch('sonic_py_common.device_info.is_switch_bmc', return_value=False)
+    def test_system_led_non_bmc(self, _mock_is_switch_bmc):
+        # Non-BMC platforms are expected to implement these themselves.
+        chassis = ChassisBase()
+        not_implemented_methods = [
+                [chassis.initizalize_system_led, [], {}],
+                [chassis.set_status_led, ["COLOR"], {}],
+                [chassis.get_status_led, [], {}],
+            ]
+
+        for method in not_implemented_methods:
+            exception_raised = False
+            try:
+                func = method[0]
+                args = method[1]
+                kwargs = method[2]
+                func(*args, **kwargs)
+            except NotImplementedError:
+                exception_raised = True
+
+            assert exception_raised
+
     def test_smartswitch(self):
         chassis = ChassisBase()
         assert(chassis.is_smartswitch() == False)


### PR DESCRIPTION
#### Description

Add BMC defaults for the system status LED methods on `ChassisBase`, gated on `is_switch_bmc()`:
- `initizalize_system_led()` returns `True`
- `set_status_led()` returns `False`
- `get_status_led()` returns `"N/A"`

Non-BMC platforms are unaffected: they still `raise NotImplementedError` (or use their own platform override). The methods use the module-level `device_info` import that `chassis_base.py` already has, and guard it with `if device_info and ...` so they still raise `NotImplementedError` rather than `AttributeError` when `sonic_py_common` is shadowed by a partial mock and `device_info` is `None`.

#### Motivation and Context

`show system-health` (sonic-utilities) calls `chassis.initizalize_system_led()`, `set_status_led()` and `get_status_led()` unconditionally. BMC platforms have no controllable system status LED, and `ChassisBase` left `set`/`get` as `NotImplementedError` with no `initizalize_system_led()` at all, so the CLI failed on BMC images. Handling this once in the common base, instead of duplicating no-op stubs in each vendor's `chassis.py`, keeps the behavior consistent across all BMC platforms.

The method name `initizalize_system_led` intentionally keeps the existing (misspelled) name used by the `show system-health` caller and current platform implementations.

#### How Has This Been Tested?

Non-BMC behavior is unchanged (still `NotImplementedError`, since `is_switch_bmc()` is false there). On a BMC image the expected result is that `show system-health summary` no longer errors and reports `System status LED  N/A`.

#### Additional Information (Optional)

