### PR TITLE
Add SFF-8024 Rev 4.14 LRO (RTLR) AppSel host electrical interface codes

### DIFF
--- a/sonic_platform_base/sonic_xcvr/codes/public/sff8024.py
+++ b/sonic_platform_base/sonic_xcvr/codes/public/sff8024.py
@@ -298,6 +298,10 @@ class Sff8024(XcvrCodes):
         149: 'EEI-400G-RTLR-4-L',
         150: 'EEI-800G-RTLR-8-S',
         151: 'EEI-800G-RTLR-8-L',
+        152: 'EEI-200G-RTLR-1',
+        153: 'EEI-400G-RTLR-2',
+        154: 'EEI-800G-RTLR-4',
+        155: 'EEI-1.6T-RTLR-8',
         160: 'IB XDR',
     }
 


### PR DESCRIPTION
#### Description

Adds the four LRO (linear-receive optics) AppSel host electrical interface IDs introduced in SFF-8024 Rev 4.14 Table 4-5 to `sonic_platform_base/sonic_xcvr/codes/public/sff8024.py`:

| ID | Hex | Host Electrical Interface | Bit rate (Gb/s) | Lanes | Baud (GBd) |
|----|-----|---------------------------|-----------------|-------|------------|
| 152 | 98 | `EEI-200G-RTLR-1`  | 212.5 | 1 | 106.25 |
| 153 | 99 | `EEI-400G-RTLR-2`  | 425   | 2 | 106.25 |
| 154 | 9A | `EEI-800G-RTLR-4`  | 850   | 4 | 106.25 |
| 155 | 9B | `EEI-1.6T-RTLR-8`  | 1700  | 8 | 106.25 |

These are the 106.25 GBd/lane siblings of the 53.125 GBd `EEI-*-RTLR-*-S/L` codes 144-151 that are already in the table. Values transcribed from SFF-8024 Rev 4.14 (published 2026-06-04), Table 4-5, page 27.

Nothing else changes: no `MODULE_MEDIA_TYPE` / media-interface entries are touched, and `CmisApi.LPO_HOST_ELECTRICAL_INTERFACE_IDS` is deliberately left alone as LRO is not LPO, and codes 144-151 aren't in that list either. In a future PR I'll ad something similar to the CmisAPI

#### Motivation and Context

Without these entries, a module advertising an LRO application in its AppSel table decodes to `Unknown` in `get_application_advertisement()` and everything downstream of it (`sfputil`, `TRANSCEIVER_INFO`, xcvrd application selection).

#### How Has This Been Tested?

Static verification only — no LRO module on hand:
- Parsed the modified dict via `ast.literal_eval`, confirmed no duplicate keys, and 152-155 resolve to the names above.
- Cross-checked every existing 144-151 name against Rev 4.14 Table 4-5.

One pre-existing discrepancy spotted while cross-checking, **not** fixed here
to keep this diff to the requested change: `SM_MEDIA_INTERFACE[147]` is
`'800G-FR4-LPO'`, but Rev 4.14 Table 4-8 lists code 147 (0x93) as `400G-FR4-LPO`. Can fix in a follow-up if desired.
