### PR TITLE
Fix CPO log spam in xcvrd

### DIFF
--- a/sonic_platform_base/chassis_base.py
+++ b/sonic_platform_base/chassis_base.py
@@ -856,8 +856,9 @@ class ChassisBase(device_base.DeviceBase):
         try:
             cpo = self._cpo_list[index]
         except IndexError:
-            sys.stderr.write("CPO index {} out of range (0-{})\n".format(
-                             index, len(self._cpo_list)-1))
+            if len(self._cpo_list) > 0:
+                sys.stderr.write("CPO index {} out of range (0-{})\n".format(
+                                 index, len(self._cpo_list)-1))
         return cpo
 
     def get_port_or_cage_type(self, index):

--- a/tests/chassis_base_test.py
+++ b/tests/chassis_base_test.py
@@ -343,3 +343,26 @@ class TestChassisBase:
 
         assert chassis.get_num_sfps() == 2
         assert chassis.get_num_cpos() == 0
+
+    def test_get_cpo_out_of_range(self, capsys):
+        """get_cpo() only logs an out-of-range index when the CPO list is populated."""
+        chassis = ChassisBase()
+
+        # Empty CPO list (non-CPO platform): out-of-range lookups stay silent so
+        # xcvrd's per-port probing does not spam the log.
+        assert chassis.get_cpo(0) is None
+        assert chassis.get_cpo(5) is None
+        assert capsys.readouterr().err == ""
+
+        cpo0, cpo1 = mock.MagicMock(), mock.MagicMock()
+        chassis._cpo_list = [cpo0, cpo1]
+        assert chassis.get_cpo(0) is cpo0
+        assert chassis.get_cpo(1) is cpo1
+        assert capsys.readouterr().err == ""
+
+        # Populated CPO list: out-of-range index is logged to stderr.
+        assert chassis.get_cpo(2) is None
+        assert "CPO index 2 out of range (0-1)" in capsys.readouterr().err
+
+        assert chassis.get_cpo(-3) is None
+        assert "CPO index -3 out of range (0-1)" in capsys.readouterr().err


### PR DESCRIPTION
#### Description
There are a lot of noisy CPO-related logs being emitted by xcvrd on non-CPO hardware platforms:
```
2026 Sep  2 18:28:27.247934 test INFO pmon#supervisord: xcvrd CPO index 51 out of range (0--1)
```

#### Motivation and Context
`xvrd` logs should be high-signal and readable.

#### How Has This Been Tested?
Applied the change on a real switch.

## Before
```
~$ sudo cat /var/log/syslog | grep CPO
...
2026 Sep  2 18:28:27.239464 test INFO pmon#supervisord: xcvrd CPO index 57 out of range (0--1)
2026 Sep  2 18:28:27.239617 test INFO pmon#supervisord: xcvrd CPO index 62 out of range (0--1)
2026 Sep  2 18:28:27.239768 test INFO pmon#supervisord: xcvrd CPO index 63 out of range (0--1)
2026 Sep  2 18:28:27.239931 test INFO pmon#supervisord: xcvrd CPO index 20 out of range (0--1)
2026 Sep  2 18:28:27.240058 test INFO pmon#supervisord: xcvrd CPO index 23 out of range (0--1)
2026 Sep  2 18:28:27.240201 test INFO pmon#supervisord: xcvrd CPO index 35 out of range (0--1)
2026 Sep  2 18:28:27.240766 test INFO pmon#supervisord: xcvrd CPO index 60 out of range (0--1)
2026 Sep  2 18:28:27.240916 test INFO pmon#supervisord: xcvrd CPO index 27 out of range (0--1)
2026 Sep  2 18:28:27.241063 test INFO pmon#supervisord: xcvrd CPO index 64 out of range (0--1)
2026 Sep  2 18:28:27.241633 test INFO pmon#supervisord: xcvrd CPO index 33 out of range (0--1)
2026 Sep  2 18:28:27.242199 test INFO pmon#supervisord: xcvrd CPO index 65 out of range (0--1)
2026 Sep  2 18:28:27.242998 test INFO pmon#supervisord: xcvrd CPO index 56 out of range (0--1)
2026 Sep  2 18:28:27.243147 test INFO pmon#supervisord: xcvrd CPO index 50 out of range (0--1)
2026 Sep  2 18:28:27.243354 test INFO pmon#supervisord: xcvrd CPO index 34 out of range (0--1)
2026 Sep  2 18:28:27.243972 test INFO pmon#supervisord: xcvrd CPO index 59 out of range (0--1)
2026 Sep  2 18:28:27.244505 test INFO pmon#supervisord: xcvrd CPO index 42 out of range (0--1)
2026 Sep  2 18:28:27.244654 test INFO pmon#supervisord: xcvrd CPO index 36 out of range (0--1)
2026 Sep  2 18:28:27.244799 test INFO pmon#supervisord: xcvrd CPO index 16 out of range (0--1)
2026 Sep  2 18:28:27.244946 test INFO pmon#supervisord: xcvrd CPO index 3 out of range (0--1)
2026 Sep  2 18:28:27.245091 test INFO pmon#supervisord: xcvrd CPO index 30 out of range (0--1)
2026 Sep  2 18:28:27.245647 test INFO pmon#supervisord: xcvrd CPO index 5 out of range (0--1)
2026 Sep  2 18:28:27.246226 test INFO pmon#supervisord: xcvrd CPO index 1 out of range (0--1)
2026 Sep  2 18:28:27.246796 test INFO pmon#supervisord: xcvrd CPO index 55 out of range (0--1)
2026 Sep  2 18:28:27.246943 test INFO pmon#supervisord: xcvrd CPO index 11 out of range (0--1)
2026 Sep  2 18:28:27.247089 test INFO pmon#supervisord: xcvrd CPO index 61 out of range (0--1)
2026 Sep  2 18:28:27.247641 test INFO pmon#supervisord: xcvrd CPO index 48 out of range (0--1)
2026 Sep  2 18:28:27.247790 test INFO pmon#supervisord: xcvrd CPO index 15 out of range (0--1)
2026 Sep  2 18:28:27.247934 test INFO pmon#supervisord: xcvrd CPO index 51 out of range (0--1)
2026 Sep  2 18:28:27.248079 test INFO pmon#supervisord: xcvrd CPO index 29 out of range (0--1)
2026 Sep  2 18:28:27.248230 test INFO pmon#supervisord: xcvrd CPO index 2 out of range (0--1)
2026 Sep  2 18:28:27.248378 test INFO pmon#supervisord: xcvrd CPO index 47 out of range (0--1)
2026 Sep  2 18:28:27.248522 test INFO pmon#supervisord: xcvrd CPO index 66 out of range (0--1)
```

## After
Applied the fix in this PR, restarted xcvrd and brought all interfaces up again.
```
~$ sudo config interface startup Ethernet0-513
~$ date
Wed Sep  2 06:34:53 PM UTC 2026
~$ sudo cat /var/log/syslog | grep CPO | tail -n 5
2026 Sep  2 18:28:27.247934 test INFO pmon#supervisord: xcvrd CPO index 51 out of range (0--1)
2026 Sep  2 18:28:27.248079 test INFO pmon#supervisord: xcvrd CPO index 29 out of range (0--1)
2026 Sep  2 18:28:27.248230 test INFO pmon#supervisord: xcvrd CPO index 2 out of range (0--1)
2026 Sep  2 18:28:27.248378 test INFO pmon#supervisord: xcvrd CPO index 47 out of range (0--1)
2026 Sep  2 18:28:27.248522 test INFO pmon#supervisord: xcvrd CPO index 66 out of range (0--1)
```

All links came up and the log was not emitted after `xcvrd` restart and interface startup (the existing logs were from prior to the fix being applied).