### PR TITLE
[CPO] Add ChassisBase hook for ELSFP presence

### DIFF
--- a/sonic_platform_base/chassis_base.py
+++ b/sonic_platform_base/chassis_base.py
@@ -985,7 +985,48 @@ class ChassisBase(device_base.DeviceBase):
                       status='6' Bad cable.
         """
         raise NotImplementedError
-    
+
+    def get_elsfp_change_event(self, timeout=0):
+        """
+        Returns a nested dictionary containing the ELSFPs which have
+        experienced a presence change at chassis level
+
+        This is the CPO (co-packaged optics) counterpart of get_change_event().
+        For a CPO port the optical engine is co-packaged and always present, so
+        the ELSFP is the only removable device. Since get_change_event() is a
+        single blocking event stream, ELSFP events are reported through this
+        separate stream so that the CPO and the traditional transceiver tasks
+        can each block on their own stream without consuming each other's
+        events. Implementations must therefore not report ELSFP events on
+        get_change_event().
+
+        An ELSFP may be associated with more than one physical port. In that
+        case the event is reported once for each of those physical ports.
+
+        Args:
+            timeout: Timeout in milliseconds (optional). If timeout == 0,
+                this method will block until a change is detected.
+
+        Returns:
+            (bool, dict):
+                - True if call successful, False if not;
+                - A nested dictionary where key is the device type 'elsfp',
+                  value is a dictionary with key:value pairs in the format of
+                  {'device_id':'device_event'},
+                  where device_id is the physical port index the ELSFP is
+                  associated with and device_event,
+                             status='1' represents ELSFP inserted,
+                             status='0' represents ELSFP removed.
+                  Ex. {'elsfp':{'1':'1', '2':'1', '11':'0'}}
+                      indicates that the ELSFP shared by physical ports 1 and 2
+                      has been inserted and the ELSFP on physical port 11 has
+                      been removed.
+                  The error statuses defined for get_change_event() ('2' I2C bus
+                  stuck, '3' Bad eeprom, '4' Unsupported cable, '5' High
+                  Temperature, '6' Bad cable) apply here as well.
+        """
+        raise NotImplementedError
+
     def get_bmc(self):
         """
         Get bmc device on this chassis

--- a/tests/chassis_base_test.py
+++ b/tests/chassis_base_test.py
@@ -34,6 +34,8 @@ class TestChassisBase:
                 [chassis.get_uid_led, [], {}],
                 [chassis.set_uid_led, ["COLOR"], {}],
                 [chassis.get_dpu_id, [], {"name": "DPU0"}],
+                [chassis.get_elsfp_change_event, [], {}],
+                [chassis.get_elsfp_change_event, [1000], {}],
                 [chassis.get_dataplane_state, [], {}],
                 [chassis.get_controlplane_state, [], {}],
             ]

--- a/tests/chassis_base_test.py
+++ b/tests/chassis_base_test.py
@@ -36,6 +36,8 @@ class TestChassisBase:
                 [chassis.get_dpu_id, [], {"name": "DPU0"}],
                 [chassis.get_elsfp_change_event, [], {}],
                 [chassis.get_elsfp_change_event, [1000], {}],
+                [chassis.get_change_event, [], {}],
+                [chassis.get_change_event, [1000], {}],
                 [chassis.get_dataplane_state, [], {}],
                 [chassis.get_controlplane_state, [], {}],
             ]


### PR DESCRIPTION
#### Description
As described in the [`xcvrd` CPO HLD](https://github.com/sonic-net/SONiC/blob/98de38fd1512017cfee5513025d750da8b1fa2f1/doc/pmon/xcvrd_cpo.md) (see section 7.3.2.2 Presence Change Event Handling), a new hook to notify xcvrd of ELSFP insertion/removal events is required for CPO hardware.

#### Motivation and Context
In `xcvrd`, there will be a dedicated CPO task to react to ELSFP insertion and removal. It cannot re-use the existing `get_change_event` API since that would cause events for traditional pluggable ports to be consumed by the CPO task and vice-versa.

#### How Has This Been Tested?
Relying on unit-tests. This PR does not add any meaningful logic, just an unimplemented stub for vendors to implement.

