### PR TITLE
[eeprom] Use swsscommon instead of redis-py in eeprom_tlvinfo.

### DIFF
--- a/sonic_platform_base/chassis_base.py
+++ b/sonic_platform_base/chassis_base.py
@@ -7,7 +7,6 @@
 
 import sys
 from . import device_base
-from . import sfp_base
 
 class ChassisBase(device_base.DeviceBase):
     """

--- a/sonic_platform_base/sonic_eeprom/eeprom_tlvinfo.py
+++ b/sonic_platform_base/sonic_eeprom/eeprom_tlvinfo.py
@@ -13,13 +13,9 @@ from __future__ import print_function
 try:
     import sys
 
-    import redis
-
     from . import eeprom_base    # Dot module supports both Python 2 and Python 3 using explicit relative import methods
 except ImportError as e:
     raise ImportError (str(e) + "- required module not found")
-
-STATE_DB_INDEX = 6
 
 #
 # TlvInfo Format - This eeprom format was defined by Cumulus Networks
@@ -79,7 +75,7 @@ class TlvInfoDecoder(eeprom_base.EepromDecoder):
                                              ro)
         self.eeprom_start = start
         self.eeprom_max_len = max_len
-        self._redis_client = None
+        self._state_db = None
 
 
     def __print_db(self, code, num=0):
@@ -618,20 +614,22 @@ class TlvInfoDecoder(eeprom_base.EepromDecoder):
         return 'crc32'
 
     @property
-    def redis_client(self):
-        """Handy property to get a redis client. Make sure only create the redis client once.
+    def state_db(self):
+        """Handy property to get a STATE_DB connector. Only create it once.
 
         Returns:
-            A redis client instance
+            A connected SonicV2Connector instance bound to STATE_DB
         """
-        if not self._redis_client:
-            self._redis_client = redis.Redis(db=STATE_DB_INDEX)
-        return self._redis_client
+        if not self._state_db:
+            from swsscommon.swsscommon import SonicV2Connector
+            self._state_db = SonicV2Connector()
+            self._state_db.connect(self._state_db.STATE_DB)
+        return self._state_db
 
     def _redis_hget(self, key, field):
-        value = self.redis_client.hget(key, field)
+        value = self.state_db.get(self.state_db.STATE_DB, key, field)
         if value is not None:
-            value = value.decode().rstrip('\0')
+            value = value.rstrip('\0')
         return value
 
     def visit_eeprom(self, e, visitor):

--- a/tests/eeprom_base_test.py
+++ b/tests/eeprom_base_test.py
@@ -158,16 +158,17 @@ class TestEepromTlvinfo:
             assert exit_mock.called
 
     def test_eeprom_tlvinfo_update_eeprom_db(self):
-        # Test updating eeprom to DB by mocking redis hmset
+        # Test updating eeprom to DB by mocking the STATE_DB connector hmset
         eeprom_class = eeprom_tlvinfo.TlvInfoDecoder(EEPROM_SYMLINK_FULL_PATH, 0, '', True)
         eeprom = eeprom_class.read_eeprom()
-        eeprom_class.redis_client.hmset = mock.MagicMock(return_value = True)
+        eeprom_class.state_db.hmset = mock.MagicMock(return_value = True)
         assert(0 == eeprom_class.update_eeprom_db(eeprom))
 
     def test_eeprom_tlvinfo_read_eeprom_db(self):
-        # Test reading from DB by mocking redis hget
+        # Test reading from DB by mocking the STATE_DB connector get.
+        # SonicV2Connector.get() returns a decoded str (not bytes).
         eeprom_class = eeprom_tlvinfo.TlvInfoDecoder(EEPROM_SYMLINK_FULL_PATH, 0, '', True)
-        eeprom_class.redis_client.hget = mock.MagicMock(return_value = b'1')
+        eeprom_class.state_db.get = mock.MagicMock(return_value = '1')
         assert(0 == eeprom_class.read_eeprom_db())
 
 class TestEepromDecoder(object):


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

- Drop the top-level "import redis" and the STATE_DB_INDEX constant.
- Rename the redis_client property to state_db, returning a lazily connected SonicV2Connector bound to STATE_DB.
- _redis_hget reads via SonicV2Connector.get, which returns a decoded str, so the previous .decode() is dropped; rstrip('\0') is kept.
- EepromRedisVisitor writes via a new _hmset helper that coerces field values to str (SonicV2Connector.hmset requires str values, whereas redis-py stringified them implicitly), so int fields such as Version and Total Length are stored exactly as before.

The EEPROM_INFO key space and field names are unchanged, so all consumers (show platform syseeprom, gNMI, etc.) are unaffected.
Also remove an unused "from . import sfp_base" in chassis_base.py; the symbol is referenced nowhere except a docstring.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

The TlvInfo EEPROM decoder imported redis-py at module top level and created a redis.Redis(db=STATE_DB_INDEX) client to read/write the STATE_DB EEPROM_INFO tables. redis-py is heavy (~20MB RSS on import), and this cost is paid by every process that imports the decoder, even those that only decode the EEPROM buffer and never touch the DB.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

Verified on mtvr-panther-07 (SN2700): syseepromd process RSS dropped from ~47MB to ~35MB, EEPROM_INFO contents identical before and after, and redis is no longer loaded in the process.

#### Additional Information (Optional)

