### PR TITLE
Add OCP ehanced optical telemetry info support for Credo CMIS modules

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/credo/cmis_credo.py
+++ b/sonic_platform_base/sonic_xcvr/api/credo/cmis_credo.py
@@ -1,0 +1,174 @@
+"""
+    cmis_credo.py
+
+    API for Credo transceivers/cables that support the vendor "Get Telemetry
+    Info" CDB command (opcode 0x8000). Adds link-quality/FEC/eye telemetry to
+    the standard TRANSCEIVER_DOM_REAL_VALUE fields.
+"""
+
+import struct
+
+from sonic_py_common.syslogger import SysLogger
+
+from ..public.cmis import CmisApi
+from ...cdb.cdb import CdbCmdHandler
+from ...codes.public.cdb import CdbCodes
+from ...codes.public.cmis import CmisCodes
+from ...fields import credo_cdb_consts as consts
+from ...mem_maps.credo import cdb_credo
+
+SYSLOG_IDENTIFIER = "CmisCredo"
+log = SysLogger(SYSLOG_IDENTIFIER)
+log.logger.propagate = False
+
+# Telemetry data is only valid when EEPROM page 0 byte 36 reads back this value,
+# and only once the module's CMIS FW has finished booting (ModuleState == ModuleReady).
+_TELEMETRY_COMPLIANCE_OFFSET = 36
+_TELEMETRY_COMPLIANCE_VALUE = 0x21
+_MODULE_STATE_READY = CmisCodes.MODULE_STATE[3]
+
+_POLL_TARGET = 'local'
+
+
+def _telemetry_na_dict(host_lane_count=0, media_lane_count=0):
+    """Fallback shape when telemetry can't be read: 'N/A' for every host/media lane field."""
+    na_dict = {}
+    for lane in range(1, host_lane_count + 1):
+        na_dict.update({consts.host_field(lane, s): 'N/A' for s in consts.COMMON_SUFFIXES})
+    for lane in range(1, media_lane_count + 1):
+        na_dict.update({consts.media_field(lane, s): 'N/A' for s in consts.COMMON_SUFFIXES})
+        na_dict.update({consts.media_field(lane, s): 'N/A' for s in consts.MEDIA_ONLY_SUFFIXES})
+    return na_dict
+
+
+class CredoCdbCmdHandler(CdbCmdHandler):
+    """Low-level sender/reader for Credo's vendor CDB opcode (0x8000)."""
+
+    def __init__(self, reader, writer):
+        super(CredoCdbCmdHandler, self).__init__(reader, writer, cdb_credo.CmisCdbCredoMemMap(CdbCodes))
+
+    def get_telemetry_info(self, target, side, dport, timeout=None):
+        """Run CDB command 0x8000 and return the decoded reply dict, or None on failure."""
+        payload = {'target': target, 'side': side, 'dport': dport}
+        if not self.send_cmd(cdb_credo.CDB_GET_TELEMETRY_INFO_CMD, payload, timeout=timeout):
+            return None
+        return self.read(consts.TELEMETRY_INFO_FIELD)
+
+    def access_remote_byte(self, target, side, dport, offset, value=None, timeout=None):
+        """Read or write a single byte on the local/remote side via CDB command 0x8001.
+
+        If `value` is None, reads the byte at `offset` and returns it (or None
+        on failure). Otherwise writes `value` and returns True/False for success.
+        """
+        rw = 'read' if value is None else 'write'
+        payload = {
+            'target': target, 'side': side, 'dport': dport,
+            'offset': offset, 'rw': rw, 'value': value if value is not None else 0,
+        }
+        if not self.send_cmd(cdb_credo.CDB_ACCESS_REMOTE_BYTE_CMD, payload, timeout=timeout):
+            return None if rw == 'read' else False
+        if rw == 'write':
+            return True
+        reply = self.read(consts.REMOTE_BYTE_FIELD)
+        return reply[consts.REMOTE_BYTE_VALUE] if reply else None
+
+    def access_remote_page(self, target, side, dport, page, data=None, timeout=None):
+        """Read or write up to cdb_credo.REMOTE_PAGE_DATA_SIZE bytes on the
+        local/remote side via CDB command 0x8002.
+
+        If `data` is None, reads back `page` and returns its bytes (or None on
+        failure). Otherwise writes `data` and returns True/False for success.
+        """
+        rw = 'read' if data is None else 'write'
+        payload = {'target': target, 'side': side, 'dport': dport, 'page': page, 'rw': rw, 'data': data}
+        if not self.send_cmd(cdb_credo.CDB_ACCESS_REMOTE_PAGE_CMD, payload, timeout=timeout):
+            return None if rw == 'read' else False
+        if rw == 'write':
+            return True
+        reply = self.read(consts.REMOTE_PAGE_FIELD)
+        return reply[consts.REMOTE_PAGE_DATA] if reply else None
+
+class CmisCredoApi(CmisApi):
+    def __init__(self, xcvr_eeprom, init_cdb_fw_handler=False):
+        super(CmisCredoApi, self).__init__(xcvr_eeprom, init_cdb_fw_handler=init_cdb_fw_handler)
+        self._init_credo_cdb_handler = True
+        self._credo_cdb_handler = None
+
+    @property
+    def _credo_cdb(self):
+        if not self._init_credo_cdb_handler:
+            return None
+        if self._credo_cdb_handler is None:
+            self._credo_cdb_handler = self._create_credo_cdb_handler()
+        return self._credo_cdb_handler
+
+    def _create_credo_cdb_handler(self):
+        if not self.is_cdb_supported():
+            self._init_credo_cdb_handler = False
+            return None
+        try:
+            return CredoCdbCmdHandler(self.xcvr_eeprom.reader, self.xcvr_eeprom.writer)
+        except Exception as err:
+            log.log_error("Failed to initialize Credo CDB handler: {}".format(err))
+        self._init_credo_cdb_handler = False
+        return None
+
+    def _is_capability_supported(self):
+        """Telemetry data is only valid when EEPROM page 0 byte 36 == 0x21"""
+        if not self.is_cdb_supported():
+            return False
+
+        compliance = self.xcvr_eeprom.read_raw(_TELEMETRY_COMPLIANCE_OFFSET, 1)
+        if compliance != _TELEMETRY_COMPLIANCE_VALUE:
+            return False
+
+        return True
+
+    def _get_credo_telemetry_info(self, host_lane_count, media_lane_count):
+        """Fetch and decode local telemetry via CDB 0x8000, once per host/media lane.
+
+        Returns a fully-populated dict ('N/A' for lanes/fields that aren't
+        queried or fail to read), or None if the module isn't ModuleReady yet.
+        """
+        if self.get_module_state() != _MODULE_STATE_READY:
+            return None
+
+        result = _telemetry_na_dict(host_lane_count, media_lane_count)
+
+        for side, lane_count in ((consts.HOST, host_lane_count), (consts.MEDIA, media_lane_count)):
+            field = consts.host_field if side == consts.HOST else consts.media_field
+            for lane in range(1, lane_count + 1):
+                dport = lane - 1
+                try:
+                    raw = self._credo_cdb.get_telemetry_info(_POLL_TARGET, side, dport)
+                    if raw is None:
+                        continue
+                    decoded = {field(lane, suffix): raw[suffix] for suffix in consts.COMMON_SUFFIXES}
+                    if side == consts.MEDIA:
+                        decoded.update({
+                            field(lane, suffix): raw[suffix]
+                            for suffix in consts.MEDIA_ONLY_SUFFIXES if suffix in raw
+                        })
+                except Exception as err:
+                    log.log_error("Failed to read Credo {}-side lane {} telemetry info: {}".format(side, lane, err))
+                    continue
+                result.update(decoded)
+
+        return result
+
+    def get_transceiver_dom_real_value(self):
+        trans_dom = super(CmisCredoApi, self).get_transceiver_dom_real_value()
+        if trans_dom is None:
+            return None
+
+        host_lane_count = self.get_host_lane_count() or 0
+        media_lane_count = self.get_media_lane_count() or 0
+        na_dict = _telemetry_na_dict(host_lane_count, media_lane_count)
+
+        if not self._is_capability_supported():
+            trans_dom.update(na_dict)
+            return trans_dom
+
+        telemetry = self._get_credo_telemetry_info(host_lane_count, media_lane_count)
+        trans_dom.update(telemetry if telemetry is not None else na_dict)
+        return trans_dom

--- a/sonic_platform_base/sonic_xcvr/fields/cmis_credo.py
+++ b/sonic_platform_base/sonic_xcvr/fields/cmis_credo.py
@@ -1,0 +1,46 @@
+import math
+import struct
+
+from .xcvr_field import NumberRegField
+
+# Link report category bitmask -> name (CDB 0x8000 reply, bits 0-6).
+_CATEGORY_BITS = {
+    0: "LINK_DOWN_COUNTER",
+    1: "FEC_BIN_COUNTER",
+    2: "PRE_FEC_BER",
+    3: "MPI",
+    4: "SNR",
+    5: "EYE_HEIGHT",
+    6: "FLAGS",
+}
+
+_RAW_UNITS_PER_MW = 10000.0  # raw optical power registers are 0.1uW/LSB
+
+
+def _mw_to_dbm_or_floor(mw):
+    """Convert mW to dBm, flooring non-positive readings to -40 dBm (module "no light" value)."""
+    if mw <= 0:
+        return -40.0
+    return round(10 * math.log10(mw), 3)
+
+
+class CredoLinkStatusField(NumberRegField):
+    """Decodes the link status byte (bit 0) into a bool."""
+    def decode(self, raw_data, **decoded_deps):
+        return bool(struct.unpack(self.format, raw_data)[0] & 0x1)
+
+
+class CredoActiveCategoriesField(NumberRegField):
+    """Decodes the 2-byte link report category bitmask into a comma-joined
+    string of active category names."""
+    def decode(self, raw_data, **decoded_deps):
+        mask = struct.unpack(self.format, raw_data)[0]
+        return ','.join(name for bit, name in _CATEGORY_BITS.items() if mask & (1 << bit))
+
+
+class CredoOpticalPowerDbmField(NumberRegField):
+    """Decodes a raw 0.1uW/LSB optical power register into dBm. Reused for
+    OPTICAL_TX_POWER_MIN/MAX and OPTICAL_RX_POWER_MIN/MAX."""
+    def decode(self, raw_data, **decoded_deps):
+        raw_units = struct.unpack(self.format, raw_data)[0]
+        return _mw_to_dbm_or_floor(raw_units / _RAW_UNITS_PER_MW)

--- a/sonic_platform_base/sonic_xcvr/fields/credo_cdb_consts.py
+++ b/sonic_platform_base/sonic_xcvr/fields/credo_cdb_consts.py
@@ -1,0 +1,88 @@
+
+# Get Telemetry Info (CDB 0x8000) reply field group -- page 9Fh, bytes 134-247.
+TELEMETRY_INFO_FIELD = "TelemetryInfoField"
+RPL_LEN = "TelemetryRplLen"
+
+# Access Remote Byte (CDB 0x8001) reply field -- page 9Fh, byte
+# cdb_consts.RPL_DATA_START_OFFSET (136).
+REMOTE_BYTE_FIELD = "RemoteByteField"
+REMOTE_BYTE_VALUE = "remote_byte_value"
+
+# Access Remote Page (CDB 0x8002) reply field -- page 9Fh, starting at byte
+# cdb_consts.RPL_DATA_START_OFFSET (136). Sized to REMOTE_PAGE_DATA_SIZE (see
+# cdb_credo.py), the largest chunk that fits in one LPL command alongside its
+# target/side/dport/page/rw header -- not a full 128-byte EEPROM page.
+REMOTE_PAGE_FIELD = "RemotePageField"
+REMOTE_PAGE_DATA = "remote_page_data"
+
+HOST = "host"
+MEDIA = "media"
+
+LINK_STATUS = "link_status"
+SCORE = "score"
+ACTIVE_CATEGORIES = "active_categories"
+SERIAL_NUMBER = "serial_number"
+LINK_DOWN_CNTR = "link_down_cntr"
+LINK_UP_TIME = "link_up_time"
+MODULE_FLAGS = "module_flags"
+SNR = "snr"
+LTP = "ltp"
+EYE1 = "eye1"
+EYE2 = "eye2"
+EYE3 = "eye3"
+TEMPERATURE = "temperature"
+VOLTAGE = "voltage"
+PRE_FEC_BER = "pre_fec_ber"
+POST_FEC_ERRORS = "post_fec_errors"
+SHUFFLE_DATA_PATH_ID = "shuffle_data_path_id"
+SHUFFLE_IB_DETECTION_STATUS = "shuffle_ib_detection_status"
+OPTICAL_TX_POWER_MIN = "optical_tx_power_min"
+OPTICAL_TX_POWER_MAX = "optical_tx_power_max"
+
+# Media-only: the CDB reply only populates these when queried with side='media'.
+OPTICAL_POWER_FLAGS = "optical_power_flags"
+OPTICAL_LASER_BIAS_FLAGS = "optical_laser_bias_flags"
+MPI = "mpi"
+# No CDB reply field is ever decoded for this suffix -- the vendor CDB spec
+# doesn't document a distinct byte/bit range for it beyond the single MPI
+# flag byte -- so it always stays at its 'N/A' default from _telemetry_na_dict.
+MPI_VALUE = "mpi_value"
+OPTICAL_RX_POWER_MIN = "optical_rx_power_min"
+OPTICAL_RX_POWER_MAX = "optical_rx_power_max"
+
+NUM_FEC_BINS = 16
+FEC_BIN_PREFIX = "fec_bin_"
+
+# Suffixes decoded from both a host-side and a media-side query (each side's
+# reply gets its own telemetry_host_*/telemetry_media_* key).
+COMMON_SUFFIXES = [
+    LINK_STATUS, SCORE, ACTIVE_CATEGORIES, SERIAL_NUMBER, LINK_DOWN_CNTR,
+    LINK_UP_TIME, MODULE_FLAGS, SNR, LTP, EYE1, EYE2, EYE3, TEMPERATURE,
+    VOLTAGE, PRE_FEC_BER, POST_FEC_ERRORS, SHUFFLE_DATA_PATH_ID,
+    SHUFFLE_IB_DETECTION_STATUS, OPTICAL_TX_POWER_MIN, OPTICAL_TX_POWER_MAX,
+] + ["{}{}".format(FEC_BIN_PREFIX, i) for i in range(NUM_FEC_BINS)]
+
+# Suffixes only ever decoded on a media-side query (no telemetry_host_* key exists).
+MEDIA_ONLY_SUFFIXES = [
+    OPTICAL_POWER_FLAGS, OPTICAL_LASER_BIAS_FLAGS, MPI, MPI_VALUE,
+    OPTICAL_RX_POWER_MIN, OPTICAL_RX_POWER_MAX,
+]
+
+
+def _field(side, lane, suffix):
+    return "telemetry_{}_lane{}_{}".format(side, lane, suffix)
+
+
+def host_field(lane, suffix):
+    """Return the TRANSCEIVER_DOM_REAL_VALUE field name for host *lane* (1-based) telemetry *suffix*."""
+    return _field(HOST, lane, suffix)
+
+
+def media_field(lane, suffix):
+    """Return the TRANSCEIVER_DOM_REAL_VALUE field name for media *lane* (1-based) telemetry *suffix*."""
+    return _field(MEDIA, lane, suffix)
+
+
+def fec_bin_field(side, lane, index):
+    """Return the TRANSCEIVER_DOM_REAL_VALUE field name for RS-FEC bin *index* (0-15) on *side*/*lane*."""
+    return _field(side, lane, "{}{}".format(FEC_BIN_PREFIX, index))

--- a/sonic_platform_base/sonic_xcvr/mem_maps/credo/cdb_credo.py
+++ b/sonic_platform_base/sonic_xcvr/mem_maps/credo/cdb_credo.py
@@ -1,0 +1,197 @@
+
+import struct
+
+from ..public.cmis.cdb import CDBCommand, CdbMemMap
+from ..public.cmis.pages.page import CmisPage
+from ...fields.xcvr_field import FixedNumberRegField, NumberRegField, StringRegField
+from ...fields.cmis_credo import CredoActiveCategoriesField, CredoLinkStatusField, CredoOpticalPowerDbmField
+from ...fields import cdb_consts
+from ...fields import credo_cdb_consts as consts
+
+# Credo vendor CDB opcodes (0x8000 range)
+CDB_GET_TELEMETRY_INFO_CMD = 0x8000
+CDB_ACCESS_REMOTE_BYTE_CMD = 0x8001
+CDB_ACCESS_REMOTE_PAGE_CMD = 0x8002
+
+TARGET_CODE = {'local': 0, 'remote': 1}
+SIDE_CODE = {'host': 0, 'media': 1}
+RW_CODE = {'read': 0, 'write': 1}
+
+# Largest chunk CdbCredoAccessRemotePage can move in one LPL command: the
+# LPL payload ceiling (cdb_consts.LPL_MAX_PAYLOAD_SIZE) minus its 5-byte
+# target/side/dport/page/rw header. Not a full 128-byte EEPROM page.
+REMOTE_PAGE_DATA_SIZE = cdb_consts.LPL_MAX_PAYLOAD_SIZE - 5
+
+
+class _CmisCdbCredoPage9f(CmisPage):
+
+    def __init__(self, codes):
+        super().__init__(codes, page=cdb_consts.LPL_PAGE, bank=0)
+
+        # Get Telemetry Info (0x8000) reply layout, page 9Fh bytes 134-247.
+        self.fields[consts.TELEMETRY_INFO_FIELD] = [
+            NumberRegField(consts.RPL_LEN, self.getaddr(134), size=1),
+
+            # Link status byte (bit 0) - byte 136
+            CredoLinkStatusField(consts.LINK_STATUS, self.getaddr(136), size=1),
+
+            # Link report category mask, score, serial number - bytes 137-155
+            CredoActiveCategoriesField(consts.ACTIVE_CATEGORIES, self.getaddr(137), format=">H", size=2),
+            NumberRegField(consts.SCORE, self.getaddr(139), size=1),
+            StringRegField(consts.SERIAL_NUMBER, self.getaddr(140), size=16),
+
+            # Link/module counters and flags - bytes 156-165
+            NumberRegField(consts.LINK_DOWN_CNTR, self.getaddr(156), format=">H", size=2),
+            NumberRegField(consts.LINK_UP_TIME, self.getaddr(158), format=">I", size=4),
+            NumberRegField(consts.MODULE_FLAGS, self.getaddr(162), size=1),
+            NumberRegField(consts.OPTICAL_POWER_FLAGS, self.getaddr(163), size=1),
+            NumberRegField(consts.OPTICAL_LASER_BIAS_FLAGS, self.getaddr(164), size=1),
+            NumberRegField(consts.MPI, self.getaddr(165), size=1),
+
+            # Link quality/eye/environment measurements - bytes 166-183
+            NumberRegField(consts.SNR, self.getaddr(166), format=">H", size=2, scale=256),
+            NumberRegField(consts.LTP, self.getaddr(168), format=">H", size=2, scale=256),
+            NumberRegField(consts.EYE1, self.getaddr(170), format=">H", size=2),
+            NumberRegField(consts.EYE2, self.getaddr(172), format=">H", size=2),
+            NumberRegField(consts.EYE3, self.getaddr(174), format=">H", size=2),
+            FixedNumberRegField(consts.TEMPERATURE, self.getaddr(176), 8, format=">h", size=2),
+            NumberRegField(consts.VOLTAGE, self.getaddr(178), format=">H", size=2, scale=10000),
+            CredoOpticalPowerDbmField(consts.OPTICAL_RX_POWER_MIN, self.getaddr(180), format=">H", size=2),
+            CredoOpticalPowerDbmField(consts.OPTICAL_RX_POWER_MAX, self.getaddr(182), format=">H", size=2),
+
+            # FEC stats - bytes 184-241 (post-FEC error/bin counters are wider
+            # than the pre-FEC BER/RS-FEC bin fields they follow)
+            NumberRegField(consts.PRE_FEC_BER, self.getaddr(184), format=">H", size=2),
+            NumberRegField(consts.POST_FEC_ERRORS, self.getaddr(186), format=">I", size=4),
+            *self._fec_bin_fields(),
+
+            # Shuffle/optical Tx power - bytes 242-247
+            NumberRegField(consts.SHUFFLE_DATA_PATH_ID, self.getaddr(242), size=1),
+            NumberRegField(consts.SHUFFLE_IB_DETECTION_STATUS, self.getaddr(243), size=1),
+            CredoOpticalPowerDbmField(consts.OPTICAL_TX_POWER_MIN, self.getaddr(244), format=">H", size=2),
+            CredoOpticalPowerDbmField(consts.OPTICAL_TX_POWER_MAX, self.getaddr(246), format=">H", size=2),
+        ]
+
+        # Access Remote Byte (0x8001) reply -- single byte at the LPL reply start.
+        self.fields[consts.REMOTE_BYTE_FIELD] = [
+            NumberRegField(consts.REMOTE_BYTE_VALUE, self.getaddr(cdb_consts.RPL_DATA_START_OFFSET), size=1),
+        ]
+
+        # Access Remote Page (0x8002) reply -- REMOTE_PAGE_DATA_SIZE bytes
+        # starting at the LPL reply start.
+        self.fields[consts.REMOTE_PAGE_FIELD] = [
+            NumberRegField(
+                consts.REMOTE_PAGE_DATA, self.getaddr(cdb_consts.RPL_DATA_START_OFFSET),
+                format=">{}s".format(REMOTE_PAGE_DATA_SIZE), size=REMOTE_PAGE_DATA_SIZE,
+            ),
+        ]
+
+    def _fec_bin_fields(self):
+        """RS-FEC bin counters, bytes 190-241: bin 0 is 8 bytes, bins 1-7 are
+        4 bytes each, bins 8-15 are 2 bytes each."""
+        fields = []
+        offset = 190
+        index = 0
+        for count, fmt, size in ((1, ">Q", 8), (7, ">I", 4), (8, ">H", 2)):
+            for _ in range(count):
+                fields.append(NumberRegField(
+                    "{}{}".format(consts.FEC_BIN_PREFIX, index), self.getaddr(offset), format=fmt, size=size,
+                ))
+                offset += size
+                index += 1
+        return fields
+
+class CdbCredoTelemetry(CDBCommand):
+    """
+    Credo vendor CDB command 0x8000 to get per-lane telemetry info (link
+    quality/FEC/eye/optical power stats).
+
+    Args:
+        id: 2 bytes identifier
+        epl: 2 bytes extended payload length
+        lpl: 1 byte length of payload
+        checksum: 1 byte checksum
+    """
+    def __init__(self, cmd_id=CDB_GET_TELEMETRY_INFO_CMD):
+        super(CdbCredoTelemetry, self).__init__(cmd_id, epl=0, lpl=3)
+
+    def encode(self, payload):
+        target = payload.get("target")
+        side = payload.get("side")
+        dport = payload.get("dport")
+        lpl_data = struct.pack("BBB", TARGET_CODE[target], SIDE_CODE[side], dport)
+        return super(CdbCredoTelemetry, self).encode(payload=lpl_data)
+
+
+class CdbCredoAccessRemoteByte(CDBCommand):
+    """
+    Credo vendor CDB command 0x8001 to read or write a single byte on the
+    local/remote side (see TARGET_CODE/SIDE_CODE).
+
+    Args:
+        id: 2 bytes identifier
+        epl: 2 bytes extended payload length
+        lpl: 1 byte length of payload
+        checksum: 1 byte checksum
+    """
+    def __init__(self, cmd_id=CDB_ACCESS_REMOTE_BYTE_CMD):
+        super(CdbCredoAccessRemoteByte, self).__init__(cmd_id, epl=0, lpl=6)
+
+    def encode(self, payload):
+        target = payload.get("target")
+        side = payload.get("side")
+        dport = payload.get("dport")
+        offset = payload.get("offset")
+        rw = payload.get("rw")
+        value = payload.get("value", 0)
+        lpl_data = struct.pack(
+            "BBBBBB", TARGET_CODE[target], SIDE_CODE[side], dport, offset, RW_CODE[rw], value,
+        )
+        return super(CdbCredoAccessRemoteByte, self).encode(payload=lpl_data)
+
+
+class CdbCredoAccessRemotePage(CDBCommand):
+    """
+    Credo vendor CDB command 0x8002 to read or write up to
+    REMOTE_PAGE_DATA_SIZE bytes on the local/remote side (see
+    TARGET_CODE/SIDE_CODE) -- not a full 128-byte EEPROM page, see
+    REMOTE_PAGE_DATA_SIZE.
+
+    Args:
+        id: 2 bytes identifier
+        epl: 2 bytes extended payload length
+        lpl: 1 byte length of payload
+        checksum: 1 byte checksum
+    """
+    def __init__(self, cmd_id=CDB_ACCESS_REMOTE_PAGE_CMD):
+        super(CdbCredoAccessRemotePage, self).__init__(cmd_id, epl=0, lpl=5)
+
+    def encode(self, payload):
+        target = payload.get("target")
+        side = payload.get("side")
+        dport = payload.get("dport")
+        page = payload.get("page")
+        rw = payload.get("rw")
+        data = payload.get("data")
+        hdr = struct.pack("BBBBB", TARGET_CODE[target], SIDE_CODE[side], dport, page, RW_CODE[rw])
+        if data is not None:
+            assert len(data) <= REMOTE_PAGE_DATA_SIZE, \
+                "data length exceeds REMOTE_PAGE_DATA_SIZE ({})".format(REMOTE_PAGE_DATA_SIZE)
+            hdr += data
+        return super(CdbCredoAccessRemotePage, self).encode(payload=hdr)
+
+
+class CmisCdbCredoMemMap(CdbMemMap):
+    """CdbMemMap with Credo's vendor CDB commands (0x8000-0x8002) registered
+    alongside the standard cdb1_* commands."""
+
+    def __init__(self, codes):
+        super().__init__(codes)
+
+        self.cdb_credo_get_telemetry_cmd = CdbCredoTelemetry()
+        self.cdb_credo_access_remote_byte_cmd = CdbCredoAccessRemoteByte()
+        self.cdb_credo_access_remote_page_cmd = CdbCredoAccessRemotePage()
+
+        self.add_pages(
+            _CmisCdbCredoPage9f(codes)
+        )

--- a/sonic_platform_base/sonic_xcvr/xcvr_api_factory.py
+++ b/sonic_platform_base/sonic_xcvr/xcvr_api_factory.py
@@ -16,6 +16,7 @@ from .mem_maps.public.cmis.c_cmis import CCmisMemMap
 
 from .codes.credo.aec_800g import CredoAec800gCodes
 from .api.credo.aec_800g import CredoAec800gApi
+from .api.credo.cmis_credo import CmisCredoApi
 from .mem_maps.credo.aec_800g import CredoAec800gMemMap
 
 from .api.arista.cmis_enhanced_lpo import CmisEnhancedLpoApi
@@ -41,7 +42,10 @@ from .api.public.sff8472 import Sff8472Api
 from .mem_maps.public.sff8472 import Sff8472MemMap
 
 CREDO_800G_AEC_VENDOR_PN_LIST = ["CAC81X321M2MC1MS", "CAC815321M2MC1MS", "CAC82X321M2MC1MS"]
+CREDO_ZFL_VENDOR_PN_LIST = ["CFZ8D8S2M12AA1HW"]
+
 ARISTA_ENHANCED_LPO_PN_LIST = ["LPO-800G-2DR4"]
+
 INL_800G_VENDOR_PN_LIST = ["T-DL8CNT-NCI", "T-DH8CNT-NCI", "T-DH8CNT-N00", "T-DP4CNH-NCI", "T-DP8CNT-NNO",
                            "T-DP8CNH-NNO", "T-DC8CNT-NNO", "T-DP8CNL-NNO", "T-OL8CNT-N00", "T-OH8CNH-N00",
                            "T-OH8CNH-NNO", "T-OL8CNT-NNO"]
@@ -59,9 +63,14 @@ class XcvrApiFactory(object):
         vendor_name = self.lower_memory_info.get_vendor_name()
         vendor_pn = self.lower_memory_info.get_vendor_part_num()
 
-        if vendor_name == 'Credo' and vendor_pn in CREDO_800G_AEC_VENDOR_PN_LIST:
-            xcvr_eeprom = XcvrEeprom(self.reader, self.writer, CredoAec800gMemMap(CredoAec800gCodes, bank=bank))
-            api = CredoAec800gApi(xcvr_eeprom, init_cdb_fw_handler=True)
+        if vendor_name == 'Credo':
+            if vendor_pn in CREDO_800G_AEC_VENDOR_PN_LIST:
+                xcvr_eeprom = XcvrEeprom(self.reader, self.writer, CredoAec800gMemMap(CredoAec800gCodes, bank=bank))
+                api = CredoAec800gApi(xcvr_eeprom, init_cdb_fw_handler=True)
+            else:
+                xcvr_eeprom = XcvrEeprom(self.reader, self.writer, CmisMemMap(CmisCodes, bank=bank))
+                api = CmisCredoApi(xcvr_eeprom, init_cdb_fw_handler=True)
+
         elif ('INNOLIGHT' in vendor_name and vendor_pn in INL_800G_VENDOR_PN_LIST) or \
              ('EOPTOLINK' in vendor_name and vendor_pn in EOP_800G_VENDOR_PN_LIST):
             xcvr_eeprom = XcvrEeprom(self.reader, self.writer, CmisMemMap(CmisCodes, bank=bank))


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

Adds link-quality/FEC/eye/optical-power telemetry for Credo CMIS modules that support the vendor "Get Telemetry Info" CDB command (opcode 0x8000), merged into TRANSCEIVER_DOM_REAL_VALUE. Follows the CmisEnhancedLpoApi/CmisEnhancedLpoMemMap convention: the module keeps the standard CmisMemMap as its main EEPROM map, with the vendor CDB commands handled by a dedicated internal CdbMemMap-based handler (mirroring CmisApi's own cdb_fw_hdlr/_cdb_mem_map pattern).

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)

