### PR TITLE
[action/cherry-pick][sonic_xcvr] Fix firmware download TypeError

### DIFF
--- a/sonic_platform_base/sonic_xcvr/cdb/cdb_fw.py
+++ b/sonic_platform_base/sonic_xcvr/cdb/cdb_fw.py
@@ -35,9 +35,9 @@ class CdbFwHandler(CdbCmdHandler):
             log.log_notice("Failed to read firmware management features")
             return False
 
-        self.start_payload_size = reply[cdb_consts.CDB_START_CMD_PAYLOAD_SIZE]
+        self.start_payload_size = int(reply[cdb_consts.CDB_START_CMD_PAYLOAD_SIZE])
         self.is_lpl_only = reply[cdb_consts.CDB_WRITE_MECHANISM] == "LPL"
-        self.rw_length_ext = reply[cdb_consts.CDB_READ_WRITE_LENGTH_EXT] + 8
+        self.rw_length_ext = int(reply[cdb_consts.CDB_READ_WRITE_LENGTH_EXT]) + 8
 
         if self.is_lpl_only:
             self.rw_length_ext = min(cdb_consts.LPL_MAX_PAYLOAD_SIZE, self.rw_length_ext)

--- a/tests/sonic_xcvr/test_cdb_fw.py
+++ b/tests/sonic_xcvr/test_cdb_fw.py
@@ -109,11 +109,13 @@ class TestCdbFwHandler:
         handler.read_reply = MagicMock(return_value={
             cdb_consts.CDB_START_CMD_PAYLOAD_SIZE: 256,
             cdb_consts.CDB_WRITE_MECHANISM: "EPL",
-            cdb_consts.CDB_READ_WRITE_LENGTH_EXT: 5000
+            cdb_consts.CDB_READ_WRITE_LENGTH_EXT: 800.0
         })
-        
+
         result = handler.initFwHandler()
         assert result == True
+        assert isinstance(handler.rw_length_ext, int)
+        assert handler.rw_length_ext == 808
 
     def test_get_fw_mgmt_features_none(self):
         """Test get_fw_mgmt_features returns None when both sizes are 0"""


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
Cherry-pick of #744 to 202605.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
There is a cherry-pick conflict, so manually creating PR for backport.
#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
On version 202605:
**Hardware**: Reproduced the TypeError on the unpatched code, then confirmed firmware download proceeds past block-write with the fix applied.
**Unit tests:** pytest tests/sonic_xcvr/test_cdb_fw.py
#### Additional Information (Optional)

