### PR TITLE
to add fan speed display in rpm, as of now it display only in percent

### DIFF
--- a/sonic_platform_base/fan_base.py
+++ b/sonic_platform_base/fan_base.py
@@ -46,6 +46,15 @@ class FanBase(device_base.DeviceBase):
         """
         raise NotImplementedError
 
+    def get_speed_rpm(self):
+        """
+        Retrieves the speed of fan in RPM
+
+        Returns:
+           An integer, the speed of the fan in RPM
+        """
+        raise NotImplementedError
+
     def get_target_speed(self):
         """
         Retrieves the target (expected) speed of the fan

--- a/tests/fan_base_test.py
+++ b/tests/fan_base_test.py
@@ -141,6 +141,7 @@ class TestFanBase:
         not_implemented_methods = [
             (fan.get_direction,),
             (fan.get_speed,),
+            (fan.get_speed_rpm,),
             (fan.get_target_speed,),
             (fan.get_speed_tolerance,),
             (fan.set_speed, 50),


### PR DESCRIPTION
Signed-off-by: Sardar Shamsher Singh <meetshamsher@gmail.com>

<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
    Add get_speed_rpm() to common FanBase interface
    Adds method stub with docstring and NotImplementedError in base class
    Enables platform implementations to expose fan speed in RPM
    Keeps backward-compatible base behavior for platforms not implementing it yet.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
    Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
     Currently fan speed is getting populated as percentage value but also needed values in rpm as well. 
     To update RPM values in redis DB to use it further for display.
     So this change will keep backward compatible for platform which has not yet implemented.
#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
 Loaded image in local target and checked for rdis-db data population as show below: 
 Note: the setup contains two PSU and 4 Fan tray with each two fans.
root@sonic:/home/admin# sonic-db-cli STATE_DB KEYS 'FAN_INFO|*' | sort | while read -r k; do printf '%-28s %s\n' "$k" "$(sonic-db-cli STATE_DB HGET "$k" speed_rpm)"; done
FAN_INFO|fantray1.fan1 12134
FAN_INFO|fantray1.fan2 10325
FAN_INFO|fantray2.fan1 12026
FAN_INFO|fantray2.fan2 10305
FAN_INFO|fantray3.fan1 12162
FAN_INFO|fantray3.fan2 10285
FAN_INFO|fantray4.fan1 12053
FAN_INFO|fantray4.fan2 10246
FAN_INFO|PSU1.fan1 10080
FAN_INFO|PSU2.fan1 9952
root@sonic:/home/admin# 
root@sonic:/home/admin# for k in $(sonic-db-cli STATE_DB KEYS "FAN_INFO|*"); do echo "=== $k ==="; sonic-db-cli STATE_DB HGETALL "$k"; echo; done
=== FAN_INFO|PSU1.fan1 ===
{'presence': 'True', 'status': 'True', 'direction': 'N/A', 'speed': '50', 'speed_rpm': '10080', 'timestamp': '20260602 11:06:27', 'led_status': 'N/A', 'drawer_name': 'N/A', 'model': 'NXA-PAC-500W-PE', 'serial': 'LIT2709A9HY', 'speed_target': '50', 'is_under_speed': 'False', 'is_over_speed': 'False', 'is_replaceable': 'False'}

=== FAN_INFO|fantray1.fan1 ===
{'presence': 'True', 'drawer_name': 'fantray1', 'model': 'NXA-SFAN-35CFM-PE', 'serial': 'DCH2936TJEW25372537A0', 'status': 'True', 'direction': 'exhaust', 'speed': '49', 'speed_rpm': '12134', 'speed_target': '53', 'is_under_speed': 'False', 'is_over_speed': 'False', 'is_replaceable': 'False', 'timestamp': '20260602 11:06:27', 'led_status': 'green'}

=== FAN_INFO|fantray2.fan2 ===
{'presence': 'True', 'drawer_name': 'fantray2', 'model': 'NXA-SFAN-35CFM-PE', 'serial': 'DCH2936TJ9625372537A0', 'status': 'True', 'direction': 'exhaust', 'speed': '49', 'speed_rpm': '10305', 'speed_target': '53', 'is_under_speed': 'False', 'is_over_speed': 'False', 'is_replaceable': 'False', 'timestamp': '20260602 11:06:27', 'led_status': 'green'}

=== FAN_INFO|PSU2.fan1 ===
{'presence': 'True', 'status': 'True', 'direction': 'N/A', 'speed': '50', 'speed_rpm': '9952', 'timestamp': '20260602 11:06:27', 'led_status': 'N/A', 'drawer_name': 'N/A', 'model': 'NXA-PAC-500W-PE', 'serial': 'LIT2709A9DV', 'speed_target': '50', 'is_under_speed': 'False', 'is_over_speed': 'False', 'is_replaceable': 'False'}

=== FAN_INFO|fantray2.fan1 ===
{'presence': 'True', 'drawer_name': 'fantray2', 'model': 'NXA-SFAN-35CFM-PE', 'serial': 'DCH2936TJ9625372537A0', 'status': 'True', 'direction': 'exhaust', 'speed': '49', 'speed_rpm': '12026', 'speed_target': '53', 'is_under_speed': 'False', 'is_over_speed': 'False', 'is_replaceable': 'False', 'timestamp': '20260602 11:06:27', 'led_status': 'green'}

=== FAN_INFO|fantray3.fan1 ===
{'presence': 'True', 'drawer_name': 'fantray3', 'model': 'NXA-SFAN-35CFM-PE', 'serial': 'DCH2936TJZK25372537A0', 'status': 'True', 'direction': 'exhaust', 'speed': '49', 'speed_rpm': '12162', 'speed_target': '53', 'is_under_speed': 'False', 'is_over_speed': 'False', 'is_replaceable': 'False', 'timestamp': '20260602 11:06:27', 'led_status': 'green'}

=== FAN_INFO|fantray4.fan2 ===
{'presence': 'True', 'drawer_name': 'fantray4', 'model': 'NXA-SFAN-35CFM-PE', 'serial': 'DCH2936TJZT25372537A0', 'status': 'True', 'direction': 'exhaust', 'speed': '48', 'speed_rpm': '10246', 'speed_target': '53', 'is_under_speed': 'False', 'is_over_speed': 'False', 'is_replaceable': 'False', 'timestamp': '20260602 11:06:27', 'led_status': 'green'}

=== FAN_INFO|fantray4.fan1 ===
{'presence': 'True', 'drawer_name': 'fantray4', 'model': 'NXA-SFAN-35CFM-PE', 'serial': 'DCH2936TJZT25372537A0', 'status': 'True', 'direction': 'exhaust', 'speed': '49', 'speed_rpm': '12053', 'speed_target': '53', 'is_under_speed': 'False', 'is_over_speed': 'False', 'is_replaceable': 'False', 'timestamp': '20260602 11:06:27', 'led_status': 'green'}

=== FAN_INFO|fantray1.fan2 ===
{'presence': 'True', 'drawer_name': 'fantray1', 'model': 'NXA-SFAN-35CFM-PE', 'serial': 'DCH2936TJEW25372537A0', 'status': 'True', 'direction': 'exhaust', 'speed': '49', 'speed_rpm': '10325', 'speed_target': '53', 'is_under_speed': 'False', 'is_over_speed': 'False', 'is_replaceable': 'False', 'timestamp': '20260602 11:06:27', 'led_status': 'green'}

=== FAN_INFO|fantray3.fan2 ===
{'presence': 'True', 'drawer_name': 'fantray3', 'model': 'NXA-SFAN-35CFM-PE', 'serial': 'DCH2936TJZK25372537A0', 'status': 'True', 'direction': 'exhaust', 'speed': '49', 'speed_rpm': '10285', 'speed_target': '53', 'is_under_speed': 'False', 'is_over_speed': 'False', 'is_replaceable': 'False', 'timestamp': '20260602 11:06:27', 'led_status': 'green'}

root@sonic:/home/admin#
#### Additional Information (Optional)
Related sonic-platform-daemons change PR:  https://github.com/sonic-net/sonic-platform-daemons/pull/888
