### PR TITLE
[ChassisBase] Add get_media_settings_key() override hook

### DIFF
--- a/sonic_platform_base/chassis_base.py
+++ b/sonic_platform_base/chassis_base.py
@@ -817,6 +817,27 @@ class ChassisBase(device_base.DeviceBase):
 
         return sfp
 
+    def get_media_settings_key(self, physical_port, transceiver_dict, port_speed, lane_count):
+        """
+        Derive a platform-specific media settings key for the given port.
+
+        This is an optional vendor override hook. Platforms may implement it to
+        return a custom key used to look up SerDes SI settings in
+        media_settings.json. When a non-None key is returned, it takes the
+        highest precedence over the vendor, media and medium lane speed keys.
+
+        Args:
+            physical_port: physical port number for this logical port
+            transceiver_dict: dictionary of transceiver info keyed by physical port
+            port_speed: logical port speed in Mbps
+            lane_count: number of lanes for this logical port
+
+        Returns:
+            A platform-specific key string, or None if the platform does not
+            provide a custom key (default behavior).
+        """
+        return None
+
     def get_num_cpos(self):
         """
         Retrieves the number of CPO ports available on this chassis

--- a/tests/chassis_base_test.py
+++ b/tests/chassis_base_test.py
@@ -58,6 +58,11 @@ class TestChassisBase:
 
             assert exception_raised
 
+    def test_get_media_settings_key(self):
+        # The base hook is an optional vendor override and must default to None
+        chassis = ChassisBase()
+        assert chassis.get_media_settings_key(0, {}, 100000, 4) is None
+
     @mock.patch('sonic_py_common.device_info.is_switch_bmc', return_value=True)
     def test_system_led_bmc(self, _mock_is_switch_bmc):
         # BMC platforms have no controllable system LED, so the base class


### PR DESCRIPTION
Add an optional get_media_settings_key(physical_port, transceiver_dict, port_speed, lane_count) hook to ChassisBase, returning None by default. Platforms may override it to derive a custom media_settings.json lookup key. The default None preserves existing behavior on all platforms.

#### Description
Add an optional `get_media_settings_key(self, physical_port, transceiver_dict, port_speed, lane_count)`
method to `ChassisBase`. It returns `None` by default. Platforms may override it to derive a
custom key used to look up SerDes SI settings in `media_settings.json`. The four parameters
mirror xcvrd's module-level media-settings key builder so a platform override is not limited
in what it can key on.

#### Motivation and Context
xcvrd resolves SerDes SI media settings from `media_settings.json` using vendor / media /
medium-lane-speed keys. Some platforms need a platform-vendor-defined key that these fixed keys
cannot express. This adds a chassis-level hook so a platform can supply its own key without changing
the common resolution logic. Returning `None` by default keeps behavior identical on every
existing platform.

#### How Has This Been Tested?
Added `test_get_media_settings_key` asserting the base class returns `None`
(`chassis = ChassisBase(); assert chassis.get_media_settings_key(0, {}, 100000, 4) is None`).

#### Additional Information (Optional)
This is the base hook only; the consuming change lives in [sonic-platform-daemons](https://github.com/sonic-net/sonic-platform-daemons/pull/891) (xcvrd) .
No platform currently overrides the hook, so no platform behavior changes as of now.
