### PR TITLE
Allow device_info import to fail in chassis_base.py

### DIFF
--- a/sonic_platform_base/chassis_base.py
+++ b/sonic_platform_base/chassis_base.py
@@ -6,7 +6,13 @@
 """
 
 import sys
-from sonic_py_common import device_info
+try:
+    from sonic_py_common import device_info
+except ImportError:
+    # Unit-test packages may shadow sonic_py_common with a partial mock that
+    # does not provide device_info. This should not occur outside of test
+    # environments.
+    device_info = None
 from . import device_base
 from . import sfp_base
 
@@ -93,7 +99,7 @@ class ChassisBase(device_base.DeviceBase):
 
         # On platforms that provide a cpo.json file, populate self._cpo_list
         # based on the device topology described in that file
-        cpo_data = device_info.get_cpo_data()
+        cpo_data = device_info.get_cpo_data() if device_info else None
         if cpo_data:
             self.construct_cpo_devices(cpo_data)
 

--- a/tests/chassis_base_test.py
+++ b/tests/chassis_base_test.py
@@ -1,6 +1,10 @@
+import builtins
+import importlib
+
 import pytest
 from unittest import mock
 
+from sonic_platform_base import chassis_base
 from sonic_platform_base.chassis_base import ChassisBase
 
 class TestChassisBase:
@@ -208,6 +212,32 @@ class TestChassisBase:
         chassis = CpoChassis()
         assert chassis.get_num_cpos() == 1
         assert chassis.get_cpo(0) == "Ethernet0"
+
+    def test_device_info_import_failure(self):
+        # Some unit-test packages shadow sonic_py_common with a partial mock
+        # that does not provide device_info. chassis_base must still import
+        # successfully so these tests do not fail, since device_info is only
+        # required for CPO hardware.
+        real_import = builtins.__import__
+
+        def failing_import(name, *args, **kwargs):
+            if name == "sonic_py_common":
+                raise ImportError("no module named sonic_py_common.device_info")
+            return real_import(name, *args, **kwargs)
+
+        try:
+            with mock.patch.object(builtins, "__import__", failing_import):
+                importlib.reload(chassis_base)
+
+            assert chassis_base.device_info is None
+            chassis = chassis_base.ChassisBase()
+            self.mock_get_cpo_data.assert_not_called()
+            assert chassis.get_num_cpos() == 0
+        finally:
+            # Restore the module for the remaining tests
+            importlib.reload(chassis_base)
+
+        assert chassis_base.device_info is not None
 
     def test_sfp_counts_only_valid_objects(self):
         chassis = ChassisBase()


### PR DESCRIPTION
#### Description
Build failures have been observed in https://github.com/sonic-net/sonic-buildimage/pull/28794 as a result of a new import being added in https://github.com/sonic-net/sonic-platform-common/pull/700 that causes some unit-tests to fail, because the test package shadows `sonic_py_common` with its own mock package that does not contain any `device_info.py` file.

This PR changes the import behaviour to catch ImportErrors so that these partial mock scenarios don't cause any test failure.

#### Motivation and Context
This is motivated by getting the tests to pass so the submodule bump PR can merge.

#### How Has This Been Tested?
The previously failing sonic-bmcctld tests now pass.

