### PR TITLE
[sonic_xcvr] Fix firmware download TypeError

### DIFF
--- a/sonic_platform_base/sonic_xcvr/cdb/cdb_fw.py
+++ b/sonic_platform_base/sonic_xcvr/cdb/cdb_fw.py
@@ -42,9 +42,9 @@ class CdbFwHandler(CdbCmdHandler):
             return False
 
         mgmt_features_adv = reply.get(cdb_consts.CDB_FIRMWARE_MGMT_ADV, {})
-        self.start_payload_size = reply[cdb_consts.CDB_START_CMD_PAYLOAD_SIZE]
+        self.start_payload_size = int(reply[cdb_consts.CDB_START_CMD_PAYLOAD_SIZE])
         self.is_lpl_only = reply[cdb_consts.CDB_WRITE_MECHANISM] == "LPL"
-        self.rw_length_ext = reply[cdb_consts.CDB_READ_WRITE_LENGTH_EXT] + 8
+        self.rw_length_ext = int(reply[cdb_consts.CDB_READ_WRITE_LENGTH_EXT]) + 8
         self.is_abort_supported = bool(mgmt_features_adv.get(cdb_consts.CDB_ABORT_CMD_SUPPORTED, 0))
 
         if self.is_lpl_only:

--- a/tests/sonic_xcvr/test_cdb_fw.py
+++ b/tests/sonic_xcvr/test_cdb_fw.py
@@ -109,11 +109,13 @@ class TestCdbFwHandler:
         handler.read_reply = MagicMock(return_value={
             cdb_consts.CDB_START_CMD_PAYLOAD_SIZE: 256,
             cdb_consts.CDB_WRITE_MECHANISM: "EPL",
-            cdb_consts.CDB_READ_WRITE_LENGTH_EXT: 5000
+            cdb_consts.CDB_READ_WRITE_LENGTH_EXT: 800.0
         })
-        
+
         result = handler.initFwHandler()
         assert result == True
+        assert isinstance(handler.rw_length_ext, int)
+        assert handler.rw_length_ext == 808
 
     def test_get_fw_mgmt_features_none(self):
         """Test get_fw_mgmt_features returns None when both sizes are 0"""


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
The CDB firmware block size fields come back from the module as floats. That float made it all to `file.read() `during firmware download, which only accepts an integer, so the download crashed with a TypeError on any EPL-capable module that didn't advertise the maximum block size.

#### Motivation and Context
#### Motivation and Context
Firmware download fails on any module that doesn't advertise the maximum block size:
```
    CDB: Starting firmware download
    Downloading ...  [------------------------------------]    0%
    Traceback (most recent call last):
      File "/usr/local/bin/sfputil", line 8, in <module>
        sys.exit(cli())
      ...
      File "/usr/local/lib/python3.13/dist-packages/sfputil/main.py", line 1725, in download
        status = download_firmware(port_name, filepath)
      File "/usr/local/lib/python3.13/dist-packages/sfputil/main.py", line 1580, in download_firmware
        data = fd.read(count)
    TypeError: argument should be integer or None, not 'float'
    CDB: Starting firmware download
    CDB: Start firmware download failed - status 67
    CDB: Starting firmware download
    CDB: Start firmware download failed - status 67
```
#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
- Modified unit tests and made sure they are passing
- With the fix, verified firmware downloaded successfully

On version 202605:
**Hardware:** Reproduced the `TypeError` on the unpatched code, then confirmed firmware download proceeds past block-write with the fix applied.
**Unit tests:** `pytest tests/sonic_xcvr/test_cdb_fw.py`

#### Additional Information (Optional)

MSFT ADO - 39388348