### PR TITLE
[CDB] Separate CDB handler functionality from CmisAPI

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/c_cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/c_cmis.py
@@ -49,8 +49,8 @@ C_CMIS_XCVR_INFO_DEFAULT_DICT.update({
 })
 
 class CCmisApi(CmisApi):
-    def __init__(self, xcvr_eeprom, init_cdb_fw_handler=False):
-        super(CCmisApi, self).__init__(xcvr_eeprom, init_cdb_fw_handler)
+    def __init__(self, xcvr_eeprom):
+        super(CCmisApi, self).__init__(xcvr_eeprom)
 
     def _get_vdm_key_to_db_prefix_map(self):
         combined_map = {**CMIS_VDM_KEY_TO_DB_PREFIX_KEY_MAP, **C_CMIS_DELTA_VDM_KEY_TO_DB_PREFIX_KEY_MAP}

--- a/sonic_platform_base/sonic_xcvr/api/public/cdb_fw.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cdb_fw.py
@@ -20,20 +20,12 @@ class CmisCdbFw:
     CDB firmware upgrade operations for CMIS modules.
     """
 
-    @property
-    def cdb_fw_hdlr(self):
-        if not self._init_cdb_fw_handler:
-            return None
-
-        if self._cdb_fw_hdlr is None:
-            self._cdb_fw_hdlr = self._create_cdb_fw_handler()
-        return self._cdb_fw_hdlr
+    def __init__(self, xcvr_eeprom):
+        self.xcvr_eeprom = xcvr_eeprom
+        self._cdb_mem_map = CdbMemMap(CdbCodes)
+        self.cdb_fw_hdlr = self._create_cdb_fw_handler()
 
     def _create_cdb_fw_handler(self):
-        if not self.is_cdb_supported():
-            self._init_cdb_fw_handler = False
-            return None
-
         try:
             return CdbFw(self.xcvr_eeprom.reader, self.xcvr_eeprom.writer, self._cdb_mem_map)
         except AssertionError as err:
@@ -41,7 +33,6 @@ class CmisCdbFw:
         except Exception as err:
             log.log_error("Failed to initialize CDB firmware handler: {}".format(err))
 
-        self._init_cdb_fw_handler = False
         return None
 
     def get_module_fw_mgmt_feature(self, verbose = False):

--- a/sonic_platform_base/sonic_xcvr/api/public/cdb_fw.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cdb_fw.py
@@ -22,6 +22,8 @@ class CmisCdbFw:
     CDB firmware upgrade operations for CMIS modules.
     """
 
+    cdb_fw_hdlr = None
+
     def __init__(self, xcvr_eeprom):
         self.xcvr_eeprom = xcvr_eeprom
         self._cdb_mem_map = CdbMemMap(CdbCodes)

--- a/sonic_platform_base/sonic_xcvr/api/public/cdb_fw.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cdb_fw.py
@@ -7,6 +7,8 @@
 from ...fields import consts
 from ...fields import cdb_consts
 from ...cdb.cdb_fw import CdbFwHandler as CdbFw
+from ...mem_maps.public.cmis.cdb import CdbMemMap
+from ...codes.public.cdb import CdbCodes
 import time
 from sonic_py_common.syslogger import SysLogger
 

--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -11,9 +11,7 @@ from ..xcvr_api import XcvrApi
 from .cdb_fw import CmisCdbFw
 import logging
 from ...codes.public.cmis import CmisCodes
-from ...codes.public.cdb import CdbCodes
 from ...codes.public.sff8024 import Sff8024
-from ...mem_maps.public.cmis.cdb import CdbMemMap
 from .cmisVDM import CmisVdmApi
 import time
 import copy
@@ -105,7 +103,7 @@ CMIS_XCVR_INFO_DEFAULT_DICT = {
         "vdm_supported": "N/A"
         }
 
-class CmisApi(XcvrApi):
+class CmisApi(CmisCdbFw, XcvrApi):
     NUM_CHANNELS = 8
     LowPwrRequestSW = 4
     LowPwrAllowRequestHW = 6
@@ -135,21 +133,11 @@ class CmisApi(XcvrApi):
         cls.cache_enabled = bool(enabled)
 
     def __init__(self, xcvr_eeprom):
-        super(CmisApi, self).__init__(xcvr_eeprom)
+        XcvrApi.__init__(self, xcvr_eeprom)
         self.vdm = CmisVdmApi(xcvr_eeprom) if not self.is_flat_memory() else None
 
-        self.cdb_fw = None
         if self.is_cdb_supported():
-            self.cdb_fw = CmisCdbFw(xcvr_eeprom)
-
-    def get_module_fw_info(self):
-        """
-        Get firmware information from the CDB helper when supported.
-        """
-        if self.cdb_fw is None:
-            return {'status': False, 'info': "CDB Not supported", 'result': None}
-
-        return self.cdb_fw.get_module_fw_info()
+            CmisCdbFw.__init__(self, xcvr_eeprom)
 
     def _get_vdm_key_to_db_prefix_map(self):
         return CMIS_VDM_KEY_TO_DB_PREFIX_KEY_MAP

--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -105,7 +105,7 @@ CMIS_XCVR_INFO_DEFAULT_DICT = {
         "vdm_supported": "N/A"
         }
 
-class CmisApi(CmisCdbFw, XcvrApi):
+class CmisApi(XcvrApi):
     NUM_CHANNELS = 8
     LowPwrRequestSW = 4
     LowPwrAllowRequestHW = 6
@@ -134,12 +134,22 @@ class CmisApi(CmisCdbFw, XcvrApi):
         """
         cls.cache_enabled = bool(enabled)
 
-    def __init__(self, xcvr_eeprom, init_cdb_fw_handler=False):
+    def __init__(self, xcvr_eeprom):
         super(CmisApi, self).__init__(xcvr_eeprom)
         self.vdm = CmisVdmApi(xcvr_eeprom) if not self.is_flat_memory() else None
-        self._init_cdb_fw_handler = init_cdb_fw_handler
-        self._cdb_fw_hdlr = None
-        self._cdb_mem_map = CdbMemMap(CdbCodes) if init_cdb_fw_handler else None
+
+        self.cdb_fw = None
+        if self.is_cdb_supported():
+            self.cdb_fw = CmisCdbFw(xcvr_eeprom)
+
+    def get_module_fw_info(self):
+        """
+        Get firmware information from the CDB helper when supported.
+        """
+        if self.cdb_fw is None:
+            return {'status': False, 'info': "CDB Not supported", 'result': None}
+
+        return self.cdb_fw.get_module_fw_info()
 
     def _get_vdm_key_to_db_prefix_map(self):
         return CMIS_VDM_KEY_TO_DB_PREFIX_KEY_MAP

--- a/sonic_platform_base/sonic_xcvr/xcvr_api_factory.py
+++ b/sonic_platform_base/sonic_xcvr/xcvr_api_factory.py
@@ -61,23 +61,23 @@ class XcvrApiFactory(object):
 
         if vendor_name == 'Credo' and vendor_pn in CREDO_800G_AEC_VENDOR_PN_LIST:
             xcvr_eeprom = XcvrEeprom(self.reader, self.writer, CredoAec800gMemMap(CredoAec800gCodes, bank=bank))
-            api = CredoAec800gApi(xcvr_eeprom, init_cdb_fw_handler=True)
+            api = CredoAec800gApi(xcvr_eeprom)
         elif ('INNOLIGHT' in vendor_name and vendor_pn in INL_800G_VENDOR_PN_LIST) or \
              ('EOPTOLINK' in vendor_name and vendor_pn in EOP_800G_VENDOR_PN_LIST):
             xcvr_eeprom = XcvrEeprom(self.reader, self.writer, CmisMemMap(CmisCodes, bank=bank))
-            api = CmisFr800gApi(xcvr_eeprom, init_cdb_fw_handler=True)
+            api = CmisFr800gApi(xcvr_eeprom)
         elif vendor_name == 'Hisense' and vendor_pn is not None and re.match(HISENSE_2X100G_VENDOR_PN, vendor_pn):
             xcvr_eeprom = XcvrEeprom(self.reader, self.writer, CmisMemMap(CmisCodes, bank=bank))
-            api = CmisAocSingleBankApi(xcvr_eeprom, init_cdb_fw_handler=True)
+            api = CmisAocSingleBankApi(xcvr_eeprom)
         elif vendor_pn in ARISTA_ENHANCED_LPO_PN_LIST:
             xcvr_eeprom = XcvrEeprom(self.reader, self.writer, CmisEnhancedLpoMemMap(CmisCodes, bank=bank))
-            api = CmisEnhancedLpoApi(xcvr_eeprom, init_cdb_fw_handler=True)
+            api = CmisEnhancedLpoApi(xcvr_eeprom)
         else:
             xcvr_eeprom = XcvrEeprom(self.reader, self.writer, CmisMemMap(CmisCodes, bank=bank))
-            api = CmisApi(xcvr_eeprom, init_cdb_fw_handler=True)
+            api = CmisApi(xcvr_eeprom)
             if api.is_coherent_module():
                 xcvr_eeprom = XcvrEeprom(self.reader, self.writer, CCmisMemMap(CmisCodes, bank=bank))
-                api = CCmisApi(xcvr_eeprom, init_cdb_fw_handler=True)
+                api = CCmisApi(xcvr_eeprom)
         return api
 
     def _create_qsfp_api(self):

--- a/tests/sonic_xcvr/test_ccmis.py
+++ b/tests/sonic_xcvr/test_ccmis.py
@@ -15,7 +15,7 @@ class TestCCmis(object):
     writer = MagicMock()
     eeprom = XcvrEeprom(reader, writer, mem_map)
 
-    api = CCmisApi(eeprom, init_cdb_fw_handler=False)
+    api = CCmisApi(eeprom)
 
     @pytest.mark.parametrize("mock_response, expected", [
         (8, 150),

--- a/tests/sonic_xcvr/test_sfp_optoe_base.py
+++ b/tests/sonic_xcvr/test_sfp_optoe_base.py
@@ -21,8 +21,8 @@ class TestSfpOptoeBase(object):
     writer = MagicMock() 
     eeprom = XcvrEeprom(reader, writer, mem_map) 
     sfp_optoe_api = SfpOptoeBase() 
-    ccmis_api = CCmisApi(eeprom, init_cdb_fw_handler=False) 
-    cmis_api = CmisApi(eeprom, init_cdb_fw_handler=False) 
+    ccmis_api = CCmisApi(eeprom)
+    cmis_api = CmisApi(eeprom)
     sff8472_api = Sff8472Api(eeprom)
  
     def test_is_transceiver_vdm_supported_non_cmis(self):


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
This change cleans up the CMIS CDB firmware handling by separating capability detection from CDB helper ownership.

Previously, the CDB firmware state was duplicated across the API and the helper object, creating unnecessary coupling:

CmisApi stored a redundant cdb_fw_hdlr alias
the API also exposed a pass-through _create_cdb_fw_handler() method
the actual CDB firmware logic was spread across ownership boundaries instead of staying with the helper object

#### Motivation and Context
The CDB firmware functionality is a capability-specific helper, not core CMIS API state. Keeping CDB handler creation and memory-map ownership on the API class made the design harder to reason about and duplicated state that could drift out of sync.

This cleanup makes the ownership boundaries explicit and reduces the risk of wrong lifecycle management for CMIS modules that do not support CDB. The refactor keeps the external behavior intact while aligning the implementation with the actual capability model.

This results in a simpler composition model:

- CmisApi decides whether CDB is supported
- CmisCdbFw owns the CDB firmware handler and memory map
- Firmware calls go through the helper, not duplicate API state (TODO: Sfputil needs to use proper API pending fix)


#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)

