### PR TITLE
[eeprom] Use swsscommon instead of redis-py in eeprom_tlvinfo.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,6 @@ setup(
     install_requires=[
         'natsort',
         'PyYAML',
-        'redis',
     ] + sonic_dependencies,
     setup_requires = [
         'pytest-runner',

--- a/sonic_platform_base/chassis_base.py
+++ b/sonic_platform_base/chassis_base.py
@@ -7,7 +7,6 @@
 
 import sys
 from . import device_base
-from . import sfp_base
 
 class ChassisBase(device_base.DeviceBase):
     """

--- a/sonic_platform_base/sonic_eeprom/eeprom_tlvinfo.py
+++ b/sonic_platform_base/sonic_eeprom/eeprom_tlvinfo.py
@@ -13,13 +13,9 @@ from __future__ import print_function
 try:
     import sys
 
-    import redis
-
     from . import eeprom_base    # Dot module supports both Python 2 and Python 3 using explicit relative import methods
 except ImportError as e:
     raise ImportError (str(e) + "- required module not found")
-
-STATE_DB_INDEX = 6
 
 #
 # TlvInfo Format - This eeprom format was defined by Cumulus Networks
@@ -79,7 +75,7 @@ class TlvInfoDecoder(eeprom_base.EepromDecoder):
                                              ro)
         self.eeprom_start = start
         self.eeprom_max_len = max_len
-        self._redis_client = None
+        self._state_db = None
 
 
     def __print_db(self, code, num=0):
@@ -618,20 +614,29 @@ class TlvInfoDecoder(eeprom_base.EepromDecoder):
         return 'crc32'
 
     @property
-    def redis_client(self):
-        """Handy property to get a redis client. Make sure only create the redis client once.
+    def state_db(self):
+        """Handy property to get a STATE_DB connector. Only create it once.
+
+        Connects with retry_on=False so an unreachable STATE_DB fails fast
+        instead of blocking in swsscommon's unbounded reconnect loop. This
+        preserves the old redis.Redis(db=...) behavior, which raised a
+        ConnectionError rather than hanging when the DB was down.
 
         Returns:
-            A redis client instance
+            A connected SonicV2Connector instance bound to STATE_DB
         """
-        if not self._redis_client:
-            self._redis_client = redis.Redis(db=STATE_DB_INDEX)
-        return self._redis_client
+        if not self._state_db:
+            from swsscommon.swsscommon import SonicV2Connector
+            self._state_db = SonicV2Connector()
+            self._state_db.connect(self._state_db.STATE_DB, retry_on=False)
+        return self._state_db
 
     def _redis_hget(self, key, field):
-        value = self.redis_client.hget(key, field)
+        # Name kept for backward-compat (tests call it directly); the backend
+        # is now swsscommon's STATE_DB connector, not redis-py.
+        value = self.state_db.get(self.state_db.STATE_DB, key, field)
         if value is not None:
-            value = value.decode().rstrip('\0')
+            value = value.rstrip('\0')
         return value
 
     def visit_eeprom(self, e, visitor):
@@ -728,19 +733,25 @@ class EepromDecodeVisitor(EepromDefaultVisitor):
 
 
 class EepromRedisVisitor(EepromDefaultVisitor):
+    # Name kept for backward-compat; writes go to STATE_DB via swsscommon's
+    # SonicV2Connector, not redis-py.
     def __init__(self, eeprom_object):
         self.eeprom_object = eeprom_object
-        self.redis_client = eeprom_object.redis_client
+        self.state_db = eeprom_object.state_db
         self.vendor_ext_tlv_num = 0
         self.fvs = {}
         self.error = None
+
+    def _hmset(self, key):
+        fvs = {k: str(v) for k, v in self.fvs.items()}
+        self.state_db.hmset(self.state_db.STATE_DB, key, fvs)
 
     def visit_header(self, eeprom_id, version, header_length):
         if eeprom_id is not None:
             self.fvs['Id String'] = eeprom_id
             self.fvs['Version'] = version
             self.fvs['Total Length'] = header_length
-            self.redis_client.hmset("EEPROM_INFO|TlvHeader", self.fvs)
+            self._hmset("EEPROM_INFO|TlvHeader")
             self.fvs.clear()
 
     def visit_tlv(self, name, code, length, value):
@@ -754,13 +765,13 @@ class EepromRedisVisitor(EepromDefaultVisitor):
             self.fvs['Name'] = name
             self.fvs['Len'] = length
             self.fvs['Value'] = value
-        self.redis_client.hmset('EEPROM_INFO|{}'.format(hex(code)), self.fvs)
+        self._hmset('EEPROM_INFO|{}'.format(hex(code)))
         self.fvs.clear()
 
     def visit_end(self, eeprom_data):
         if self.vendor_ext_tlv_num > 0:
             self.fvs['Num_vendor_ext'] = str(self.vendor_ext_tlv_num)
-            self.redis_client.hmset('EEPROM_INFO|{}'.format(hex(self.eeprom_object._TLV_CODE_VENDOR_EXT)), self.fvs)
+            self._hmset('EEPROM_INFO|{}'.format(hex(self.eeprom_object._TLV_CODE_VENDOR_EXT)))
             self.fvs.clear()
 
         (is_valid, _) = self.eeprom_object.is_checksum_valid(eeprom_data)
@@ -769,11 +780,11 @@ class EepromRedisVisitor(EepromDefaultVisitor):
         else:
             self.fvs['Valid'] = '0'
 
-        self.redis_client.hmset('EEPROM_INFO|Checksum', self.fvs)
+        self._hmset('EEPROM_INFO|Checksum')
         self.fvs.clear()
 
         self.fvs['Initialized'] = '1'
-        self.redis_client.hmset('EEPROM_INFO|State', self.fvs)
+        self._hmset('EEPROM_INFO|State')
 
     def set_error(self, error):
         self.error = error

--- a/tests/eeprom_base_test.py
+++ b/tests/eeprom_base_test.py
@@ -158,17 +158,67 @@ class TestEepromTlvinfo:
             assert exit_mock.called
 
     def test_eeprom_tlvinfo_update_eeprom_db(self):
-        # Test updating eeprom to DB by mocking redis hmset
+        # Test updating eeprom to DB by mocking the STATE_DB connector hmset.
+        # Inject a mock connector before touching .state_db so the property
+        # never builds a real SonicV2Connector / connects to STATE_DB.
         eeprom_class = eeprom_tlvinfo.TlvInfoDecoder(EEPROM_SYMLINK_FULL_PATH, 0, '', True)
         eeprom = eeprom_class.read_eeprom()
-        eeprom_class.redis_client.hmset = mock.MagicMock(return_value = True)
+        eeprom_class._state_db = mock.MagicMock()
+        eeprom_class._state_db.hmset = mock.MagicMock(return_value = True)
         assert(0 == eeprom_class.update_eeprom_db(eeprom))
 
+        # _hmset must coerce every value to str: SonicV2Connector.hmset takes a
+        # map<string,string> and rejects ints, whereas redis-py stringified
+        # them implicitly. Assert on every captured hmset call.
+        assert eeprom_class._state_db.hmset.call_count > 0
+        for call in eeprom_class._state_db.hmset.call_args_list:
+            fvs = call.args[2]
+            for field, value in fvs.items():
+                assert isinstance(value, str), \
+                    "hmset value for {!r} is {!r}, expected str".format(field, value)
+
     def test_eeprom_tlvinfo_read_eeprom_db(self):
-        # Test reading from DB by mocking redis hget
+        # Test reading from DB by mocking the STATE_DB connector get.
+        # SonicV2Connector.get() returns a decoded str (not bytes), so the
+        # side_effect returns field-specific decoded values (including a
+        # trailing-NUL value that _redis_hget must strip, and None for a
+        # missing field) rather than a constant, and the connector calls are
+        # asserted below.
         eeprom_class = eeprom_tlvinfo.TlvInfoDecoder(EEPROM_SYMLINK_FULL_PATH, 0, '', True)
-        eeprom_class.redis_client.hget = mock.MagicMock(return_value = b'1')
+
+        # Inject a mock connector before touching .state_db so the property
+        # never builds a real SonicV2Connector / connects to STATE_DB.
+        eeprom_class._state_db = mock.MagicMock()
+        state_db = eeprom_class.state_db
+        db_values = {
+            ('EEPROM_INFO|State', 'Initialized'): '1',
+            # Trailing NUL must be stripped by _redis_hget.rstrip('\0').
+            ('EEPROM_INFO|TlvHeader', 'Version'): '1\x00',
+            ('EEPROM_INFO|TlvHeader', 'Id String'): 'TlvInfo',
+            ('EEPROM_INFO|TlvHeader', 'Total Length'): '170',
+            ('EEPROM_INFO|Checksum', 'Valid'): '1',
+        }
+
+        def fake_get(db, key, field):
+            # Only STATE_DB is expected; a missing field yields None so the
+            # None-handling path (e.g. Num_vendor_ext -> ValueError/TypeError)
+            # is exercised too.
+            assert db == state_db.STATE_DB
+            return db_values.get((key, field))
+
+        state_db.get = mock.MagicMock(side_effect=fake_get)
+
         assert(0 == eeprom_class.read_eeprom_db())
+
+        # The Initialized gate and the header/checksum fields must have been
+        # read from STATE_DB via the connector.
+        state_db.get.assert_any_call(state_db.STATE_DB, 'EEPROM_INFO|State', 'Initialized')
+        state_db.get.assert_any_call(state_db.STATE_DB, 'EEPROM_INFO|TlvHeader', 'Version')
+        state_db.get.assert_any_call(state_db.STATE_DB, 'EEPROM_INFO|Checksum', 'Valid')
+        # The trailing NUL on Version must be stripped before use.
+        assert eeprom_class._redis_hget('EEPROM_INFO|TlvHeader', 'Version') == '1'
+        # A field absent from the DB decodes to None (no NUL-strip on None).
+        assert eeprom_class._redis_hget('EEPROM_INFO|TlvHeader', 'Missing') is None
 
 class TestEepromDecoder(object):
     def setup(self):


### PR DESCRIPTION
#### Why I did it
The TlvInfo EEPROM decoder imported redis-py at module top level.
redis-py is heavy (~20MB RSS on import), and this cost is paid by every process that imports the decoder, even those that only decode the EEPROM buffer and never touch the DB.

##### Work item tracking
- Microsoft ADO **(number only)**: N/A

#### How I did it
Replaced redis-py with swsscommon's `SonicV2Connector`, which is already loaded in these daemons and is the standard SONiC DB accessor:

- Dropped the top-level `import redis` and the `STATE_DB_INDEX` constant, and dropped `redis` from `setup.py` `install_requires` (no longer imported anywhere under `sonic_platform_base/`).
- Renamed the `redis_client` property to `state_db`, returning a lazily connected `SonicV2Connector` bound to STATE_DB. It connects with `retry_on=False` so an unreachable STATE_DB fails fast, matching the old redis client (which raised `ConnectionError` rather than hanging).
- `_redis_hget` reads via `SonicV2Connector.get`, which returns a decoded `str`, so the previous `.decode()` is dropped; `rstrip('\0')` is kept.
- `EepromRedisVisitor` writes via a new `_hmset` helper that coerces field values to `str` (`SonicV2Connector.hmset` requires str values, whereas redis-py stringified them implicitly), so int fields such as `Version` and `Total Length` are stored exactly as before.
- Also removed an unused `from . import sfp_base` in `chassis_base.py` (referenced nowhere except a docstring).

The `EEPROM_INFO` key space and field names are unchanged, so all consumers (`show platform syseeprom`, gNMI, etc.) are unaffected.

#### How to verify it
- On device manual test: `show platform syseeprom`, `decode-syseeprom`, and `decode-syseeprom -d` return identical output before and after; `EEPROM_INFO|*` contents in STATE_DB are byte-for-byte identical.

| daemon     | before (MB) | after (MB) | diff         |
|------------|-------------|------------|--------------|
| syseepromd | 24.5        | 15.3       | -9.2 (-37%)  |

- Platform regression test: all passed.

#### Which release branch to backport (provide reason below if selected)

#### Tested branch
- [x] master_RC

#### Test result
master_RC: PASSED (unit tests + on-device syseeprom output / STATE_DB comparison)

#### Description for the changelog
[eeprom] Use swsscommon instead of redis-py in eeprom_tlvinfo to drop the redis-py import from every process that decodes the syseeprom.